### PR TITLE
Clean up gaspricer

### DIFF
--- a/cmd/utils/flags_xlayer.go
+++ b/cmd/utils/flags_xlayer.go
@@ -148,11 +148,6 @@ var (
 		Usage: "raw gas price usdt",
 		Value: 0,
 	}
-	GpoEnableFollowerAdjustByL2L1PriceFlag = cli.BoolFlag{
-		Name:  "gpo.enable-follower-adjust",
-		Usage: "enable dynamic adjust the factor through the L1 and L2 coins price in follower strategy",
-		Value: true,
-	}
 	GpoCongestionThresholdFlag = cli.IntFlag{
 		Name:  "gpo.congestion-threshold",
 		Usage: "Used to determine whether pending tx has reached the threshold for congestion",
@@ -234,9 +229,6 @@ func setGPOXLayer(ctx *cli.Context, cfg *gaspricecfg.Config) {
 	}
 	if ctx.IsSet(GpoGasPriceUsdtFlag.Name) {
 		cfg.XLayer.GasPriceUsdt = ctx.Float64(GpoGasPriceUsdtFlag.Name)
-	}
-	if ctx.IsSet(GpoEnableFollowerAdjustByL2L1PriceFlag.Name) {
-		cfg.XLayer.EnableFollowerAdjustByL2L1Price = ctx.Bool(GpoEnableFollowerAdjustByL2L1PriceFlag.Name)
 	}
 	if ctx.IsSet(GpoCongestionThresholdFlag.Name) {
 		cfg.XLayer.CongestionThreshold = ctx.Int(GpoCongestionThresholdFlag.Name)

--- a/cmd/utils/flags_xlayer.go
+++ b/cmd/utils/flags_xlayer.go
@@ -236,7 +236,7 @@ func setGPOXLayer(ctx *cli.Context, cfg *gaspricecfg.Config) {
 
 	// Default price check
 	if cfg.Default == nil || cfg.Default.Int64() <= 0 {
-		cfg.Default = gaspricecfg.DefaultXLayerPrice
+		cfg.Default = new(big.Int).Set(gaspricecfg.DefaultXLayerPrice)
 	}
 }
 

--- a/eth/gasprice/default_xlayer.go
+++ b/eth/gasprice/default_xlayer.go
@@ -16,16 +16,15 @@ type DefaultGasPricer struct {
 
 // newDefaultGasPriceSuggester init default gas price suggester.
 func newDefaultGasPriceSuggester(ctx context.Context, cfg gaspricecfg.Config) *DefaultGasPricer {
-	gpe := &DefaultGasPricer{
-		ctx: ctx,
-		cfg: cfg,
+	return &DefaultGasPricer{
+		ctx:       ctx,
+		cfg:       cfg,
+		lastRawGP: new(big.Int).Set(cfg.Default),
 	}
-	return gpe
 }
 
 // UpdateGasPriceAvg not needed for default strategy.
 func (d *DefaultGasPricer) UpdateGasPriceAvg(l1gp *big.Int) {
-	d.lastRawGP = d.cfg.Default
 }
 
 func (d *DefaultGasPricer) GetLastRawGP() *big.Int {

--- a/eth/gasprice/default_xlayer.go
+++ b/eth/gasprice/default_xlayer.go
@@ -25,6 +25,7 @@ func newDefaultGasPriceSuggester(ctx context.Context, cfg gaspricecfg.Config) *D
 
 // UpdateGasPriceAvg not needed for default strategy.
 func (d *DefaultGasPricer) UpdateGasPriceAvg(l1gp *big.Int) {
+	d.lastRawGP = new(big.Int).Set(d.cfg.Default)
 }
 
 func (d *DefaultGasPricer) GetLastRawGP() *big.Int {

--- a/eth/gasprice/fixed_xlayer.go
+++ b/eth/gasprice/fixed_xlayer.go
@@ -35,7 +35,7 @@ func (f *FixedGasPrice) UpdateGasPriceAvg(l1GasPrice *big.Int) {
 
 	// Get L2 coin price
 	l2CoinPrice := f.ratePrc.GetL2CoinPrice()
-	if l2CoinPrice < MinUSDTPrice {
+	if l2CoinPrice < minUSDTPrice {
 		log.Warn("update gas price average failed, the L2 native coin price is too small")
 		return
 	}

--- a/eth/gasprice/fixed_xlayer.go
+++ b/eth/gasprice/fixed_xlayer.go
@@ -21,9 +21,10 @@ type FixedGasPrice struct {
 // newFixedGasPriceSuggester inits l2 fixed price suggester.
 func newFixedGasPriceSuggester(ctx context.Context, cfg gaspricecfg.Config) *FixedGasPrice {
 	gps := &FixedGasPrice{
-		cfg:     cfg,
-		ctx:     ctx,
-		ratePrc: newKafkaProcessor(cfg.XLayer, ctx),
+		cfg:       cfg,
+		ctx:       ctx,
+		lastRawGP: new(big.Int).Set(cfg.Default),
+		ratePrc:   newKafkaProcessor(cfg.XLayer, ctx),
 	}
 	return gps
 }

--- a/eth/gasprice/follower_xlayer.go
+++ b/eth/gasprice/follower_xlayer.go
@@ -23,7 +23,7 @@ func newFollowerGasPriceSuggester(ctx context.Context, cfg gaspricecfg.Config) *
 	return &FollowerGasPrice{
 		cfg:       cfg,
 		ctx:       ctx,
-		lastRawGP: new(big.Int).SetUint64(1),
+		lastRawGP: new(big.Int).Set(cfg.Default),
 		kafkaPrc:  newKafkaProcessor(cfg.XLayer, ctx),
 	}
 }

--- a/eth/gasprice/follower_xlayer.go
+++ b/eth/gasprice/follower_xlayer.go
@@ -10,12 +10,6 @@ import (
 	"github.com/ledgerwatch/log/v3"
 )
 
-const (
-	// OKBWei OKB wei
-	OKBWei       = 1e18
-	minCoinPrice = 1e-18
-)
-
 // FollowerGasPrice struct.
 type FollowerGasPrice struct {
 	cfg       gaspricecfg.Config
@@ -26,19 +20,15 @@ type FollowerGasPrice struct {
 
 // newFollowerGasPriceSuggester inits l2 follower gas price suggester which is based on the l1 gas price.
 func newFollowerGasPriceSuggester(ctx context.Context, cfg gaspricecfg.Config) *FollowerGasPrice {
-	gps := &FollowerGasPrice{
+	return &FollowerGasPrice{
 		cfg:       cfg,
 		ctx:       ctx,
 		lastRawGP: new(big.Int).SetUint64(1),
+		kafkaPrc:  newKafkaProcessor(cfg.XLayer, ctx),
 	}
-	if cfg.XLayer.EnableFollowerAdjustByL2L1Price {
-		gps.kafkaPrc = newKafkaProcessor(cfg.XLayer, ctx)
-	}
-
-	return gps
 }
 
-// UpdateGasPriceAvg updates the gas price.
+// UpdateGasPriceAvg updates the gas price in wei.
 func (f *FollowerGasPrice) UpdateGasPriceAvg(l1GasPrice *big.Int) {
 	//todo: apollo
 
@@ -47,22 +37,26 @@ func (f *FollowerGasPrice) UpdateGasPriceAvg(l1GasPrice *big.Int) {
 		return
 	}
 
-	// Apply factor to calculate l2 gasPrice
+	// Apply gasPrice factor
 	factor := big.NewFloat(0).SetFloat64(f.cfg.XLayer.Factor)
 	res := new(big.Float).Mul(factor, big.NewFloat(0).SetInt(l1GasPrice))
 
-	// convert the eth gas price to okb gas price
-	if f.cfg.XLayer.EnableFollowerAdjustByL2L1Price {
-		l1CoinPrice, l2CoinPrice := f.kafkaPrc.GetL1L2CoinPrice()
-		if l1CoinPrice < minCoinPrice || l2CoinPrice < minCoinPrice {
-			log.Warn("the L1 or L2 native coin price too small...")
-			return
-		}
-		res = new(big.Float).Mul(big.NewFloat(0).SetFloat64(l1CoinPrice/l2CoinPrice), res)
-		log.Debug(fmt.Sprintf("L2 pre gas price value: %s. L1 coin price: %f. L2 coin price: %f", res.String(), l1CoinPrice, l2CoinPrice))
+	// Get L1 and L2 coin prices
+	l1CoinPrice, l2CoinPrice := f.kafkaPrc.GetL1L2CoinPrice()
+	if l1CoinPrice < MinUSDTPrice {
+		log.Warn("update gas price average failed, the L1 native coin price is too small")
+		return
+	}
+	if l2CoinPrice < MinUSDTPrice {
+		log.Warn("update gas price average failed, the L2 native coin price is too small")
+		return
 	}
 
-	// Cache l2 gasPrice calculated
+	// Convert L1 gasPrice in Eth to L2 gasPrice in OKB
+	res = new(big.Float).Mul(big.NewFloat(0).SetFloat64(l1CoinPrice/l2CoinPrice), res)
+	log.Debug(fmt.Sprintf("L2 pre gas price value: %s. L1 coin price: %f. L2 coin price: %f", res.String(), l1CoinPrice, l2CoinPrice))
+
+	// Check for min/max L2 gasPrice
 	result := new(big.Int)
 	res.Int(result)
 	minGasPrice := new(big.Int).Set(f.cfg.Default)
@@ -90,6 +84,7 @@ func (f *FollowerGasPrice) UpdateGasPriceAvg(l1GasPrice *big.Int) {
 		truncateValue = result
 	}
 
+	// Cache L2 gasPrice calculated
 	if truncateValue != nil {
 		log.Info(fmt.Sprintf("Set l2 raw gas price: %d", truncateValue.Uint64()))
 		f.lastRawGP = truncateValue

--- a/eth/gasprice/follower_xlayer.go
+++ b/eth/gasprice/follower_xlayer.go
@@ -43,11 +43,11 @@ func (f *FollowerGasPrice) UpdateGasPriceAvg(l1GasPrice *big.Int) {
 
 	// Get L1 and L2 coin prices
 	l1CoinPrice, l2CoinPrice := f.kafkaPrc.GetL1L2CoinPrice()
-	if l1CoinPrice < MinUSDTPrice {
+	if l1CoinPrice < minUSDTPrice {
 		log.Warn("update gas price average failed, the L1 native coin price is too small")
 		return
 	}
-	if l2CoinPrice < MinUSDTPrice {
+	if l2CoinPrice < minUSDTPrice {
 		log.Warn("update gas price average failed, the L2 native coin price is too small")
 		return
 	}

--- a/eth/gasprice/follower_xlayer_test.go
+++ b/eth/gasprice/follower_xlayer_test.go
@@ -7,9 +7,10 @@ import (
 	"time"
 
 	. "github.com/ledgerwatch/erigon/eth/gasprice/gaspricecfg"
+	"github.com/stretchr/testify/require"
 )
 
-func TestUpdateGasPriceFollower(t *testing.T) {
+func TestFollowerUpdateGasPrice(t *testing.T) {
 	ctx := context.Background()
 	var d time.Duration = 1000000000
 
@@ -17,18 +18,29 @@ func TestUpdateGasPriceFollower(t *testing.T) {
 		Default:  new(big.Int).SetUint64(1000000000),
 		MaxPrice: new(big.Int).SetUint64(0),
 		XLayer: XLayerConfig{
-			Type:         FollowerType,
-			UpdatePeriod: d,
-			Factor:       0.5,
+			Type:               FollowerType,
+			UpdatePeriod:       d,
+			KafkaURL:           "127.0.0.1:9092",
+			Topic:              "middle_coinPrice_push",
+			Factor:             0.5,
+			DefaultL1CoinPrice: 1,
+			DefaultL2CoinPrice: 1,
 		},
 	}
 	l1GasPrice := big.NewInt(10000000000)
 	f := newFollowerGasPriceSuggester(ctx, cfg)
 
 	f.UpdateGasPriceAvg(l1GasPrice)
+
+	// Calculate correct GP
+	// Correct GP: L1/L2 ratio = 1, l1GasPrice * 1 * Factor
+	correctGpVal := big.NewFloat(0).Mul(big.NewFloat(0).SetFloat64(cfg.XLayer.Factor), big.NewFloat(0).SetInt(l1GasPrice))
+	correctGp := new(big.Int)
+	correctGpVal.Int(correctGp)
+	require.Equal(t, correctGp.Uint64(), f.GetLastRawGP().Uint64())
 }
 
-func TestLimitMasGasPrice(t *testing.T) {
+func TestMaxGasPriceLimit(t *testing.T) {
 	ctx := context.Background()
 	var d time.Duration = 1000000000
 
@@ -36,12 +48,17 @@ func TestLimitMasGasPrice(t *testing.T) {
 		Default:  new(big.Int).SetUint64(100000000),
 		MaxPrice: new(big.Int).SetUint64(50000000),
 		XLayer: XLayerConfig{
-			Type:         FollowerType,
-			UpdatePeriod: d,
-			Factor:       0.5,
+			Type:               FollowerType,
+			UpdatePeriod:       d,
+			KafkaURL:           "127.0.0.1:9092",
+			Topic:              "middle_coinPrice_push",
+			Factor:             0.5,
+			DefaultL1CoinPrice: 1,
+			DefaultL2CoinPrice: 1,
 		},
 	}
 	l1GasPrice := big.NewInt(1000000000)
 	f := newFollowerGasPriceSuggester(ctx, cfg)
 	f.UpdateGasPriceAvg(l1GasPrice)
+	require.Equal(t, f.GetLastRawGP().Uint64(), cfg.MaxPrice.Uint64())
 }

--- a/eth/gasprice/gasprice_xlayer.go
+++ b/eth/gasprice/gasprice_xlayer.go
@@ -1,0 +1,17 @@
+package gasprice
+
+import "math/big"
+
+const (
+	WeiToEth     = 1e18
+	MinUSDTPrice = 1e-18
+)
+
+func OKBToOKBWei(eth *big.Float) *big.Int {
+	// Convert eth to wei
+	wte := big.NewFloat(0).SetFloat64(WeiToEth)
+	val := eth.Mul(eth, wte)
+	wei := new(big.Int)
+	val.Int(wei)
+	return wei
+}

--- a/eth/gasprice/gasprice_xlayer.go
+++ b/eth/gasprice/gasprice_xlayer.go
@@ -3,13 +3,13 @@ package gasprice
 import "math/big"
 
 const (
-	WeiToEth     = 1e18
-	MinUSDTPrice = 1e-18
+	weiToEth     = 1e18
+	minUSDTPrice = 1e-18
 )
 
 func OKBToOKBWei(eth *big.Float) *big.Int {
 	// Convert eth to wei
-	wte := big.NewFloat(0).SetFloat64(WeiToEth)
+	wte := big.NewFloat(0).SetFloat64(weiToEth)
 	val := eth.Mul(eth, wte)
 	wei := new(big.Int)
 	val.Int(wei)

--- a/eth/gasprice/gaspricecfg/config_xlayer.go
+++ b/eth/gasprice/gaspricecfg/config_xlayer.go
@@ -26,25 +26,21 @@ type XLayerConfig struct {
 	DefaultL2CoinPrice float64 `toml:",omitempty"`
 	GasPriceUsdt       float64 `toml:",omitempty"`
 
-	// EnableFollowerAdjustByL2L1Price is dynamic adjust the factor through the L1 and L2 coins price in follower strategy
-	EnableFollowerAdjustByL2L1Price bool `toml:",omitempty"`
-
 	CongestionThreshold int `toml:",omitempty"`
 }
 
 var (
 	DefaultXLayerConfig = XLayerConfig{
-		Type:                            DefaultType,
-		UpdatePeriod:                    10 * time.Second,
-		Factor:                          0.01,
-		KafkaURL:                        "0.0.0.0",
-		Topic:                           "xlayer",
-		GroupID:                         "xlayer",
-		DefaultL1CoinPrice:              2000,
-		DefaultL2CoinPrice:              50,
-		GasPriceUsdt:                    0.000000476190476,
-		EnableFollowerAdjustByL2L1Price: true,
-		CongestionThreshold:             0,
+		Type:                DefaultType,
+		UpdatePeriod:        10 * time.Second,
+		Factor:              0.01,
+		KafkaURL:            "0.0.0.0",
+		Topic:               "xlayer",
+		GroupID:             "xlayer",
+		DefaultL1CoinPrice:  2000,
+		DefaultL2CoinPrice:  50,
+		GasPriceUsdt:        0.000000476190476,
+		CongestionThreshold: 0,
 	}
 	DefaultXLayerPrice = big.NewInt(1 * params.GWei)
 )

--- a/eth/gasprice/kafka_proc_xlayer.go
+++ b/eth/gasprice/kafka_proc_xlayer.go
@@ -201,13 +201,6 @@ func (rp *KafkaProcessor) updateL2CoinPrice(price float64) {
 	rp.l2Price = price
 }
 
-// GetL2CoinPrice get L2 coin price
-func (rp *KafkaProcessor) GetL2CoinPrice() float64 {
-	rp.rwLock.RLock()
-	defer rp.rwLock.RUnlock()
-	return rp.l2Price
-}
-
 func (rp *KafkaProcessor) updateL1L2CoinPrice(prices map[int]float64) {
 	if len(prices) == 0 {
 		return
@@ -229,13 +222,6 @@ func (rp *KafkaProcessor) updateL1L2CoinPrice(prices map[int]float64) {
 		rp.tmpPrices.l2Update = false
 		return
 	}
-}
-
-// GetL1L2CoinPrice get l1, L2 coin price
-func (rp *KafkaProcessor) GetL1L2CoinPrice() (float64, float64) {
-	rp.rwLock.RLock()
-	defer rp.rwLock.RUnlock()
-	return rp.l1Price, rp.l2Price
 }
 
 func (rp *KafkaProcessor) parseCoinPrice(value []byte, coinIds []int) (map[int]float64, error) {
@@ -267,4 +253,18 @@ func (rp *KafkaProcessor) parseCoinPrice(value []byte, coinIds []int) (map[int]f
 		return results, ErrNotFindCoinPrice
 	}
 	return results, nil
+}
+
+// GetL2CoinPrice gets the L2 coin price in USDT
+func (rp *KafkaProcessor) GetL2CoinPrice() float64 {
+	rp.rwLock.RLock()
+	defer rp.rwLock.RUnlock()
+	return rp.l2Price
+}
+
+// GetL1L2CoinPrice gets both l1 and L2 coin prices in USDT
+func (rp *KafkaProcessor) GetL1L2CoinPrice() (float64, float64) {
+	rp.rwLock.RLock()
+	defer rp.rwLock.RUnlock()
+	return rp.l1Price, rp.l2Price
 }

--- a/test/config/test.erigon.seq.config.yaml
+++ b/test/config/test.erigon.seq.config.yaml
@@ -81,7 +81,6 @@ gpo.group-id: "web3"
 gpo.default-l1-coin-price: 2000
 gpo.default-l2-coin-price: 50
 gpo.gas-price-usdt: 0.000000476190476
-gpo.enable-follower-adjust: true
 gpo.congestion-threshold: 0
 
 networkid: 195

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -243,7 +243,6 @@ var DefaultFlags = []cli.Flag{
 	&utils.GpoDefaultL1CoinPriceFlag,
 	&utils.GpoDefaultL2CoinPriceFlag,
 	&utils.GpoGasPriceUsdtFlag,
-	&utils.GpoEnableFollowerAdjustByL2L1PriceFlag,
 	&utils.GpoCongestionThresholdFlag,
 	&utils.ApolloEnableFlag,
 	&utils.ApolloIPAddr,


### PR DESCRIPTION
## Summary

- Prevents node panic on startup by explicitly setting lastRawGP on gaspricer with default gasprice on gaspricer initialization
- Remove legacy gpo.enable-follower-adjust config, follower to always use both L1 and L2 coin prices for gas price calculations
- Add utility wei amount conversion method for fixed gaspricer
- Add clearer documentation and naming for readability
- Fix gaspricer follower test