### PR TITLE
200% local speedup, by setting small yieldsize and seal-batch-immediately-on-overflow

### DIFF
--- a/test/config/test.erigon.seq.config.yaml
+++ b/test/config/test.erigon.seq.config.yaml
@@ -93,3 +93,7 @@ networkid: 195
 pprof: true
 pprof.port: 6060
 pprof.addr: 0.0.0.0
+
+yieldsize: 2
+
+zkevm.seal-batch-immediately-on-overflow: true

--- a/test/config/test.erigon.seq.config.yaml
+++ b/test/config/test.erigon.seq.config.yaml
@@ -96,7 +96,7 @@ pprof.addr: 0.0.0.0
 
 # Small yieldsize for huge OKX Pay Transaction
 # yield # transactions from the transaction pool for processing in each batch
-yieldsize: 2
+yieldsize: 10
 
 # close a block/batch immediately after the 1st zkCounter overflow TX
 zkevm.seal-batch-immediately-on-overflow: true


### PR DESCRIPTION
batch size = 10
MacBook M1 Pro
baseline: 80 UOPS
seal-batch-immediately-on-overflow: 86 UOPS
yieldsize = 2 & seal-batch-immediately-on-overflow: 219 UOPS

Apply existing optimizations, then it's easier to monitor other parts in pprof.