### PR TITLE
Set initial base fee explicitly to zero

### DIFF
--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -118,10 +118,12 @@ const (
 	// Introduced in Tangerine Whistle (Eip 150)
 	CreateBySelfdestructGas uint64 = 25000
 
-	BaseFeeChangeDenominator          = 8          // Bounds the amount the base fee can change between blocks.
-	BaseFeeChangeDenominatorPostDelhi = 16         // Bounds the amount the base fee can change between blocks post delhi hard fork for polygon networks.
-	ElasticityMultiplier              = 2          // Bounds the maximum gas limit an EIP-1559 block may have.
-	InitialBaseFee                    = 1000000000 // Initial base fee for EIP-1559 blocks.
+	BaseFeeChangeDenominator          = 8  // Bounds the amount the base fee can change between blocks.
+	BaseFeeChangeDenominatorPostDelhi = 16 // Bounds the amount the base fee can change between blocks post delhi hard fork for polygon networks.
+	ElasticityMultiplier              = 2  // Bounds the maximum gas limit an EIP-1559 block may have.
+	// InitialBaseFee                    = 1000000000 // Initial base fee for EIP-1559 blocks.
+	// For X Layer
+	InitialBaseFee = 0 // Initial base fee for X Layer.
 
 	MaxCodeSize     = 24576           // Maximum bytecode to permit for a contract
 	MaxInitCodeSize = 2 * MaxCodeSize // Maximum initcode to permit in a creation transaction and create instructions

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -118,9 +118,9 @@ const (
 	// Introduced in Tangerine Whistle (Eip 150)
 	CreateBySelfdestructGas uint64 = 25000
 
-	BaseFeeChangeDenominator          = 8  // Bounds the amount the base fee can change between blocks.
-	BaseFeeChangeDenominatorPostDelhi = 16 // Bounds the amount the base fee can change between blocks post delhi hard fork for polygon networks.
-	ElasticityMultiplier              = 2  // Bounds the maximum gas limit an EIP-1559 block may have.
+	BaseFeeChangeDenominator          = 8          // Bounds the amount the base fee can change between blocks.
+	BaseFeeChangeDenominatorPostDelhi = 16         // Bounds the amount the base fee can change between blocks post delhi hard fork for polygon networks.
+	ElasticityMultiplier              = 2          // Bounds the maximum gas limit an EIP-1559 block may have.
 	// InitialBaseFee                    = 1000000000 // Initial base fee for EIP-1559 blocks.
 	// For X Layer
 	InitialBaseFee = 0 // Initial base fee for X Layer.


### PR DESCRIPTION
## Summary

- Context of issue: https://github.com/0xPolygonHermez/cdk-erigon/issues/773
- Upstream PR: https://github.com/0xPolygonHermez/cdk-erigon/pull/774
- Sets the protocol parameter's initial base fee explicitly to zero on X Layer since EIP1559 is disable on chain
- Safeguards against undesirable behaviours on and genesis block StageLoop that trickles down to txpool