### PR TITLE
Localnet: Run prover on arm64 machine

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -95,6 +95,7 @@ services:
   erigon-prover:
     container_name: erigon-prover
     image: hermeznetwork/zkevm-prover:v6.0.3-RC17
+    platform: linux/amd64
     volumes:
       - ./config/test.prover.config.json:/usr/src/app/config.json
     command: >


### PR DESCRIPTION
## Summary

- Explicitly specify platform to be amd64 to enable prover to run using emulation layer