### PR TITLE
Fix gas pricer default price and dynamic price calculation pipeline

### DIFF
--- a/cmd/rpcdaemon/commands/eth_api_xlayer.go
+++ b/cmd/rpcdaemon/commands/eth_api_xlayer.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"github.com/gateway-fm/cdk-erigon-lib/common"
-	"github.com/ledgerwatch/erigon/eth/gasprice/gaspricecfg"
 )
 
 func (apii *APIImpl) GetGPCache() *GasPriceCache {
@@ -11,10 +10,6 @@ func (apii *APIImpl) GetGPCache() *GasPriceCache {
 
 func (apii *APIImpl) runL2GasPricerForXLayer() {
 	// set default gas price
-	defaultPrice := apii.L2GasPricer.GetConfig().Default
-	if defaultPrice == nil || defaultPrice.Int64() <= 0 {
-		defaultPrice = gaspricecfg.DefaultXLayerPrice
-	}
-	apii.gasCache.SetLatest(common.Hash{}, defaultPrice)
+	apii.gasCache.SetLatest(common.Hash{}, apii.L2GasPricer.GetConfig().Default)
 	go apii.runL2GasPriceSuggester()
 }

--- a/cmd/rpcdaemon/commands/eth_api_xlayer.go
+++ b/cmd/rpcdaemon/commands/eth_api_xlayer.go
@@ -13,7 +13,7 @@ func (apii *APIImpl) runL2GasPricerForXLayer() {
 	// set default gas price
 	defaultPrice := apii.L2GasPricer.GetConfig().Default
 	if defaultPrice == nil || defaultPrice.Int64() <= 0 {
-		defaultPrice = gaspricecfg.DefaultMinimumBaseFee
+		defaultPrice = gaspricecfg.DefaultXLayerPrice
 	}
 	apii.gasCache.SetLatest(common.Hash{}, defaultPrice)
 	go apii.runL2GasPriceSuggester()

--- a/cmd/rpcdaemon/commands/eth_api_xlayer.go
+++ b/cmd/rpcdaemon/commands/eth_api_xlayer.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"github.com/gateway-fm/cdk-erigon-lib/common"
+	"github.com/ledgerwatch/erigon/eth/gasprice/gaspricecfg"
 )
 
 func (apii *APIImpl) GetGPCache() *GasPriceCache {
@@ -10,6 +11,10 @@ func (apii *APIImpl) GetGPCache() *GasPriceCache {
 
 func (apii *APIImpl) runL2GasPricerForXLayer() {
 	// set default gas price
-	apii.gasCache.SetLatest(common.Hash{}, apii.L2GasPricer.GetConfig().Default)
+	defaultPrice := apii.L2GasPricer.GetConfig().Default
+	if defaultPrice == nil || defaultPrice.Int64() <= 0 {
+		defaultPrice = gaspricecfg.DefaultMinimumBaseFee
+	}
+	apii.gasCache.SetLatest(common.Hash{}, defaultPrice)
 	go apii.runL2GasPriceSuggester()
 }

--- a/cmd/rpcdaemon/commands/eth_system_xlayer.go
+++ b/cmd/rpcdaemon/commands/eth_system_xlayer.go
@@ -140,7 +140,7 @@ func (api *APIImpl) runL2GasPriceSuggester() {
 	cfg := api.L2GasPricer.GetConfig()
 	ctx := api.L2GasPricer.GetCtx()
 
-	//todo: apollo
+	// TODO: apollo
 	l1gp, err := gasprice.GetL1GasPrice(api.L1RpcUrl)
 	// if err != nil, do nothing
 	if err == nil {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1485,10 +1485,7 @@ func setGPO(ctx *cli.Context, cfg *gaspricecfg.Config) {
 	}
 
 	// For X Layer
-	if ctx.IsSet(DefaultGasPrice.Name) {
-		cfg.Default = big.NewInt(ctx.Int64(DefaultGasPrice.Name))
-	}
-	setGPOXLayer(ctx, &cfg.XLayer)
+	setGPOXLayer(ctx, cfg)
 }
 
 // nolint

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1484,11 +1484,10 @@ func setGPO(ctx *cli.Context, cfg *gaspricecfg.Config) {
 		cfg.MaxPrice = big.NewInt(ctx.Int64(GpoMaxGasPriceFlag.Name))
 	}
 
-	if ctx.IsSet(GpoDefaultGasPriceFlag.Name) {
-		cfg.Default = big.NewInt(ctx.Int64(GpoDefaultGasPriceFlag.Name))
-	}
-
 	// For X Layer
+	if ctx.IsSet(DefaultGasPrice.Name) {
+		cfg.Default = big.NewInt(ctx.Int64(DefaultGasPrice.Name))
+	}
 	setGPOXLayer(ctx, &cfg.XLayer)
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1554,7 +1554,7 @@ func setTxPool(ctx *cli.Context, cfg *ethconfig.DeprecatedTxPoolConfig) {
 
 	cfg.CommitEvery = common2.RandomizeDuration(ctx.Duration(TxPoolCommitEveryFlag.Name))
 
-	// XLayer config
+	// For X Layer
 	setTxPoolXLayer(ctx, cfg)
 }
 

--- a/cmd/utils/flags_xlayer.go
+++ b/cmd/utils/flags_xlayer.go
@@ -211,6 +211,11 @@ func setGPOXLayer(ctx *cli.Context, cfg *gaspricecfg.Config) {
 	if ctx.IsSet(GpoCongestionThresholdFlag.Name) {
 		cfg.XLayer.CongestionThreshold = ctx.Int(GpoCongestionThresholdFlag.Name)
 	}
+
+	// Default price check
+	if cfg.Default == nil || cfg.Default.Int64() <= 0 {
+		cfg.Default = gaspricecfg.DefaultXLayerPrice
+	}
 }
 
 func setTxPoolXLayer(ctx *cli.Context, cfg *ethconfig.DeprecatedTxPoolConfig) {

--- a/cmd/utils/flags_xlayer.go
+++ b/cmd/utils/flags_xlayer.go
@@ -67,11 +67,6 @@ var (
 		Value: "",
 	}
 	// Gas Price
-	GpoDefaultGasPriceFlag = cli.Int64Flag{
-		Name:  "gpo.default-price",
-		Usage: "Default gas price will be recommended by gpo",
-		Value: ethconfig.Defaults.GPO.Default.Int64(),
-	}
 	GpoTypeFlag = cli.StringFlag{
 		Name:  "gpo.type",
 		Usage: "raw gas price strategy type: default, follower, fixed",
@@ -163,7 +158,6 @@ func setGPOXLayer(ctx *cli.Context, cfg *gaspricecfg.XLayerConfig) {
 	if ctx.IsSet(GpoTypeFlag.Name) {
 		cfg.Type = ctx.String(GpoTypeFlag.Name)
 	}
-
 	if ctx.IsSet(GpoUpdatePeriodFlag.Name) {
 		period, err := time.ParseDuration(ctx.String(GpoUpdatePeriodFlag.Name))
 		if err != nil {
@@ -171,59 +165,45 @@ func setGPOXLayer(ctx *cli.Context, cfg *gaspricecfg.XLayerConfig) {
 		}
 		cfg.UpdatePeriod = period
 	}
-
 	if ctx.IsSet(GpoFactorFlag.Name) {
 		cfg.Factor = ctx.Float64(GpoFactorFlag.Name)
 	}
-
 	if ctx.IsSet(GpoKafkaURLFlag.Name) {
 		cfg.KafkaURL = ctx.String(GpoKafkaURLFlag.Name)
 	}
-
 	if ctx.IsSet(GpoTopicFlag.Name) {
 		cfg.Topic = ctx.String(GpoTopicFlag.Name)
 	}
-
 	if ctx.IsSet(GpoGroupIDFlag.Name) {
 		cfg.GroupID = ctx.String(GpoGroupIDFlag.Name)
 	}
-
 	if ctx.IsSet(GpoUsernameFlag.Name) {
 		cfg.Username = ctx.String(GpoUsernameFlag.Name)
 	}
-
 	if ctx.IsSet(GpoPasswordFlag.Name) {
 		cfg.Password = ctx.String(GpoPasswordFlag.Name)
 	}
-
 	if ctx.IsSet(GpoRootCAPathFlag.Name) {
 		cfg.RootCAPath = ctx.String(GpoRootCAPathFlag.Name)
 	}
-
 	if ctx.IsSet(GpoL1CoinIdFlag.Name) {
 		cfg.L1CoinId = ctx.Int(GpoL1CoinIdFlag.Name)
 	}
-
 	if ctx.IsSet(GpoL2CoinIdFlag.Name) {
 		cfg.L2CoinId = ctx.Int(GpoL2CoinIdFlag.Name)
 	}
-
 	if ctx.IsSet(GpoDefaultL1CoinPriceFlag.Name) {
 		cfg.DefaultL1CoinPrice = ctx.Float64(GpoDefaultL1CoinPriceFlag.Name)
 	}
-
 	if ctx.IsSet(GpoDefaultL2CoinPriceFlag.Name) {
 		cfg.DefaultL2CoinPrice = ctx.Float64(GpoDefaultL2CoinPriceFlag.Name)
 	}
-
 	if ctx.IsSet(GpoGasPriceUsdtFlag.Name) {
 		cfg.GasPriceUsdt = ctx.Float64(GpoGasPriceUsdtFlag.Name)
 	}
-
 	if ctx.IsSet(GpoEnableFollowerAdjustByL2L1PriceFlag.Name) {
 		cfg.EnableFollowerAdjustByL2L1Price = ctx.Bool(GpoEnableFollowerAdjustByL2L1PriceFlag.Name)
 	}
-
 	if ctx.IsSet(GpoCongestionThresholdFlag.Name) {
 		cfg.CongestionThreshold = ctx.Int(GpoCongestionThresholdFlag.Name)
 	}

--- a/cmd/utils/flags_xlayer.go
+++ b/cmd/utils/flags_xlayer.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"math/big"
 	"time"
 
 	libcommon "github.com/gateway-fm/cdk-erigon-lib/common"
@@ -154,58 +155,61 @@ var (
 	}
 )
 
-func setGPOXLayer(ctx *cli.Context, cfg *gaspricecfg.XLayerConfig) {
+func setGPOXLayer(ctx *cli.Context, cfg *gaspricecfg.Config) {
+	if ctx.IsSet(DefaultGasPrice.Name) {
+		cfg.Default = big.NewInt(ctx.Int64(DefaultGasPrice.Name))
+	}
 	if ctx.IsSet(GpoTypeFlag.Name) {
-		cfg.Type = ctx.String(GpoTypeFlag.Name)
+		cfg.XLayer.Type = ctx.String(GpoTypeFlag.Name)
 	}
 	if ctx.IsSet(GpoUpdatePeriodFlag.Name) {
 		period, err := time.ParseDuration(ctx.String(GpoUpdatePeriodFlag.Name))
 		if err != nil {
 			panic(fmt.Sprintf("could not parse GpoUpdatePeriodFlag value %s", ctx.String(GpoUpdatePeriodFlag.Name)))
 		}
-		cfg.UpdatePeriod = period
+		cfg.XLayer.UpdatePeriod = period
 	}
 	if ctx.IsSet(GpoFactorFlag.Name) {
-		cfg.Factor = ctx.Float64(GpoFactorFlag.Name)
+		cfg.XLayer.Factor = ctx.Float64(GpoFactorFlag.Name)
 	}
 	if ctx.IsSet(GpoKafkaURLFlag.Name) {
-		cfg.KafkaURL = ctx.String(GpoKafkaURLFlag.Name)
+		cfg.XLayer.KafkaURL = ctx.String(GpoKafkaURLFlag.Name)
 	}
 	if ctx.IsSet(GpoTopicFlag.Name) {
-		cfg.Topic = ctx.String(GpoTopicFlag.Name)
+		cfg.XLayer.Topic = ctx.String(GpoTopicFlag.Name)
 	}
 	if ctx.IsSet(GpoGroupIDFlag.Name) {
-		cfg.GroupID = ctx.String(GpoGroupIDFlag.Name)
+		cfg.XLayer.GroupID = ctx.String(GpoGroupIDFlag.Name)
 	}
 	if ctx.IsSet(GpoUsernameFlag.Name) {
-		cfg.Username = ctx.String(GpoUsernameFlag.Name)
+		cfg.XLayer.Username = ctx.String(GpoUsernameFlag.Name)
 	}
 	if ctx.IsSet(GpoPasswordFlag.Name) {
-		cfg.Password = ctx.String(GpoPasswordFlag.Name)
+		cfg.XLayer.Password = ctx.String(GpoPasswordFlag.Name)
 	}
 	if ctx.IsSet(GpoRootCAPathFlag.Name) {
-		cfg.RootCAPath = ctx.String(GpoRootCAPathFlag.Name)
+		cfg.XLayer.RootCAPath = ctx.String(GpoRootCAPathFlag.Name)
 	}
 	if ctx.IsSet(GpoL1CoinIdFlag.Name) {
-		cfg.L1CoinId = ctx.Int(GpoL1CoinIdFlag.Name)
+		cfg.XLayer.L1CoinId = ctx.Int(GpoL1CoinIdFlag.Name)
 	}
 	if ctx.IsSet(GpoL2CoinIdFlag.Name) {
-		cfg.L2CoinId = ctx.Int(GpoL2CoinIdFlag.Name)
+		cfg.XLayer.L2CoinId = ctx.Int(GpoL2CoinIdFlag.Name)
 	}
 	if ctx.IsSet(GpoDefaultL1CoinPriceFlag.Name) {
-		cfg.DefaultL1CoinPrice = ctx.Float64(GpoDefaultL1CoinPriceFlag.Name)
+		cfg.XLayer.DefaultL1CoinPrice = ctx.Float64(GpoDefaultL1CoinPriceFlag.Name)
 	}
 	if ctx.IsSet(GpoDefaultL2CoinPriceFlag.Name) {
-		cfg.DefaultL2CoinPrice = ctx.Float64(GpoDefaultL2CoinPriceFlag.Name)
+		cfg.XLayer.DefaultL2CoinPrice = ctx.Float64(GpoDefaultL2CoinPriceFlag.Name)
 	}
 	if ctx.IsSet(GpoGasPriceUsdtFlag.Name) {
-		cfg.GasPriceUsdt = ctx.Float64(GpoGasPriceUsdtFlag.Name)
+		cfg.XLayer.GasPriceUsdt = ctx.Float64(GpoGasPriceUsdtFlag.Name)
 	}
 	if ctx.IsSet(GpoEnableFollowerAdjustByL2L1PriceFlag.Name) {
-		cfg.EnableFollowerAdjustByL2L1Price = ctx.Bool(GpoEnableFollowerAdjustByL2L1PriceFlag.Name)
+		cfg.XLayer.EnableFollowerAdjustByL2L1Price = ctx.Bool(GpoEnableFollowerAdjustByL2L1PriceFlag.Name)
 	}
 	if ctx.IsSet(GpoCongestionThresholdFlag.Name) {
-		cfg.CongestionThreshold = ctx.Int(GpoCongestionThresholdFlag.Name)
+		cfg.XLayer.CongestionThreshold = ctx.Int(GpoCongestionThresholdFlag.Name)
 	}
 }
 

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -97,7 +97,7 @@ func NewOracle(backend OracleBackend, params gaspricecfg.Config, cache Cache) *O
 	// For X Layer
 	defaultPrice := params.Default
 	if defaultPrice == nil || defaultPrice.Int64() <= 0 {
-		defaultPrice = gaspricecfg.DefaultMinimumBaseFee
+		defaultPrice = gaspricecfg.DefaultXLayerPrice
 	}
 	return &Oracle{
 		backend:          backend,

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -62,6 +62,9 @@ type Oracle struct {
 	checkBlocks                       int
 	percentile                        int
 	maxHeaderHistory, maxBlockHistory int
+
+	// For X Layer
+	defaultPrice *big.Int
 }
 
 // NewOracle returns a new gasprice oracle which can recommend suitable
@@ -91,6 +94,11 @@ func NewOracle(backend OracleBackend, params gaspricecfg.Config, cache Cache) *O
 		ignorePrice = gaspricecfg.DefaultIgnorePrice
 		log.Warn("Sanitizing invalid gasprice oracle ignore price", "provided", params.IgnorePrice, "updated", ignorePrice)
 	}
+	// For X Layer
+	defaultPrice := params.Default
+	if defaultPrice == nil || defaultPrice.Int64() <= 0 {
+		defaultPrice = gaspricecfg.DefaultMinimumBaseFee
+	}
 	return &Oracle{
 		backend:          backend,
 		lastPrice:        params.Default,
@@ -101,6 +109,8 @@ func NewOracle(backend OracleBackend, params gaspricecfg.Config, cache Cache) *O
 		cache:            cache,
 		maxHeaderHistory: params.MaxHeaderHistory,
 		maxBlockHistory:  params.MaxBlockHistory,
+		// For X Layer
+		defaultPrice: defaultPrice,
 	}
 }
 
@@ -151,12 +161,13 @@ func (oracle *Oracle) SuggestTipCap(ctx context.Context) (*big.Int, error) {
 		// Don't need to pop it, just take from the top of the heap
 		price = txPrices[0].ToBig()
 	}
-	if oracle.maxPrice.Int64() > 0 && price.Cmp(oracle.maxPrice) > 0 {
+	if price.Cmp(oracle.maxPrice) > 0 {
 		price = new(big.Int).Set(oracle.maxPrice)
 	}
 
-	if price.Cmp(oracle.lastPrice) < 0 {
-		price = new(big.Int).Set(oracle.lastPrice)
+	// For X Layer
+	if price.Cmp(oracle.defaultPrice) < 0 {
+		price = new(big.Int).Set(oracle.defaultPrice)
 	}
 
 	oracle.cache.SetLatest(headHash, price)
@@ -259,9 +270,9 @@ func (oracle *Oracle) getBlockPrices(ctx context.Context, blockNum uint64, limit
 		}
 	}
 
-	// xlayer
+	// For X Layer
 	if count == 0 {
-		defaultGP := uint256.NewInt(oracle.lastPrice.Uint64())
+		defaultGP := uint256.NewInt(oracle.defaultPrice.Uint64())
 		heap.Push(s, defaultGP)
 	}
 

--- a/eth/gasprice/gaspricecfg/config_xlayer.go
+++ b/eth/gasprice/gaspricecfg/config_xlayer.go
@@ -1,6 +1,11 @@
 package gaspricecfg
 
-import "time"
+import (
+	"math/big"
+	"time"
+
+	"github.com/ledgerwatch/erigon/params"
+)
 
 // XLayerConfig is the X Layer gas price config
 type XLayerConfig struct {
@@ -27,9 +32,12 @@ type XLayerConfig struct {
 	CongestionThreshold int `toml:",omitempty"`
 }
 
-var DefaultXLayerConfig = XLayerConfig{
-	Type: DefaultType,
-}
+var (
+	DefaultXLayerConfig = XLayerConfig{
+		Type: DefaultType,
+	}
+	DefaultMinimumBaseFee = big.NewInt(10 * params.GWei)
+)
 
 const (
 	// DefaultType default gas price from config is set.

--- a/eth/gasprice/gaspricecfg/config_xlayer.go
+++ b/eth/gasprice/gaspricecfg/config_xlayer.go
@@ -36,7 +36,7 @@ var (
 	DefaultXLayerConfig = XLayerConfig{
 		Type: DefaultType,
 	}
-	DefaultMinimumBaseFee = big.NewInt(10 * params.GWei)
+	DefaultXLayerPrice = big.NewInt(1 * params.GWei)
 )
 
 const (

--- a/test/config/test.erigon.seq.config.yaml
+++ b/test/config/test.erigon.seq.config.yaml
@@ -66,7 +66,6 @@ txpool.globalbasefeeslots: 100000
 txpool.globalqueue: 100000
 
 gpo.type: "follower"
-gpo.default-price: 1000000000
 gpo.update-period: "10s"
 gpo.factor: 0.01
 gpo.kafka-url: "0.0.0.0"

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -117,7 +117,6 @@ var DefaultFlags = []cli.Flag{
 	&utils.GpoBlocksFlag,
 	&utils.GpoPercentileFlag,
 	&utils.GpoMaxGasPriceFlag,
-	&utils.GpoDefaultGasPriceFlag,
 	&utils.GpoTypeFlag,
 	&utils.GpoUpdatePeriodFlag,
 	&utils.GpoFactorFlag,


### PR DESCRIPTION
## Summary

This PR fixes issues on the L2 gaspricer pipeline:
- If default price is not configured, oracle will automatically set default price to minimum base fee (10 gwei)
- Likewise on X Layer gpcache initialization, if default price is not configured, cache will automatically set default price to DefaultXLayerPrice (1 gwei)
- Better refactor lastPrice to defaultPrice on the oracle. lastPrice is never used in any pipeline now and we cannot assume that upstream will not change or use it. Since we want the dynamic GP checks on the dynamic price calculated to be checked against the default price, we should do this instead
- Fix default gas price config to only be zkevm.default-gas-price