### PR TITLE
Replace fail tx count with zkCounter overflow block metric

### DIFF
--- a/cmd/prometheus/dashboards/xlayer.json
+++ b/cmd/prometheus/dashboards/xlayer.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 7,
+  "id": 9,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -344,167 +344,6 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 0,
-        "y": 17
-      },
-      "id": 198,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "10.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "exemplar": false,
-          "expr": "sequencer_tx_count{instance=\"xlayer-seq:9095\"}",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Total Transactions",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 0
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 4,
-        "y": 17
-      },
-      "id": 199,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "10.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "sequencer_fail_tx_count{instance=\"xlayer-seq:9095\"}",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Failed Transactions",
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "datasource": "${DS_PROMETHEUS}",
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 20
-      },
-      "id": 183,
-      "panels": [],
-      "targets": [
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "refId": "A"
-        }
-      ],
-      "title": "RPC",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
@@ -565,8 +404,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 21
+        "x": 12,
+        "y": 9
       },
       "id": 185,
       "options": {
@@ -613,6 +452,147 @@
       ],
       "title": "RPS",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 17
+      },
+      "id": 198,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sequencer_tx_count{instance=\"xlayer-seq:9095\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Successful Transactions",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 6,
+        "y": 17
+      },
+      "id": 199,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sequencer_zk_overflow_block_count{instance=\"xlayer-seq:9095\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "ZK Counter Overflow Blocks",
+      "type": "stat"
     },
     {
       "datasource": {
@@ -679,7 +659,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 21
+        "y": 17
       },
       "id": 187,
       "options": {
@@ -712,6 +692,26 @@
       ],
       "title": "RPC Latency",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "id": 183,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "refId": "A"
+        }
+      ],
+      "title": "RPC",
+      "type": "row"
     },
     {
       "datasource": {
@@ -778,7 +778,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 29
+        "y": 26
       },
       "id": 204,
       "options": {
@@ -879,7 +879,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 29
+        "y": 26
       },
       "id": 205,
       "options": {
@@ -924,7 +924,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 37
+        "y": 34
       },
       "id": 4,
       "panels": [],
@@ -1004,7 +1004,7 @@
         "h": 11,
         "w": 5,
         "x": 0,
-        "y": 38
+        "y": 35
       },
       "id": 110,
       "options": {
@@ -1117,7 +1117,7 @@
         "h": 11,
         "w": 5,
         "x": 5,
-        "y": 38
+        "y": 35
       },
       "id": 116,
       "options": {
@@ -1245,7 +1245,7 @@
         "h": 11,
         "w": 7,
         "x": 10,
-        "y": 38
+        "y": 35
       },
       "id": 106,
       "options": {
@@ -1349,7 +1349,7 @@
         "h": 11,
         "w": 7,
         "x": 17,
-        "y": 38
+        "y": 35
       },
       "id": 154,
       "options": {
@@ -1520,7 +1520,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1536,7 +1537,7 @@
         "h": 19,
         "w": 10,
         "x": 0,
-        "y": 49
+        "y": 46
       },
       "id": 196,
       "options": {
@@ -1617,7 +1618,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1633,7 +1635,7 @@
         "h": 11,
         "w": 7,
         "x": 10,
-        "y": 49
+        "y": 46
       },
       "id": 77,
       "options": {
@@ -1742,7 +1744,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1758,7 +1761,7 @@
         "h": 11,
         "w": 7,
         "x": 17,
-        "y": 49
+        "y": 46
       },
       "id": 96,
       "options": {
@@ -1872,7 +1875,7 @@
         "h": 8,
         "w": 7,
         "x": 10,
-        "y": 60
+        "y": 57
       },
       "id": 85,
       "options": {
@@ -1985,7 +1988,7 @@
         "h": 8,
         "w": 7,
         "x": 17,
-        "y": 60
+        "y": 57
       },
       "id": 159,
       "options": {
@@ -2217,7 +2220,7 @@
     ]
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {
@@ -2247,6 +2250,6 @@
   "timezone": "",
   "title": "XLayer",
   "uid": "xlayer",
-  "version": 4,
+  "version": 11,
   "weekStart": ""
 }

