### PR TITLE
Remove fail tx metric

### DIFF
--- a/zk/metrics/metrics_xlayer.go
+++ b/zk/metrics/metrics_xlayer.go
@@ -103,13 +103,6 @@ var SeqTxCount = prometheus.NewCounter(
 	},
 )
 
-var SeqFailTxCount = prometheus.NewCounter(
-	prometheus.CounterOpts{
-		Name: SeqFailTxCountName,
-		Help: "[SEQUENCER] total fail tx count",
-	},
-)
-
 var SeqBlockGasUsed = prometheus.NewGauge(
 	prometheus.GaugeOpts{
 		Name: SeqBlockGasUsedName,

--- a/zk/metrics/metrics_xlayer.go
+++ b/zk/metrics/metrics_xlayer.go
@@ -22,7 +22,6 @@ var (
 	PoolTxCountName      = SeqPrefix + "pool_tx_count"
 	SeqTxDurationName    = SeqPrefix + "tx_duration"
 	SeqTxCountName       = SeqPrefix + "tx_count"
-	SeqFailTxCountName   = SeqPrefix + "fail_tx_count"
 	SeqBlockGasUsedName  = SeqPrefix + "block_gas_used"
 
 	RpcPrefix              = "rpc_"
@@ -35,7 +34,6 @@ func Init() {
 	prometheus.MustRegister(PoolTxCount)
 	prometheus.MustRegister(SeqTxDuration)
 	prometheus.MustRegister(SeqTxCount)
-	prometheus.MustRegister(SeqFailTxCount)
 	prometheus.MustRegister(SeqBlockGasUsed)
 	prometheus.MustRegister(RpcDynamicGasPrice)
 	prometheus.MustRegister(RpcInnerTxExecuted)

--- a/zk/metrics/statistics_xlayer.go
+++ b/zk/metrics/statistics_xlayer.go
@@ -14,7 +14,6 @@ const (
 	GetTxPauseTiming              logTag = "GetTxPauseTiming"
 	BatchCloseReason              logTag = "BatchCloseReason"
 	ReprocessingTxCounter         logTag = "ReProcessingTxCounter"
-	FailTxCounter                 logTag = "FailTxCounter"
 	FailTxResourceOverCounter     logTag = "FailTxResourceOverCounter"
 	BatchGas                      logTag = "BatchGas"
 	ProcessingTxTiming            logTag = "ProcessingTxTiming"

--- a/zk/metrics/statisticsimpl_xlayer.go
+++ b/zk/metrics/statisticsimpl_xlayer.go
@@ -58,7 +58,6 @@ func (l *statisticsInstance) Summary() string {
 	getTxPauseTiming := "GetTxPauseTiming<" + strconv.Itoa(int(l.statistics[GetTxPauseTiming])) + "ms>, "
 	reprocessTx := "ReprocessTx<" + strconv.Itoa(int(l.statistics[ReprocessingTxCounter])) + ">, "
 	resourceOverTx := "ResourceOverTx<" + strconv.Itoa(int(l.statistics[FailTxResourceOverCounter])) + ">, "
-	failTx := "FailTx<" + strconv.Itoa(int(l.statistics[FailTxCounter])) + ">, "
 	invalidTx := "InvalidTx<" + strconv.Itoa(int(l.statistics[ProcessingInvalidTxCounter])) + ">, "
 	processTxTiming := "ProcessTx<" + strconv.Itoa(int(l.statistics[ProcessingTxTiming])) + "ms>, "
 	batchCommitDBTiming := "BatchCommitDBTiming<" + strconv.Itoa(int(l.statistics[BatchCommitDBTiming])) + "ms>, "
@@ -68,7 +67,7 @@ func (l *statisticsInstance) Summary() string {
 	batchCloseReason := "BatchCloseReason<" + l.tags[BatchCloseReason] + ">"
 
 	result := batch + totalDuration + gasUsed + blockCount + tx + getTx + getTxPause + getTxPauseTiming +
-		reprocessTx + resourceOverTx + failTx + invalidTx + processTxTiming + pbStateTiming +
+		reprocessTx + resourceOverTx + invalidTx + processTxTiming + pbStateTiming +
 		zkIncIntermediateHashesTiming + finaliseBlockWriteTiming + batchCommitDBTiming +
 		batchCloseReason
 	log.Info(result)

--- a/zk/metrics/statisticsimpl_xlayer_test.go
+++ b/zk/metrics/statisticsimpl_xlayer_test.go
@@ -26,7 +26,6 @@ func TestStatisticsInstanceSummary(t *testing.T) {
 				GetTxPauseTiming:              time.Second.Milliseconds() * 30,
 				ReprocessingTxCounter:         3,
 				FailTxResourceOverCounter:     1,
-				FailTxCounter:                 1,
 				ProcessingInvalidTxCounter:    2,
 				ProcessingTxTiming:            time.Second.Milliseconds() * 30,
 				BatchCommitDBTiming:           time.Second.Milliseconds() * 10,

--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -426,10 +426,6 @@ func sequencingBatchStep(
 					backupDataSizeChecker := *blockDataSizeChecker
 					receipt, execResult, anyOverflow, err := attemptAddTransaction(cfg, sdb, ibs, batchCounters, &blockContext, header, transaction, effectiveGas, batchState.isL1Recovery(), batchState.forkId, l1TreeUpdateIndex, &backupDataSizeChecker)
 					if err != nil {
-						// For X Layer
-						metrics.GetLogStatistics().CumulativeCounting(metrics.FailTxCounter)
-						metrics.SeqFailTxCount.Inc()
-
 						if batchState.isLimboRecovery() {
 							panic("limbo transaction has already been executed once so they must not fail while re-executing")
 						}


### PR DESCRIPTION
Why remove this metric:
1. fail tx counter is not accurate, since overflow tx will be counted as failed tx and in the next block it will get success
2. We don't need to count how many fail tx in sequencer. fail tx is rejected in RPC?

Example: loadtest 5000 Web3 tx
Result metric: 5000 success tx, 5000 failed tx. In fact, all 5000 tx are successful
