### PR TITLE
RPC: Add dynamic batch request enabled flag and limit

### DIFF
--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -517,6 +517,8 @@ func startRegularRpcServer(ctx context.Context, cfg httpcfg.HttpCfg, rpcAPI []rp
 	}
 	srv.SetAllowList(allowListForRPC)
 
+	// For X Layer
+	srv.SetBatchEnabled(cfg.BatchEnabled)
 	srv.SetBatchLimit(cfg.BatchLimit)
 
 	var defaultAPIList []rpc.API

--- a/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
+++ b/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
@@ -70,6 +70,9 @@ type HttpCfg struct {
 	DataStreamHost         string
 	DataStreamWriteTimeout time.Duration
 	L2RpcUrl               string
-	HttpApiKeys            string
-	MethodRateLimit        string
+
+	// For X Layer
+	BatchEnabled    bool
+	HttpApiKeys     string
+	MethodRateLimit string
 }

--- a/cmd/utils/flags_xlayer.go
+++ b/cmd/utils/flags_xlayer.go
@@ -170,6 +170,11 @@ var (
 		Value: false,
 	}
 	// RPC
+	RpcBatchEnabled = cli.BoolFlag{
+		Name:  "rpc.batch.enabled",
+		Usage: "Enable batches request",
+		Value: false,
+	}
 	HTTPApiKeysFlag = cli.StringFlag{
 		Name: "http.apikeys",
 		Usage: `API keys for the HTTP-RPC server and you can add rate limit to this apikey , format: 

--- a/rpc/server_xlayer.go
+++ b/rpc/server_xlayer.go
@@ -1,0 +1,19 @@
+package rpc
+
+import "github.com/ledgerwatch/erigon/node/nodecfg"
+
+// SetBatchEnabled sets if batches requests are handled by this server
+func (s *Server) SetBatchEnabled(flag bool) {
+	s.batchEnabled = flag
+}
+
+func (s *Server) getBatchReqLimitXLayer() (bool, int) {
+	// if apollo is enabled, get the config from apollo
+	if nodecfg.IsApolloConfigEnable() {
+		apolloConf, err := nodecfg.GetApolloConfig()
+		if err == nil {
+			return apolloConf.Http.BatchEnabled, apolloConf.Http.BatchLimit
+		}
+	}
+	return s.batchEnabled, s.batchLimit
+}

--- a/rpc/server_xlayer.go
+++ b/rpc/server_xlayer.go
@@ -10,8 +10,7 @@ func (s *Server) SetBatchEnabled(flag bool) {
 func (s *Server) getBatchReqLimitXLayer() (bool, int) {
 	// if apollo is enabled, get the config from apollo
 	if nodecfg.IsApolloConfigEnable() {
-		apolloConf, err := nodecfg.GetApolloConfig()
-		if err == nil {
+		if apolloConf, err := nodecfg.GetApolloConfig(); err == nil {
 			return apolloConf.Http.BatchEnabled, apolloConf.Http.BatchLimit
 		}
 	}

--- a/test/config/test.erigon.seq.config.yaml
+++ b/test/config/test.erigon.seq.config.yaml
@@ -51,6 +51,7 @@ http.corsdomain: any
 http.timeouts.read: "60s"
 http.timeouts.write: "60s"
 rpc.batch.concurrency: 2
+rpc.batch.enabled: true
 rpc.batch.limit: 20
 ws: true
 

--- a/turbo/cli/flags_xlayer.go
+++ b/turbo/cli/flags_xlayer.go
@@ -27,6 +27,7 @@ func ApplyFlagsForEthXLayerConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 }
 
 func ApplyFlagsForNodeXLayerConfig(ctx *cli.Context, cfg *nodecfg.Config) {
+	cfg.Http.BatchEnabled = ctx.Bool(utils.RpcBatchEnabled.Name)
 	cfg.Http.HttpApiKeys = ctx.String(utils.HTTPApiKeysFlag.Name)
 	cfg.Http.MethodRateLimit = ctx.String(utils.MethodRateLimitFlag.Name)
 }

--- a/zk/apollo/jsonrpc.go
+++ b/zk/apollo/jsonrpc.go
@@ -72,6 +72,9 @@ func loadNodeJsonRPCConfig(ctx *cli.Context, nodeCfg *nodecfg.Config) {
 	if ctx.IsSet(utils.RpcBatchConcurrencyFlag.Name) {
 		nodeCfg.Http.RpcBatchConcurrency = ctx.Uint(utils.RpcBatchConcurrencyFlag.Name)
 	}
+	if ctx.IsSet(utils.RpcBatchEnabled.Name) {
+		nodeCfg.Http.BatchEnabled = ctx.Bool(utils.RpcBatchEnabled.Name)
+	}
 	if ctx.IsSet(utils.RpcBatchLimit.Name) {
 		nodeCfg.Http.BatchLimit = ctx.Int(utils.RpcBatchLimit.Name)
 	}


### PR DESCRIPTION
## Summary

- Support batch request enabled flag (rpc.batch.enabled)
- Implement batch request enabled flag into apollo 
- Implement existing batch limit flag into apollo