### PR TITLE
Fix Apollo configurations

### DIFF
--- a/cmd/cdk-erigon/main.go
+++ b/cmd/cdk-erigon/main.go
@@ -18,8 +18,8 @@ import (
 	"github.com/ledgerwatch/erigon/params"
 	erigonapp "github.com/ledgerwatch/erigon/turbo/app"
 	erigoncli "github.com/ledgerwatch/erigon/turbo/cli"
-	"github.com/ledgerwatch/erigon/turbo/node"
 	"github.com/ledgerwatch/erigon/turbo/logging"
+	"github.com/ledgerwatch/erigon/turbo/node"
 )
 
 func main() {
@@ -63,7 +63,7 @@ func runErigon(cliCtx *cli.Context) error {
 	ethCfg := node.NewEthConfigUrfave(cliCtx, nodeCfg)
 
 	// Init for X Layer
-	initRunForXLayer(ethCfg, nodeCfg)
+	initRunForXLayer(ethCfg)
 
 	ethNode, err := node.New(nodeCfg, ethCfg)
 	if err != nil {

--- a/cmd/cdk-erigon/main.go
+++ b/cmd/cdk-erigon/main.go
@@ -18,8 +18,8 @@ import (
 	"github.com/ledgerwatch/erigon/params"
 	erigonapp "github.com/ledgerwatch/erigon/turbo/app"
 	erigoncli "github.com/ledgerwatch/erigon/turbo/cli"
-	"github.com/ledgerwatch/erigon/turbo/logging"
 	"github.com/ledgerwatch/erigon/turbo/node"
+	"github.com/ledgerwatch/erigon/turbo/logging"
 )
 
 func main() {

--- a/cmd/cdk-erigon/run_xlayer.go
+++ b/cmd/cdk-erigon/run_xlayer.go
@@ -2,13 +2,12 @@ package main
 
 import (
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
-	"github.com/ledgerwatch/erigon/node/nodecfg"
 	"github.com/ledgerwatch/erigon/zk/apollo"
 	"github.com/ledgerwatch/log/v3"
 )
 
-func initRunForXLayer(ethCfg *ethconfig.Config, nodeCfg *nodecfg.Config) {
-	apolloClient := apollo.NewClient(ethCfg, nodeCfg)
+func initRunForXLayer(ethCfg *ethconfig.Config) {
+	apolloClient := apollo.NewClient(ethCfg)
 	if apolloClient.LoadConfig() {
 		log.Info("apollo config loaded")
 	}

--- a/cmd/utils/flags_xlayer.go
+++ b/cmd/utils/flags_xlayer.go
@@ -263,3 +263,8 @@ func setTxPoolXLayer(ctx *cli.Context, cfg *ethconfig.DeprecatedTxPoolConfig) {
 		cfg.GasPriceMultiple = ctx.Uint64(TxPoolGasPriceMultiple.Name)
 	}
 }
+
+// SetApolloGPOXLayer is a public wrapper function to set GPO configurations
+func SetApolloGPOXLayer(ctx *cli.Context, cfg *gaspricecfg.Config) {
+	setGPO(ctx, cfg)
+}

--- a/cmd/utils/flags_xlayer.go
+++ b/cmd/utils/flags_xlayer.go
@@ -263,8 +263,3 @@ func setTxPoolXLayer(ctx *cli.Context, cfg *ethconfig.DeprecatedTxPoolConfig) {
 		cfg.GasPriceMultiple = ctx.Uint64(TxPoolGasPriceMultiple.Name)
 	}
 }
-
-// SetApolloGPOXLayer is a public wrapper function to set GPO configurations
-func SetApolloGPOXLayer(ctx *cli.Context, cfg *gaspricecfg.Config) {
-	setGPO(ctx, cfg)
-}

--- a/eth/ethconfig/apollo_xlayer.go
+++ b/eth/ethconfig/apollo_xlayer.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/ledgerwatch/erigon/zkevm/log"
 )
 
 // ApolloConfig is the apollo eth backend dynamic config
@@ -25,7 +27,12 @@ func GetApolloConfig() (Config, error) {
 	if UnsafeGetApolloConfig().Enable() {
 		UnsafeGetApolloConfig().RLock()
 		defer UnsafeGetApolloConfig().RUnlock()
-		return UnsafeGetApolloConfig().Conf, nil
+		conf, err := UnsafeGetApolloConfig().Conf.TryClone()
+		if err != nil {
+			log.Debug(fmt.Sprintf("GetApolloConfig error: %v", err))
+			return Config{}, err
+		}
+		return conf, nil
 	} else {
 		return Config{}, fmt.Errorf("apollo config disabled")
 	}

--- a/eth/ethconfig/apollo_xlayer.go
+++ b/eth/ethconfig/apollo_xlayer.go
@@ -13,7 +13,12 @@ type ApolloConfig struct {
 	sync.RWMutex
 }
 
-var apolloConfig = &ApolloConfig{}
+var apolloConfig = &ApolloConfig{
+	EnableApollo: false,
+	Conf: Config{
+		Zk: &Zk{},
+	},
+}
 
 // GetApolloConfig returns a copy of the singleton instance apollo config
 func GetApolloConfig() (Config, error) {

--- a/eth/ethconfig/apollo_xlayer.go
+++ b/eth/ethconfig/apollo_xlayer.go
@@ -47,7 +47,7 @@ func UnsafeGetApolloConfig() *ApolloConfig {
 	return apolloConfig
 }
 
-// Enable returns true if apollo is enabled
+// enable returns true if apollo is enabled
 func (c *ApolloConfig) enable() bool {
 	if c == nil || !c.EnableApollo {
 		return false

--- a/eth/ethconfig/apollo_xlayer.go
+++ b/eth/ethconfig/apollo_xlayer.go
@@ -20,9 +20,14 @@ var apolloConfig = &ApolloConfig{
 	},
 }
 
+// IsApolloConfigEnable returns true if the singleton instnace apollo config is enabled
+func IsApolloConfigEnable() bool {
+	return UnsafeGetApolloConfig().enable()
+}
+
 // GetApolloConfig returns a copy of the singleton instance apollo config
 func GetApolloConfig() (Config, error) {
-	if UnsafeGetApolloConfig().Enable() {
+	if IsApolloConfigEnable() {
 		UnsafeGetApolloConfig().RLock()
 		defer UnsafeGetApolloConfig().RUnlock()
 		conf, err := UnsafeGetApolloConfig().Conf.TryClone()
@@ -35,15 +40,15 @@ func GetApolloConfig() (Config, error) {
 	}
 }
 
-// UnsafeGetApolloConfig is an unsafe function that returns directly the singleton
-// instance without locking the sync mutex
+// UnsafeGetApolloConfig is an unsafe function that returns directly the singleton instance
+// without locking the sync mutex
 // For read operations and most use cases, GetApolloConfig should be used instead
 func UnsafeGetApolloConfig() *ApolloConfig {
 	return apolloConfig
 }
 
 // Enable returns true if apollo is enabled
-func (c *ApolloConfig) Enable() bool {
+func (c *ApolloConfig) enable() bool {
 	if c == nil || !c.EnableApollo {
 		return false
 	}

--- a/eth/ethconfig/apollo_xlayer.go
+++ b/eth/ethconfig/apollo_xlayer.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"sync"
 	"time"
-
-	"github.com/ledgerwatch/erigon/zkevm/log"
 )
 
 // ApolloConfig is the apollo eth backend dynamic config
@@ -29,7 +27,6 @@ func GetApolloConfig() (Config, error) {
 		defer UnsafeGetApolloConfig().RUnlock()
 		conf, err := UnsafeGetApolloConfig().Conf.TryClone()
 		if err != nil {
-			log.Debug(fmt.Sprintf("GetApolloConfig error: %v", err))
 			return Config{}, err
 		}
 		return conf, nil

--- a/eth/ethconfig/config_xlayer.go
+++ b/eth/ethconfig/config_xlayer.go
@@ -1,6 +1,11 @@
 package ethconfig
 
-import "time"
+import (
+	"fmt"
+	"time"
+
+	"github.com/mitchellh/copystructure"
+)
 
 // XLayerConfig is the X Layer config used on the eth backend
 type XLayerConfig struct {
@@ -27,4 +32,17 @@ type ApolloClientConfig struct {
 	IP            string
 	AppID         string
 	NamespaceName string
+}
+
+// TryClone is the helper method to return a deep copy of the ethconfig instance
+func (c *Config) TryClone() (Config, error) {
+	clone, err := copystructure.Copy(*c)
+	if err != nil {
+		return Config{}, err
+	}
+	ret, ok := clone.(Config)
+	if !ok {
+		return Config{}, fmt.Errorf("type assertion failed")
+	}
+	return ret, nil
 }

--- a/eth/ethconfig/config_xlayer.go
+++ b/eth/ethconfig/config_xlayer.go
@@ -11,7 +11,7 @@ type XLayerConfig struct {
 	SequencerBatchSleepDuration time.Duration
 }
 
-var DefaultXLayerConfig = &XLayerConfig{}
+var DefaultXLayerConfig = XLayerConfig{}
 
 // NacosConfig is the config for nacos
 type NacosConfig struct {

--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -70,10 +70,10 @@ type Zk struct {
 	ExecutorPayloadOutput       string
 
 	// For X Layer
-	XLayer *XLayerConfig
+	XLayer XLayerConfig
 }
 
-var DefaultZkConfig = &Zk{
+var DefaultZkConfig = Zk{
 	// For X Layer
 	XLayer: DefaultXLayerConfig,
 }

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/libp2p/go-libp2p-pubsub v0.9.3
 	github.com/maticnetwork/crand v1.0.2
 	github.com/maticnetwork/polyproto v0.0.2
+	github.com/mitchellh/copystructure v1.2.0
 	github.com/multiformats/go-multiaddr v0.8.0
 	github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1
 	github.com/nxadm/tail v1.4.9-0.20211216163028-4472660a31a6
@@ -76,6 +77,8 @@ require (
 	github.com/pelletier/go-toml/v2 v2.1.0
 	github.com/pion/stun v0.4.0
 	github.com/prometheus/client_golang v1.15.1
+	github.com/prometheus/client_model v0.4.0
+	github.com/prometheus/common v0.44.0
 	github.com/protolambda/eth2-shuffle v1.1.0
 	github.com/protolambda/ztyp v0.2.2
 	github.com/prysmaticlabs/go-bitfield v0.0.0-20210809151128-385d8c5e3fb7
@@ -84,6 +87,7 @@ require (
 	github.com/rs/cors v1.8.3
 	github.com/segmentio/kafka-go v0.4.47
 	github.com/shirou/gopsutil/v3 v3.23.2
+	github.com/spf13/afero v1.10.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/status-im/keycard-go v0.2.0
@@ -214,6 +218,7 @@ require (
 	github.com/mikioh/tcpopt v0.0.0-20190314235656-172688c1accc // indirect
 	github.com/minio/sha256-simd v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/mmcloughlin/addchain v0.4.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
@@ -251,8 +256,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
-	github.com/prometheus/client_model v0.4.0 // indirect
-	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/quic-go/qpack v0.4.0 // indirect
 	github.com/quic-go/qtls-go1-19 v0.2.1 // indirect
@@ -266,7 +269,6 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
-	github.com/spf13/afero v1.10.0 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -747,6 +747,8 @@ github.com/minio/sha256-simd v0.1.1-0.20190913151208-6de447530771/go.mod h1:B5e1
 github.com/minio/sha256-simd v1.0.0 h1:v1ta+49hkWZyvaKwrQB8elexRqm6Y0aMLjCNsrYxo6g=
 github.com/minio/sha256-simd v1.0.0/go.mod h1:OuYzVNI5vcoYIAmbIvHPl3N3jUzVedXbKy5RFepssQM=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
+github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
+github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
@@ -756,6 +758,8 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
+github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mmcloughlin/addchain v0.4.0 h1:SobOdjm2xLj1KkXN5/n0xTIWyZA2+s99UCY1iPfkHRY=
 github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqkyU72HC5wJ4RlU=
 github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=

--- a/node/nodecfg/apollo_xlayer.go
+++ b/node/nodecfg/apollo_xlayer.go
@@ -17,9 +17,14 @@ var apolloConfig = &ApolloConfig{
 	Conf:         Config{},
 }
 
+// IsApolloConfigEnable returns true if the singleton instnace apollo config is enabled
+func IsApolloConfigEnable() bool {
+	return UnsafeGetApolloConfig().enable()
+}
+
 // GetApolloConfig returns a copy of the singleton instance apollo config
 func GetApolloConfig() (Config, error) {
-	if UnsafeGetApolloConfig().Enable() {
+	if IsApolloConfigEnable() {
 		UnsafeGetApolloConfig().RLock()
 		defer UnsafeGetApolloConfig().RUnlock()
 		conf, err := UnsafeGetApolloConfig().Conf.TryClone()
@@ -32,15 +37,15 @@ func GetApolloConfig() (Config, error) {
 	}
 }
 
-// UnsafeGetApolloConfig is an unsafe function that returns directly the singleton
-// instance without locking the sync mutex
+// UnsafeGetApolloConfig is an unsafe function that returns directly the singleton instance
+// without locking the sync mutex
 // For read operations and most use cases, GetApolloConfig should be used instead
 func UnsafeGetApolloConfig() *ApolloConfig {
 	return apolloConfig
 }
 
 // Enable returns true if apollo is enabled
-func (c *ApolloConfig) Enable() bool {
+func (c *ApolloConfig) enable() bool {
 	if c == nil || !c.EnableApollo {
 		return false
 	}

--- a/node/nodecfg/apollo_xlayer.go
+++ b/node/nodecfg/apollo_xlayer.go
@@ -3,8 +3,6 @@ package nodecfg
 import (
 	"fmt"
 	"sync"
-
-	"github.com/ledgerwatch/erigon/zkevm/log"
 )
 
 // ApolloConfig is the apollo eth backend dynamic config
@@ -26,7 +24,6 @@ func GetApolloConfig() (Config, error) {
 		defer UnsafeGetApolloConfig().RUnlock()
 		conf, err := UnsafeGetApolloConfig().Conf.TryClone()
 		if err != nil {
-			log.Debug(fmt.Sprintf("GetApolloConfig error: %v", err))
 			return Config{}, err
 		}
 		return conf, nil

--- a/node/nodecfg/apollo_xlayer.go
+++ b/node/nodecfg/apollo_xlayer.go
@@ -44,7 +44,7 @@ func UnsafeGetApolloConfig() *ApolloConfig {
 	return apolloConfig
 }
 
-// Enable returns true if apollo is enabled
+// enable returns true if apollo is enabled
 func (c *ApolloConfig) enable() bool {
 	if c == nil || !c.EnableApollo {
 		return false

--- a/node/nodecfg/apollo_xlayer.go
+++ b/node/nodecfg/apollo_xlayer.go
@@ -12,7 +12,10 @@ type ApolloConfig struct {
 	sync.RWMutex
 }
 
-var apolloConfig = &ApolloConfig{}
+var apolloConfig = &ApolloConfig{
+	EnableApollo: false,
+	Conf:         Config{},
+}
 
 // GetApolloConfig returns a copy of the singleton instance apollo config
 func GetApolloConfig() (Config, error) {

--- a/node/nodecfg/apollo_xlayer.go
+++ b/node/nodecfg/apollo_xlayer.go
@@ -3,6 +3,8 @@ package nodecfg
 import (
 	"fmt"
 	"sync"
+
+	"github.com/ledgerwatch/erigon/zkevm/log"
 )
 
 // ApolloConfig is the apollo eth backend dynamic config
@@ -22,7 +24,12 @@ func GetApolloConfig() (Config, error) {
 	if UnsafeGetApolloConfig().Enable() {
 		UnsafeGetApolloConfig().RLock()
 		defer UnsafeGetApolloConfig().RUnlock()
-		return UnsafeGetApolloConfig().Conf, nil
+		conf, err := UnsafeGetApolloConfig().Conf.TryClone()
+		if err != nil {
+			log.Debug(fmt.Sprintf("GetApolloConfig error: %v", err))
+			return Config{}, err
+		}
+		return conf, nil
 	} else {
 		return Config{}, fmt.Errorf("apollo config disabled")
 	}

--- a/node/nodecfg/config_xlayer.go
+++ b/node/nodecfg/config_xlayer.go
@@ -1,0 +1,20 @@
+package nodecfg
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/copystructure"
+)
+
+// TryClone is the helper method to return a deep copy of the ethconfig instance
+func (c *Config) TryClone() (Config, error) {
+	clone, err := copystructure.Copy(*c)
+	if err != nil {
+		return Config{}, err
+	}
+	ret, ok := clone.(Config)
+	if !ok {
+		return Config{}, fmt.Errorf("type assertion failed")
+	}
+	return ret, nil
+}

--- a/node/nodecfg/config_xlayer.go
+++ b/node/nodecfg/config_xlayer.go
@@ -6,7 +6,7 @@ import (
 	"github.com/mitchellh/copystructure"
 )
 
-// TryClone is the helper method to return a deep copy of the ethconfig instance
+// TryClone is the helper method to return a deep copy of the nodecfg instance
 func (c *Config) TryClone() (Config, error) {
 	clone, err := copystructure.Copy(*c)
 	if err != nil {

--- a/turbo/cli/flags_xlayer.go
+++ b/turbo/cli/flags_xlayer.go
@@ -7,7 +7,7 @@ import (
 )
 
 func ApplyFlagsForXLayerConfig(ctx *cli.Context, cfg *ethconfig.Config) {
-	cfg.XLayer = &ethconfig.XLayerConfig{
+	cfg.XLayer = ethconfig.XLayerConfig{
 		Apollo: ethconfig.ApolloClientConfig{
 			Enable:        ctx.Bool(utils.ApolloEnableFlag.Name),
 			IP:            ctx.String(utils.ApolloIPAddr.Name),

--- a/zk/apollo/apollo.go
+++ b/zk/apollo/apollo.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/ledgerwatch/erigon/cmd/utils"
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
-	"github.com/ledgerwatch/erigon/node/nodecfg"
 	erigoncli "github.com/ledgerwatch/erigon/turbo/cli"
 	"github.com/ledgerwatch/erigon/turbo/debug"
 	"github.com/ledgerwatch/log/v3"
@@ -21,13 +20,11 @@ import (
 type Client struct {
 	*agollo.Client
 	namespaceMap map[string]string
-	ethCfg       *ethconfig.Config
-	nodeCfg      *nodecfg.Config
 	flags        []cli.Flag
 }
 
 // NewClient creates a new apollo client
-func NewClient(ethCfg *ethconfig.Config, nodeCfg *nodecfg.Config) *Client {
+func NewClient(ethCfg *ethconfig.Config) *Client {
 	if ethCfg == nil || !ethCfg.Zk.XLayer.Apollo.Enable || ethCfg.Zk.XLayer.Apollo.IP == "" || ethCfg.Zk.XLayer.Apollo.AppID == "" || ethCfg.Zk.XLayer.Apollo.NamespaceName == "" {
 		log.Info(fmt.Sprintf("apollo is not enabled, config: %+v", ethCfg.Zk.XLayer.Apollo))
 		return nil
@@ -65,8 +62,6 @@ func NewClient(ethCfg *ethconfig.Config, nodeCfg *nodecfg.Config) *Client {
 	apc := &Client{
 		Client:       client,
 		namespaceMap: nsMap,
-		ethCfg:       ethCfg,
-		nodeCfg:      nodeCfg,
 		flags:        append(erigoncli.DefaultFlags, debug.Flags...),
 	}
 	client.AddChangeListener(&CustomChangeListener{apc})

--- a/zk/apollo/common_test.go
+++ b/zk/apollo/common_test.go
@@ -24,16 +24,21 @@ func TestLoadJsonRPCConfig(t *testing.T) {
 				Apollo: ethconfig.ApolloClientConfig{
 					IP:            "0.0.0.0",
 					AppID:         "xlayer-devnet",
-					NamespaceName: "jsonrpc-ro.txt,jsonrpc-roHalt.properties",
+					NamespaceName: "jsonrpc-ro.txt, sequencer-roHalt.properties",
 					Enable:        true,
 				},
 			},
 		},
 	}
-	nc := &nodecfg.Config{}
-	client := NewClient(c, nc)
+	client := NewClient(c)
 	client.loadJsonRPC(value)
 	require.NoError(t, err)
-	logTestNodeConfig(t, client.nodeCfg)
-	logTestEthConfig(t, client.ethCfg)
+
+	apolloNodeCfg, err := nodecfg.GetApolloConfig()
+	require.NoError(t, err)
+	apolloEthCfg, err := ethconfig.GetApolloConfig()
+	require.NoError(t, err)
+
+	logTestNodeConfig(t, &apolloNodeCfg)
+	logTestEthConfig(t, &apolloEthCfg)
 }

--- a/zk/apollo/jsonrpc.go
+++ b/zk/apollo/jsonrpc.go
@@ -19,8 +19,7 @@ func (c *Client) loadJsonRPC(value interface{}) {
 	}
 
 	// Load jsonrpc config changes
-	loadNodeJsonRPCConfig(ctx, c.nodeCfg)
-	loadEthJsonRPCConfig(ctx, c.ethCfg)
+	loadJsonRPCConfig(ctx)
 	log.Info(fmt.Sprintf("loaded jsonrpc from apollo config: %+v", value.(string)))
 }
 
@@ -32,9 +31,13 @@ func (c *Client) fireJsonRPC(key string, value *storage.ConfigChange) {
 		return
 	}
 
+	loadJsonRPCConfig(ctx)
 	log.Info(fmt.Sprintf("apollo jsonrpc old config : %+v", value.OldValue.(string)))
 	log.Info(fmt.Sprintf("apollo jsonrpc config changed: %+v", value.NewValue.(string)))
+}
 
+// loadJsonRPCConfig loads the dynamic json rpc apollo configurations
+func loadJsonRPCConfig(ctx *cli.Context) {
 	// Update jsonrpc node config changes
 	nodecfg.UnsafeGetApolloConfig().Lock()
 	nodecfg.UnsafeGetApolloConfig().EnableApollo = true

--- a/zk/apollo/jsonrpc.go
+++ b/zk/apollo/jsonrpc.go
@@ -48,6 +48,7 @@ func (c *Client) fireJsonRPC(key string, value *storage.ConfigChange) {
 	ethconfig.UnsafeGetApolloConfig().Unlock()
 }
 
+// loadNodeJsonRPCConfig loads the dynamic json rpc apollo node configurations
 func loadNodeJsonRPCConfig(ctx *cli.Context, nodeCfg *nodecfg.Config) {
 	// Load jsonrpc config
 	if ctx.IsSet(utils.HTTPEnabledFlag.Name) {
@@ -76,8 +77,9 @@ func loadNodeJsonRPCConfig(ctx *cli.Context, nodeCfg *nodecfg.Config) {
 	}
 }
 
+// loadEthJsonRPCConfig loads the dynamic json rpc apollo eth configurations
 func loadEthJsonRPCConfig(ctx *cli.Context, ethCfg *ethconfig.Config) {
-	// Load ZK config
+	// Load generic ZK config
 	loadZkConfig(ctx, ethCfg)
 
 	// Load jsonrpc config

--- a/zk/apollo/l2gaspricer.go
+++ b/zk/apollo/l2gaspricer.go
@@ -47,12 +47,14 @@ func (c *Client) fireL2GasPricer(key string, value *storage.ConfigChange) {
 	ethconfig.UnsafeGetApolloConfig().Unlock()
 }
 
+// loadNodeL2GasPricerConfig loads the dynamic gas pricer apollo node configurations
 func loadNodeL2GasPricerConfig(ctx *cli.Context, nodeCfg *nodecfg.Config) {
 	// Load l2gaspricer config
 }
 
+// loadEthL2GasPricerConfig loads the dynamic gas pricer apollo eth configurations
 func loadEthL2GasPricerConfig(ctx *cli.Context, ethCfg *ethconfig.Config) {
-	// Load ZK config
+	// Load generic ZK config
 	loadZkConfig(ctx, ethCfg)
 
 	// Load l2gaspricer config

--- a/zk/apollo/l2gaspricer.go
+++ b/zk/apollo/l2gaspricer.go
@@ -18,8 +18,7 @@ func (c *Client) loadL2GasPricer(value interface{}) {
 	}
 
 	// Load l2gaspricer config changes
-	loadNodeL2GasPricerConfig(ctx, c.nodeCfg)
-	loadEthL2GasPricerConfig(ctx, c.ethCfg)
+	loadL2GasPricerConfig(ctx)
 	log.Info(fmt.Sprintf("loaded l2gaspricer from apollo config: %+v", value.(string)))
 }
 
@@ -31,9 +30,13 @@ func (c *Client) fireL2GasPricer(key string, value *storage.ConfigChange) {
 		return
 	}
 
+	loadL2GasPricerConfig(ctx)
 	log.Info(fmt.Sprintf("apollo l2gaspricer old config : %+v", value.OldValue.(string)))
 	log.Info(fmt.Sprintf("apollo l2gaspricer config changed: %+v", value.NewValue.(string)))
+}
 
+// loadL2GasPricerConfig loads the dynamic gas pricer apollo configurations
+func loadL2GasPricerConfig(ctx *cli.Context) {
 	// Update l2gaspricer node config changes
 	nodecfg.UnsafeGetApolloConfig().Lock()
 	nodecfg.UnsafeGetApolloConfig().EnableApollo = true

--- a/zk/apollo/sequencer.go
+++ b/zk/apollo/sequencer.go
@@ -47,12 +47,14 @@ func (c *Client) fireSequencer(key string, value *storage.ConfigChange) {
 	ethconfig.UnsafeGetApolloConfig().Unlock()
 }
 
+// loadNodeSequencerConfig loads the dynamic sequencer apollo node configurations
 func loadNodeSequencerConfig(ctx *cli.Context, nodeCfg *nodecfg.Config) {
 	// Load sequencer config
 }
 
+// loadEthSequencerConfig loads the dynamic sequencer apollo eth configurations
 func loadEthSequencerConfig(ctx *cli.Context, ethCfg *ethconfig.Config) {
-	// Load ZK config
+	// Load generic ZK config
 	loadZkConfig(ctx, ethCfg)
 
 	// Load sequencer config

--- a/zk/apollo/sequencer.go
+++ b/zk/apollo/sequencer.go
@@ -18,8 +18,7 @@ func (c *Client) loadSequencer(value interface{}) {
 	}
 
 	// Load sequencer config changes
-	loadNodeSequencerConfig(ctx, c.nodeCfg)
-	loadEthSequencerConfig(ctx, c.ethCfg)
+	loadSequencerConfig(ctx)
 	log.Info(fmt.Sprintf("loaded sequencer from apollo config: %+v", value.(string)))
 }
 
@@ -31,9 +30,13 @@ func (c *Client) fireSequencer(key string, value *storage.ConfigChange) {
 		return
 	}
 
+	loadSequencerConfig(ctx)
 	log.Info(fmt.Sprintf("apollo sequencer old config : %+v", value.OldValue.(string)))
 	log.Info(fmt.Sprintf("apollo sequencer config changed: %+v", value.NewValue.(string)))
+}
 
+// loadSequencerConfig loads the dynamic sequencer apollo configurations
+func loadSequencerConfig(ctx *cli.Context) {
 	// Update sequencer node config changes
 	nodecfg.UnsafeGetApolloConfig().Lock()
 	nodecfg.UnsafeGetApolloConfig().EnableApollo = true

--- a/zk/apollo/utils.go
+++ b/zk/apollo/utils.go
@@ -22,6 +22,7 @@ func createMockContext(flags []cli.Flag) *cli.Context {
 	return context
 }
 
+// loadZkConfig loads the generic zkEVM eth apollo configurations
 func loadZkConfig(ctx *cli.Context, ethCfg *ethconfig.Config) {
 	if ethCfg.Zk == nil {
 		ethCfg.Zk = &ethconfig.Zk{}


### PR DESCRIPTION
## Summary

- The old apollo configuration client holds the node's global configuration, which is dangerous since we change the node configurations on load apollo config (node startup pipeline), but on fire apollo config (dynamic configuration changes) we permutation the apollo configuration singleton instance
- This PR fixes this issue by ensuring that all apollo configurations will always configure the apollo singleton instance
- Apollo client do not hold the node global's configuration instance
- All pipelines that require the dynamic apollo configuration will implement a function call to get a copy of the apollo configuration singleton instance to better safeguard against undesired behaviour
- Implement deep copy utility methods on nodecfg and ethconfig configurations
- Switch away from XLayerConfig pointer in zk config struct