### PR TITLE
Fix rate limiter and auth keys pipelines

### DIFF
--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -509,7 +509,7 @@ func startRegularRpcServer(ctx context.Context, cfg httpcfg.HttpCfg, rpcAPI []rp
 	srv := rpc.NewServer(cfg.RpcBatchConcurrency, cfg.TraceRequests, cfg.RpcStreamingDisable)
 
 	// For X Layer
-	rpc.InitRateLimit(cfg.MethodRateLimit)
+	rpc.SetRateLimit(cfg.MethodRateLimit)
 
 	allowListForRPC, err := parseAllowListForRPC(cfg.RpcAllowListFilePath)
 	if err != nil {

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -552,7 +552,8 @@ func startRegularRpcServer(ctx context.Context, cfg httpcfg.HttpCfg, rpcAPI []rp
 	}
 
 	// For X Layer
-	apiHandler = rpc.ApiAuthHandler(cfg.HttpApiKeys, apiHandler)
+	rpc.InitApiAuth(cfg.HttpApiKeys)
+	apiHandler = rpc.ApiAuthHandler(apiHandler)
 
 	listener, httpAddr, err := node.StartHTTPEndpoint(httpEndpoint, cfg.HTTPTimeouts, apiHandler)
 	if err != nil {

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -552,7 +552,7 @@ func startRegularRpcServer(ctx context.Context, cfg httpcfg.HttpCfg, rpcAPI []rp
 	}
 
 	// For X Layer
-	rpc.InitApiAuth(cfg.HttpApiKeys)
+	rpc.SetApiAuth(cfg.HttpApiKeys)
 	apiHandler = rpc.ApiAuthHandler(apiHandler)
 
 	listener, httpAddr, err := node.StartHTTPEndpoint(httpEndpoint, cfg.HTTPTimeouts, apiHandler)

--- a/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
+++ b/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
@@ -70,6 +70,8 @@ type HttpCfg struct {
 	DataStreamHost         string
 	DataStreamWriteTimeout time.Duration
 	L2RpcUrl               string
-	HttpApiKeys            string
-	MethodRateLimit        string
+
+	// For X Layer
+	HttpApiKeys     string
+	MethodRateLimit string
 }

--- a/rpc/api_auth_xlayer.go
+++ b/rpc/api_auth_xlayer.go
@@ -46,6 +46,11 @@ func SetApiAuth(cfg string) {
 	log.Info(fmt.Sprintf("Setting API keys auth, config: %v", cfg))
 	keyItems := strings.Split(cfg, "\n")
 
+	// Clear API auth key map
+	gApikeyAuthMap.AllowKeys = make(map[string]ApiKeyItem)
+	clearApikeyRateLimitMap()
+
+	// Set API auth key map
 	for _, item := range keyItems {
 		var keyCfg = struct {
 			// Name defines the name of the key

--- a/rpc/api_auth_xlayer.go
+++ b/rpc/api_auth_xlayer.go
@@ -34,14 +34,9 @@ var gApikeyAuthMap = &ApiKeyAuthMap{
 	AllowKeys: make(map[string]ApiKeyItem),
 }
 
-// InitApiAuth initializes the gApikeyAuthMap singleton instance with the API
+// SetApiAuth sets the gApikeyAuthMap singleton instance with the API
 // auth key configs
-func InitApiAuth(cfg string) {
-	setApiAuth(cfg)
-}
-
-// setApiAuth sets the node API auth with the API key configs
-func setApiAuth(cfg string) {
+func SetApiAuth(cfg string) {
 	gApikeyAuthMap.Lock()
 	defer gApikeyAuthMap.Unlock()
 

--- a/rpc/api_auth_xlayer.go
+++ b/rpc/api_auth_xlayer.go
@@ -95,8 +95,8 @@ func setApiAuth(cfg string) {
 
 }
 
-// check returns the API key authentication check result
-func check(key string) error {
+// checkAuthKey checks the API authentication key
+func checkAuthKey(key string) error {
 	gApikeyAuthMap.RLock()
 	defer gApikeyAuthMap.RUnlock()
 
@@ -116,7 +116,7 @@ func check(key string) error {
 func apiAuthHandlerFunc(handlerFunc http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if gApikeyAuthMap.Enable {
-			if er := check(path.Base(r.URL.Path)); er != nil {
+			if er := checkAuthKey(path.Base(r.URL.Path)); er != nil {
 				err := handleNoAuthErr(w, er)
 				if err != nil {
 					http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/rpc/api_auth_xlayer.go
+++ b/rpc/api_auth_xlayer.go
@@ -47,7 +47,7 @@ func setApiAuth(cfg string) {
 	if cfg == "" {
 		return
 	}
-	log.Info(fmt.Sprintf("API keys auth enabled, config: %v", cfg))
+	log.Info(fmt.Sprintf("Setting API keys auth, config: %v", cfg))
 	keyItems := strings.Split(cfg, "\n")
 
 	for _, item := range keyItems {
@@ -62,18 +62,18 @@ func setApiAuth(cfg string) {
 		}{}
 		err := json.Unmarshal([]byte(item), &keyCfg)
 		if err != nil {
-			log.Warn(fmt.Sprintf("invalid key item: %s", item))
+			log.Warn(fmt.Sprintf("Invalid key item: %s", item))
 			continue
 		}
 
 		// Validate API key cfg inputs
 		parse, err := time.Parse("2006-01-02", keyCfg.Timeout)
 		if err != nil {
-			log.Warn(fmt.Sprintf("failed to parse API key timeout cfg: %v, err: %v", keyCfg.Timeout, err))
+			log.Warn(fmt.Sprintf("Failed to parse API key timeout cfg: %v, err: %v", keyCfg.Timeout, err))
 			continue
 		}
 		if strings.ToLower(fmt.Sprintf("%x", md5.Sum([]byte(keyCfg.Project+keyCfg.Timeout)))) != keyCfg.Key {
-			log.Warn(fmt.Sprintf("project [%s], key [%s] is invalid, key = md5(Project+Timeout)", keyCfg.Project, keyCfg.Key))
+			log.Warn(fmt.Sprintf("Project [%s], key [%s] is invalid, key = md5(Project+Timeout)", keyCfg.Project, keyCfg.Key))
 			continue
 		}
 		// Set API key authentication
@@ -104,7 +104,7 @@ func check(key string) error {
 		//metrics.RequestAuthCount(al.allowKeys[key].project)
 		return nil
 	} else if ok && time.Now().After(item.Timeout) {
-		log.Warn(fmt.Sprintf("project [%s], key [%s] has expired, ", item.Project, key))
+		log.Warn(fmt.Sprintf("Project [%s], key [%s] has expired, ", item.Project, key))
 		//metrics.RequestAuthErrorCount(metrics.RequestAuthErrorTypeKeyExpired)
 		return errors.New("key has expired")
 	}

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -177,7 +177,7 @@ func (h *handler) handleBatch(msgs []*jsonrpcMessage) {
 					<-boundedConcurrency
 				}()
 				// For X Layer
-				if !apikeyMethodRateLimitAllow(h.ApiKey, calls[i].Method) || !methodRateLimitAllow(calls[i].Method) {
+				if !checkApikeyMethodRateLimit(h.ApiKey, calls[i].Method) || !checkMethodRateLimit(calls[i].Method) {
 					answersWithNils[i] = errorMessage(fmt.Errorf("method rate limit exceeded"))
 					return
 				}
@@ -222,7 +222,7 @@ func (h *handler) handleMsg(msg *jsonrpcMessage, stream *jsoniter.Stream) {
 	}
 	h.startCallProc(func(cp *callProc) {
 		// For X Layer
-		if !apikeyMethodRateLimitAllow(h.ApiKey, msg.Method) || !methodRateLimitAllow(msg.Method) {
+		if !checkApikeyMethodRateLimit(h.ApiKey, msg.Method) || !checkMethodRateLimit(msg.Method) {
 			h.conn.writeJSON(cp.ctx, errorMessage(fmt.Errorf("rate limit exceeded")))
 			return
 		}

--- a/rpc/ratelimit_xlayer.go
+++ b/rpc/ratelimit_xlayer.go
@@ -44,11 +44,11 @@ func InitRateLimit(cfg string) {
 		log.Warn(fmt.Sprintf("invalid rate limit config: %s", cfg))
 		return
 	}
-	setRateLimit(rlc)
+	SetRateLimit(rlc)
 }
 
-// setRateLimit sets the global rate limiter
-func setRateLimit(cfg RateLimitConfig) {
+// SetRateLimit sets the rate limiter singleton instance
+func SetRateLimit(cfg RateLimitConfig) {
 	gRateLimiter.Lock()
 	defer gRateLimiter.Unlock()
 

--- a/rpc/ratelimit_xlayer.go
+++ b/rpc/ratelimit_xlayer.go
@@ -87,7 +87,7 @@ func setApikeyRateLimit(key string, cfg RateLimitConfig) {
 	defer gApikeyRateLimiter.Unlock()
 
 	if _, ok := gApikeyRateLimiter.rlm[key]; ok {
-		log.Warn(fmt.Sprintf("API key rate limiter already set, skipping."))
+		log.Warn("API key rate limiter already set, skipping")
 		return
 	}
 

--- a/rpc/ratelimit_xlayer.go
+++ b/rpc/ratelimit_xlayer.go
@@ -2,13 +2,14 @@ package rpc
 
 import (
 	"encoding/json"
+	"fmt"
 	"sync"
 
 	"github.com/ledgerwatch/log/v3"
 	"golang.org/x/time/rate"
 )
 
-// RateLimitConfig has parameters to config the rate limit
+// RateLimitConfig contains the config of the rate limiter
 type RateLimitConfig struct {
 
 	// RateLimitApis defines the apis that need to be rate limited
@@ -21,15 +22,18 @@ type RateLimitConfig struct {
 	RateLimitBucket int `json:"bucket"`
 }
 
-// RateLimit is the rate limit config
+// RateLimit is the struct definition for the node rate limiter
 type RateLimit struct {
 	rlm map[string]*rate.Limiter
 	sync.RWMutex
 }
 
-var rateLimit = &RateLimit{}
+// gRateLimiter is the node's singleton instance for the rate limiter
+var gRateLimiter = &RateLimit{
+	rlm: make(map[string]*rate.Limiter),
+}
 
-// InitRateLimit initializes the rate limit config
+// InitRateLimit initializes the rate limiter singleton instance
 func InitRateLimit(cfg string) {
 	if cfg == "" {
 		return
@@ -37,91 +41,74 @@ func InitRateLimit(cfg string) {
 	rlc := RateLimitConfig{}
 	err := json.Unmarshal([]byte(cfg), &rlc)
 	if err != nil {
-		log.Warn("invalid rate limit config: %s", cfg)
+		log.Warn(fmt.Sprintf("invalid rate limit config: %s", cfg))
 		return
 	}
 	setRateLimit(rlc)
 }
 
-// setRateLimit sets the rate limit config
-func setRateLimit(rlc RateLimitConfig) {
-	rateLimit.Lock()
-	defer rateLimit.Unlock()
-	rateLimit.rlm = updateRateLimit(rlc)
-}
+// setRateLimit sets the global rate limiter
+func setRateLimit(cfg RateLimitConfig) {
+	gRateLimiter.Lock()
+	defer gRateLimiter.Unlock()
 
-// updateRateLimit updates the rate limit config
-func updateRateLimit(rateLimit RateLimitConfig) map[string]*rate.Limiter {
-	log.Info("rate limit config updated", "config", rateLimit)
-	if len(rateLimit.RateLimitApis) > 0 {
-		log.Info("rate limit enabled", "api", rateLimit.RateLimitApis, "count", rateLimit.RateLimitCount, "bucket", rateLimit.RateLimitBucket)
-		rlm := make(map[string]*rate.Limiter)
-		for _, api := range rateLimit.RateLimitApis {
-			rlm[api] = rate.NewLimiter(rate.Limit(rateLimit.RateLimitCount), rateLimit.RateLimitBucket)
-		}
-		return rlm
+	log.Info(fmt.Sprintf("Setting node rate limiter, cfg: %v", cfg))
+	for _, api := range cfg.RateLimitApis {
+		gRateLimiter.rlm[api] = rate.NewLimiter(rate.Limit(cfg.RateLimitCount), cfg.RateLimitBucket)
+		log.Info(fmt.Sprintf("Rate limiter enabled for api method: %v with count: %v and bucket: %v", cfg.RateLimitApis, cfg.RateLimitCount, cfg.RateLimitBucket))
 	}
-	return nil
 }
 
-// methodRateLimitAllow returns true if the method is allowed by the rate limit
-func methodRateLimitAllow(method string) bool {
-	rateLimit.RLock()
-	rlm := rateLimit.rlm
-	rateLimit.RUnlock()
-	if rlm != nil && rlm[method] != nil && !rlm[method].Allow() {
-		return false
+// checkMethodRateLimit returns true if the method API is allowed by the rate limiter
+func checkMethodRateLimit(method string) bool {
+	gRateLimiter.RLock()
+	defer gRateLimiter.RUnlock()
+
+	if rl, ok := gRateLimiter.rlm[method]; ok {
+		return rl.Allow()
 	}
 	return true
 }
 
-// ApikeyRateLimit is the api rate limit config
+// ApikeyRateLimit is the struct definition for the API key rate limiter
 type ApikeyRateLimit struct {
 	rlm map[string]map[string]*rate.Limiter
 	sync.RWMutex
 }
 
-var apiKeyRateLimit = &ApikeyRateLimit{}
+// gApikeyRateLimiter is the node's singleton instance for the API key rate limiter
+var gApikeyRateLimiter = &ApikeyRateLimit{
+	rlm: make(map[string]map[string]*rate.Limiter),
+}
 
-// initApikeyRateLimit initializes the apikey rate limit config
-func initApikeyRateLimit(cfg map[string]*RateLimitConfig) {
-	if len(cfg) == 0 {
+// setApiKeyRateLimit sets the global API key rate limiter
+func setApikeyRateLimit(key string, cfg RateLimitConfig) {
+	gApikeyRateLimiter.Lock()
+	defer gApikeyRateLimiter.Unlock()
+
+	if _, ok := gApikeyRateLimiter.rlm[key]; ok {
+		log.Warn(fmt.Sprintf("API key rate limiter already set, skipping."))
 		return
 	}
-	setApikeyRateLimit(cfg)
-}
 
-// setApikeyRateLimit sets the rate limit config
-func setApikeyRateLimit(rlc map[string]*RateLimitConfig) {
-	apiKeyRateLimit.Lock()
-	defer apiKeyRateLimit.Unlock()
-	apiKeyRateLimit.rlm = updateApikeyRateLimit(rlc)
-}
-
-// updateApikeyRateLimit updates the rate limit config
-func updateApikeyRateLimit(rateLimit map[string]*RateLimitConfig) map[string]map[string]*rate.Limiter {
-	akrlm := make(map[string]map[string]*rate.Limiter)
-	log.Info("apikey rate limit config updated", "config", rateLimit)
-	for apikey, config := range rateLimit {
-		if len(config.RateLimitApis) > 0 {
-			log.Info("rate limit enabled", "api", config.RateLimitApis, "count", config.RateLimitCount, "bucket", config.RateLimitBucket)
-			rlm := make(map[string]*rate.Limiter)
-			for _, api := range config.RateLimitApis {
-				rlm[api] = rate.NewLimiter(rate.Limit(config.RateLimitCount), config.RateLimitBucket)
-			}
-			akrlm[apikey] = rlm
-		}
+	log.Info(fmt.Sprintf("Setting API key rate limiter for key: %v, cfg: %v", key, cfg))
+	gApikeyRateLimiter.rlm[key] = make(map[string]*rate.Limiter)
+	for _, api := range cfg.RateLimitApis {
+		gApikeyRateLimiter.rlm[key][api] = rate.NewLimiter(rate.Limit(cfg.RateLimitCount), cfg.RateLimitBucket)
+		log.Info(fmt.Sprintf("Rate limiter enabled for key: %v for api method: %v with count: %v and bucket: %v", key, cfg.RateLimitApis, cfg.RateLimitCount, cfg.RateLimitBucket))
 	}
-	return akrlm
 }
 
-// apikeyMethodRateLimitAllow returns true if the method is allowed by the rate limit
-func apikeyMethodRateLimitAllow(api, method string) bool {
-	apiKeyRateLimit.RLock()
-	rlm := apiKeyRateLimit.rlm
-	apiKeyRateLimit.RUnlock()
-	if rlm != nil && rlm[api] != nil && rlm[api][method] != nil && !rlm[api][method].Allow() {
-		return false
+// checkApikeyMethodRateLimit returns true if the key and the method API is allowed
+// by the API key rate limiter
+func checkApikeyMethodRateLimit(key, method string) bool {
+	gApikeyRateLimiter.RLock()
+	defer gApikeyRateLimiter.RUnlock()
+
+	if rlm, keyFound := gApikeyRateLimiter.rlm[key]; keyFound {
+		if rl, ok := rlm[method]; ok {
+			return rl.Allow()
+		}
 	}
 	return true
 }

--- a/rpc/ratelimit_xlayer.go
+++ b/rpc/ratelimit_xlayer.go
@@ -59,17 +59,6 @@ func setRateLimit(cfg RateLimitConfig) {
 	}
 }
 
-// checkMethodRateLimit returns true if the method API is allowed by the rate limiter
-func checkMethodRateLimit(method string) bool {
-	gRateLimiter.RLock()
-	defer gRateLimiter.RUnlock()
-
-	if rl, ok := gRateLimiter.rlm[method]; ok {
-		return rl.Allow()
-	}
-	return true
-}
-
 // ApikeyRateLimit is the struct definition for the API key rate limiter
 type ApikeyRateLimit struct {
 	rlm map[string]map[string]*rate.Limiter
@@ -97,6 +86,17 @@ func setApikeyRateLimit(key string, cfg RateLimitConfig) {
 		gApikeyRateLimiter.rlm[key][api] = rate.NewLimiter(rate.Limit(cfg.RateLimitCount), cfg.RateLimitBucket)
 		log.Info(fmt.Sprintf("Rate limiter enabled for key: %v for api method: %v with count: %v and bucket: %v", key, cfg.RateLimitApis, cfg.RateLimitCount, cfg.RateLimitBucket))
 	}
+}
+
+// checkMethodRateLimit returns true if the method API is allowed by the rate limiter
+func checkMethodRateLimit(method string) bool {
+	gRateLimiter.RLock()
+	defer gRateLimiter.RUnlock()
+
+	if rl, ok := gRateLimiter.rlm[method]; ok {
+		return rl.Allow()
+	}
+	return true
 }
 
 // checkApikeyMethodRateLimit returns true if the key and the method API is allowed

--- a/rpc/ratelimit_xlayer.go
+++ b/rpc/ratelimit_xlayer.go
@@ -33,8 +33,8 @@ var gRateLimiter = &RateLimit{
 	rlm: make(map[string]*rate.Limiter),
 }
 
-// InitRateLimit initializes the rate limiter singleton instance
-func InitRateLimit(cfg string) {
+// SetRateLimit sets the rate limiter singleton instance
+func SetRateLimit(cfg string) {
 	if cfg == "" {
 		return
 	}
@@ -44,11 +44,11 @@ func InitRateLimit(cfg string) {
 		log.Warn(fmt.Sprintf("invalid rate limit config: %s", cfg))
 		return
 	}
-	SetRateLimit(rlc)
+	setRateLimiter(rlc)
 }
 
-// SetRateLimit sets the rate limiter singleton instance
-func SetRateLimit(cfg RateLimitConfig) {
+// setRateLimiter sets the rate limiter in the singleton instance map
+func setRateLimiter(cfg RateLimitConfig) {
 	gRateLimiter.Lock()
 	defer gRateLimiter.Unlock()
 


### PR DESCRIPTION
## Summary

- Fix issues on https://github.com/okx/xlayer-erigon/pull/42
- Remove unnecessary and dangerous map pointers that will cause node to panic
- Fix problematic instantiation of singleton instance of the node's rate limiter
- Fix setting of configurations from node configurations on rate limiter and authentication keys pipeline
- Fix instantiation of singleton instance of the node's API key map rate limiter
- Clean up logger error that will cause node to panic