### PR TITLE
Cache Decoded Transaction and Reduce Sleep Time

### DIFF
--- a/test/config/test.erigon.seq.config.yaml
+++ b/test/config/test.erigon.seq.config.yaml
@@ -31,6 +31,7 @@ zkevm.witness-full: false
 zkevm.sequencer-block-seal-time: "3s"
 zkevm.sequencer-batch-seal-time: "10s"
 zkevm.sequencer-batch-sleep-duration: "0s"
+zkevm.sequencer-timeout-on-empty-tx-pool: "50ms"
 
 zkevm.data-stream-host: "localhost"
 zkevm.data-stream-port: 6900

--- a/zk/stages/stage_sequence_execute_utils.go
+++ b/zk/stages/stage_sequence_execute_utils.go
@@ -85,6 +85,9 @@ type SequenceBlockCfg struct {
 	yieldSize      uint16
 
 	infoTreeUpdater *l1infotree.Updater
+
+	txCache     map[common.Hash]*types.Transaction
+	senderCache map[common.Hash]*common.Address
 }
 
 func StageSequenceBlocksCfg(
@@ -141,6 +144,8 @@ func StageSequenceBlocksCfg(
 		legacyVerifier:   legacyVerifier,
 		yieldSize:        yieldSize,
 		infoTreeUpdater:  infoTreeUpdater,
+		txCache:          make(map[common.Hash]*types.Transaction),
+		senderCache:      make(map[common.Hash]*common.Address),
 	}
 }
 

--- a/zk/stages/stage_sequence_execute_utils.go
+++ b/zk/stages/stage_sequence_execute_utils.go
@@ -86,8 +86,7 @@ type SequenceBlockCfg struct {
 
 	infoTreeUpdater *l1infotree.Updater
 
-	txCache     map[common.Hash]*types.Transaction
-	senderCache map[common.Hash]*common.Address
+	txCache map[common.Hash]*types.Transaction
 }
 
 func StageSequenceBlocksCfg(
@@ -145,7 +144,6 @@ func StageSequenceBlocksCfg(
 		yieldSize:        yieldSize,
 		infoTreeUpdater:  infoTreeUpdater,
 		txCache:          make(map[common.Hash]*types.Transaction),
-		senderCache:      make(map[common.Hash]*common.Address),
 	}
 }
 


### PR DESCRIPTION
Opt. 1: Cache Decoded Transaction.
Opt. 2: Reduce Sleep Time by setting zkevm.sequencer-timeout-on-empty-tx-pool.