### PR TITLE
seq: minGasPrice to return default gas price

### DIFF
--- a/turbo/jsonrpc/eth_system_xlayer.go
+++ b/turbo/jsonrpc/eth_system_xlayer.go
@@ -177,8 +177,8 @@ func getAvgPrice(low *big.Int, high *big.Int) *big.Int {
 func (api *APIImpl) MinGasPrice(ctx context.Context) (*hexutil.Big, error) {
 	var minGP *big.Int
 	if sequencer.IsSequencer() {
-		minGP = api.gasCache.GetMinRawGPMoreRecent()
-		return (*hexutil.Big)(minGP), nil
+		configMinGP := new(big.Int).SetUint64(api.DefaultGasPrice)
+		return (*hexutil.Big)(configMinGP), nil
 	}
 
 	minGP, err := api.getGPFromTrustedNode("eth_minGasPrice")


### PR DESCRIPTION
Return gas price set inside sequencer config `zkevm.default-gas-price` instead of pulling from cache. More context, the gas price suggester uses this same config to set the minimum suggested gas price. RPCs (non-sequencer) will still call trusted nodes to be informed of min gas price.

Tested using test/e2e/smoke_test.go `TestMinGasPrice`.