### PR TITLE
Faster build Docker image, ignore large folders

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,5 @@ cmd/prometheus
 vendor
 
 cache.db
+test
+.git


### PR DESCRIPTION
test/* may contains local docker compose test data. 
.git is 400MB+