--- a/test/config/test.erigon.seq.config.yaml
+++ b/test/config/test.erigon.seq.config.yaml
@@ -93,3 +93,6 @@ networkid: 195
 pprof: true
 pprof.port: 6060
 pprof.addr: 0.0.0.0
+
+# close a block/batch immediately after the 1st zkCounter overflow TX
+zkevm.seal-batch-immediately-on-overflow: true

--- a/zk/metrics/metrics_xlayer.go
+++ b/zk/metrics/metrics_xlayer.go
@@ -22,7 +22,7 @@ var (
 	PoolTxCountName      = SeqPrefix + "pool_tx_count"
 	SeqTxDurationName    = SeqPrefix + "tx_duration"
 	SeqTxCountName       = SeqPrefix + "tx_count"
-	SeqFailTxCountName   = SeqPrefix + "fail_tx_count"
+	SeqZKOverflowBlockCounterName   = SeqPrefix + "zk_overflow_block_count"
 	SeqBlockGasUsedName  = SeqPrefix + "block_gas_used"
 
 	RpcPrefix              = "rpc_"
@@ -35,7 +35,7 @@ func Init() {
 	prometheus.MustRegister(PoolTxCount)
 	prometheus.MustRegister(SeqTxDuration)
 	prometheus.MustRegister(SeqTxCount)
-	prometheus.MustRegister(SeqFailTxCount)
+	prometheus.MustRegister(SeqZKOverflowBlockCounter)
 	prometheus.MustRegister(SeqBlockGasUsed)
 	prometheus.MustRegister(RpcDynamicGasPrice)
 	prometheus.MustRegister(RpcInnerTxExecuted)
@@ -103,10 +103,10 @@ var SeqTxCount = prometheus.NewCounter(
 	},
 )
 
-var SeqFailTxCount = prometheus.NewCounter(
+var SeqZKOverflowBlockCounter = prometheus.NewCounter(
 	prometheus.CounterOpts{
-		Name: SeqFailTxCountName,
-		Help: "[SEQUENCER] total fail tx count",
+		Name: SeqZKOverflowBlockCounterName,
+		Help: "[SEQUENCER] zkCounter overflow block count",
 	},
 )
 

--- a/zk/metrics/statistics_xlayer.go
+++ b/zk/metrics/statistics_xlayer.go
@@ -14,7 +14,7 @@ const (
 	GetTxPauseTiming              logTag = "GetTxPauseTiming"
 	BatchCloseReason              logTag = "BatchCloseReason"
 	ReprocessingTxCounter         logTag = "ReProcessingTxCounter"
-	FailTxCounter                 logTag = "FailTxCounter"
+	ZKOverflowBlockCounter        logTag = "ZKOverflowBlockCounter"
 	FailTxResourceOverCounter     logTag = "FailTxResourceOverCounter"
 	BatchGas                      logTag = "BatchGas"
 	ProcessingTxTiming            logTag = "ProcessingTxTiming"

--- a/zk/metrics/statisticsimpl_xlayer.go
+++ b/zk/metrics/statisticsimpl_xlayer.go
@@ -58,7 +58,7 @@ func (l *statisticsInstance) Summary() string {
 	getTxPauseTiming := "GetTxPauseTiming<" + strconv.Itoa(int(l.statistics[GetTxPauseTiming])) + "ms>, "
 	reprocessTx := "ReprocessTx<" + strconv.Itoa(int(l.statistics[ReprocessingTxCounter])) + ">, "
 	resourceOverTx := "ResourceOverTx<" + strconv.Itoa(int(l.statistics[FailTxResourceOverCounter])) + ">, "
-	failTx := "FailTx<" + strconv.Itoa(int(l.statistics[FailTxCounter])) + ">, "
+	zkOverflowBlock := "ZKOverflowBlock<" + strconv.Itoa(int(l.statistics[ZKOverflowBlockCounter])) + ">, "
 	invalidTx := "InvalidTx<" + strconv.Itoa(int(l.statistics[ProcessingInvalidTxCounter])) + ">, "
 	processTxTiming := "ProcessTx<" + strconv.Itoa(int(l.statistics[ProcessingTxTiming])) + "ms>, "
 	batchCommitDBTiming := "BatchCommitDBTiming<" + strconv.Itoa(int(l.statistics[BatchCommitDBTiming])) + "ms>, "
@@ -68,7 +68,7 @@ func (l *statisticsInstance) Summary() string {
 	batchCloseReason := "BatchCloseReason<" + l.tags[BatchCloseReason] + ">"
 
 	result := batch + totalDuration + gasUsed + blockCount + tx + getTx + getTxPause + getTxPauseTiming +
-		reprocessTx + resourceOverTx + failTx + invalidTx + processTxTiming + pbStateTiming +
+		reprocessTx + resourceOverTx + zkOverflowBlock + invalidTx + processTxTiming + pbStateTiming +
 		zkIncIntermediateHashesTiming + finaliseBlockWriteTiming + batchCommitDBTiming +
 		batchCloseReason
 	log.Info(result)

--- a/zk/metrics/statisticsimpl_xlayer_test.go
+++ b/zk/metrics/statisticsimpl_xlayer_test.go
@@ -26,7 +26,7 @@ func TestStatisticsInstanceSummary(t *testing.T) {
 				GetTxPauseTiming:              time.Second.Milliseconds() * 30,
 				ReprocessingTxCounter:         3,
 				FailTxResourceOverCounter:     1,
-				FailTxCounter:                 1,
+				ZKOverflowBlockCounter:                 1,
 				ProcessingInvalidTxCounter:    2,
 				ProcessingTxTiming:            time.Second.Milliseconds() * 30,
 				BatchCommitDBTiming:           time.Second.Milliseconds() * 10,

--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -406,9 +406,6 @@ func sequencingBatchStep(
 
 			InnerLoopTransactions:
 				for i, transaction := range batchState.blockState.transactionsForInclusion {
-					// For X Layer
-					metrics.GetLogStatistics().CumulativeCounting(metrics.TxCounter)
-
 					// quick check if we should stop handling transactions
 					select {
 					case <-blockTicker.C:
@@ -642,7 +639,9 @@ func sequencingBatchStep(
 		}
 
 		// For X Layer
+		// Count successful transactions
 		metrics.SeqTxCount.Add(float64(len(batchState.blockState.builtBlockElements.transactions)))
+		metrics.GetLogStatistics().CumulativeValue(metrics.TxCounter, int64(len(batchState.blockState.builtBlockElements.transactions)))
 
 		// add a check to the verifier and also check for responses
 		batchState.onBuiltBlock(blockNumber)

--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -426,10 +426,6 @@ func sequencingBatchStep(
 					backupDataSizeChecker := *blockDataSizeChecker
 					receipt, execResult, anyOverflow, err := attemptAddTransaction(cfg, sdb, ibs, batchCounters, &blockContext, header, transaction, effectiveGas, batchState.isL1Recovery(), batchState.forkId, l1TreeUpdateIndex, &backupDataSizeChecker)
 					if err != nil {
-						// For X Layer
-						metrics.GetLogStatistics().CumulativeCounting(metrics.FailTxCounter)
-						metrics.SeqFailTxCount.Inc()
-
 						if batchState.isLimboRecovery() {
 							panic("limbo transaction has already been executed once so they must not fail while re-executing")
 						}
@@ -506,6 +502,9 @@ func sequencingBatchStep(
 								// was not included in this batch because it overflowed: counter x, counter y
 								log.Info(transactionNotAddedText, "Counters context:", ocs, "overflow transactions", batchState.overflowTransactions)
 								if batchState.reachedOverflowTransactionLimit() || cfg.zk.SealBatchImmediatelyOnOverflow {
+									// For X Layer
+									metrics.GetLogStatistics().CumulativeCounting(metrics.ZKOverflowBlockCounter)
+									metrics.SeqZKOverflowBlockCounter.Inc()
 									log.Info(fmt.Sprintf("[%s] closing batch due to counters", logPrefix), "counters: ", batchState.overflowTransactions, "immediate", cfg.zk.SealBatchImmediatelyOnOverflow)
 									runLoopBlocks = false
 									if len(batchState.blockState.builtBlockElements.transactions) == 0 {


### PR DESCRIPTION
- fail tx counter is not accurate, since overflow tx will be counted as failed tx and in the next block it will get success
- Replace it with zkCounter overflow block, how many blocks are closed because of zkCounter overflow
- The new metric can help us optimize sequencer TPS
- Possbile direction: Predict zkCounter overflow without calling attemptAddTransaction