### PR TITLE
feat: Add pre-run processing

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2324,6 +2324,7 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 	setGPO(ctx, &cfg.GPO)
 
 	setTxPool(ctx, cfg)
+	SetPreRunList(ctx, cfg)
 	cfg.TxPool = ethconfig.DefaultTxPool2Config(cfg)
 	cfg.TxPool.DBDir = nodeConfig.Dirs.TxPool
 	cfg.YieldSize = ctx.Uint64(YieldSizeFlag.Name)

--- a/cmd/utils/flags_xlayer.go
+++ b/cmd/utils/flags_xlayer.go
@@ -391,13 +391,11 @@ func SetApolloPoolXLayer(ctx *cli.Context, fullCfg *ethconfig.Config) {
 	setTxPool(ctx, fullCfg)
 }
 
-// CheckAddressExists is a public wrapper function to internally call checkAddressExists
 func CheckAddressExists(addressMap map[libcommon.Address]struct{}, target libcommon.Address) bool {
 	_, exists := addressMap[target]
 	return exists
 }
 
-// SetPreRunList is a public wrapper function to internally call setPreRunList
 func SetPreRunList(ctx *cli.Context, cfg *ethconfig.Config) {
 	if ctx.IsSet(PreRunAddressList.Name) {
 		addrHexes := libcommon.CliString2Array(ctx.String(PreRunAddressList.Name))

--- a/cmd/utils/flags_xlayer.go
+++ b/cmd/utils/flags_xlayer.go
@@ -391,11 +391,13 @@ func SetApolloPoolXLayer(ctx *cli.Context, fullCfg *ethconfig.Config) {
 	setTxPool(ctx, fullCfg)
 }
 
+// CheckAddressExists check if the address exists in the address map
 func CheckAddressExists(addressMap map[libcommon.Address]struct{}, target libcommon.Address) bool {
 	_, exists := addressMap[target]
 	return exists
 }
 
+// SetPreRunList is set pre run list and cache size, ttl, chan num, task num
 func SetPreRunList(ctx *cli.Context, cfg *ethconfig.Config) {
 	if ctx.IsSet(PreRunAddressList.Name) {
 		addrHexes := libcommon.CliString2Array(ctx.String(PreRunAddressList.Name))

--- a/cmd/utils/flags_xlayer.go
+++ b/cmd/utils/flags_xlayer.go
@@ -204,6 +204,32 @@ var (
 		Usage: "Method rate limit in requests per second, format: {\"method\":[\"method1\",\"method2\"],\"count\":1,\"bucket\":1}, eg. {\"methods\":[\"eth_call\",\"eth_blockNumber\"],\"count\":10,\"bucket\":1}",
 		Value: "",
 	}
+
+	PreRunAddressList = cli.StringFlag{
+		Name:  "zkevm.pre-run-address-list",
+		Usage: "Pre run address list while receiving a transaction",
+		Value: "",
+	}
+	PreRunCacheSize = cli.IntFlag{
+		Name:  "zkevm.pre-run-cache-size",
+		Usage: "Size of pre-run cache",
+		Value: 10000,
+	}
+	PreRunCacheTTL = cli.DurationFlag{
+		Name:  "zkevm.pre-run-cache-ttl",
+		Usage: "pre-run cache entry TTL",
+		Value: time.Hour,
+	}
+	PreRunChanNum = cli.IntFlag{
+		Name:  "zkevm.pre-run-chan-num",
+		Usage: "pre-run chan num",
+		Value: 10000,
+	}
+	PreRunTaskNum = cli.IntFlag{
+		Name:  "zkevm.pre-run-task-num",
+		Usage: "pre-run task num",
+		Value: 8,
+	}
 )
 
 func setGPOXLayer(ctx *cli.Context, cfg *gaspricecfg.Config) {
@@ -337,4 +363,12 @@ func SetApolloGPOXLayer(ctx *cli.Context, cfg *gaspricecfg.Config) {
 // SetApolloPoolXLayer is a public wrapper function to internally call setTxPool
 func SetApolloPoolXLayer(ctx *cli.Context, fullCfg *ethconfig.Config) {
 	setTxPool(ctx, fullCfg)
+}
+
+func CheckAddressExists(addressMap map[libcommon.Address]struct{}, target *libcommon.Address) bool {
+	if target == nil {
+		return false
+	}
+	_, exists := addressMap[*target]
+	return exists
 }

--- a/cmd/utils/flags_xlayer.go
+++ b/cmd/utils/flags_xlayer.go
@@ -365,10 +365,24 @@ func SetApolloPoolXLayer(ctx *cli.Context, fullCfg *ethconfig.Config) {
 	setTxPool(ctx, fullCfg)
 }
 
-func CheckAddressExists(addressMap map[libcommon.Address]struct{}, target *libcommon.Address) bool {
-	if target == nil {
-		return false
-	}
-	_, exists := addressMap[*target]
+// CheckAddressExists is a public wrapper function to internally call checkAddressExists
+func CheckAddressExists(addressMap map[libcommon.Address]struct{}, target libcommon.Address) bool {
+	_, exists := addressMap[target]
 	return exists
+}
+
+// SetPreRunList is a public wrapper function to internally call setPreRunList
+func SetPreRunList(ctx *cli.Context, cfg *ethconfig.Config) {
+	if ctx.IsSet(PreRunAddressList.Name) {
+		addrHexes := libcommon.CliString2Array(ctx.String(PreRunAddressList.Name))
+
+		cfg.XLayer.PreRunList = make(map[libcommon.Address]struct{}, len(addrHexes))
+		for _, addr := range addrHexes {
+			cfg.XLayer.PreRunList[libcommon.HexToAddress(addr)] = struct{}{}
+		}
+		cfg.XLayer.PreRunCacheSize = ctx.Int(PreRunCacheSize.Name)
+		cfg.XLayer.PreRunCacheTTL = ctx.Duration(PreRunCacheTTL.Name)
+		cfg.XLayer.PreRunChanNum = ctx.Int(PreRunChanNum.Name)
+		cfg.XLayer.PreRunTaskNum = ctx.Int(PreRunTaskNum.Name)
+	}
 }

--- a/core/vm/contracts_xlayer.go
+++ b/core/vm/contracts_xlayer.go
@@ -1,0 +1,16 @@
+package vm
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ledgerwatch/erigon/cl/phase1/core/state/lru"
+	"github.com/ledgerwatch/log/v3"
+)
+
+var PrecompiledCache *lru.CacheWithTTL[string, []byte]
+
+func InitPrecompiledCache(cacheSize int, ttl time.Duration) {
+	log.Info(fmt.Sprintf("XLayer pre run cache config: cacheSize = %d, ttl = %s", cacheSize, ttl))
+	PrecompiledCache = lru.NewWithTTL[string, []byte]("evm_precompiled_cache", cacheSize, ttl)
+}

--- a/core/vm/contracts_xlayer.go
+++ b/core/vm/contracts_xlayer.go
@@ -11,6 +11,6 @@ import (
 var PrecompiledCache *lru.CacheWithTTL[string, []byte]
 
 func InitPrecompiledCache(cacheSize int, ttl time.Duration) {
-	log.Info(fmt.Sprintf("XLayer pre run cache config: cacheSize = %d, ttl = %s", cacheSize, ttl))
+	log.Info(fmt.Sprintf("prerun cache config: cacheSize = %d, ttl = %s", cacheSize, ttl))
 	PrecompiledCache = lru.NewWithTTL[string, []byte]("evm_precompiled_cache", cacheSize, ttl)
 }

--- a/eth/ethconfig/config_xlayer.go
+++ b/eth/ethconfig/config_xlayer.go
@@ -2,6 +2,8 @@ package ethconfig
 
 import (
 	"time"
+
+	"github.com/ledgerwatch/erigon-lib/common"
 )
 
 // XLayerConfig is the X Layer config used on the eth backend
@@ -17,6 +19,12 @@ type XLayerConfig struct {
 	SequencerReplayHaltOnBatchNumber  uint64
 	SequencerReplayExternalDatastream bool
 	SequencerReplayL1SyncOnly         bool
+
+	PreRunList      map[common.Address]struct{}
+	PreRunCacheSize int
+	PreRunCacheTTL  time.Duration
+	PreRunChanNum   int
+	PreRunTaskNum   int
 }
 
 var DefaultXLayerConfig = XLayerConfig{}

--- a/test/config/test.erigon.seq.config.yaml
+++ b/test/config/test.erigon.seq.config.yaml
@@ -99,3 +99,5 @@ txpool.freegaslist : '[{"name":"e2e", "from_list":["0x586cbc95ed16031d9efdaebacf
 # close a block/batch immediately after the 1st zkCounter overflow TX
 zkevm.seal-batch-immediately-on-overflow: true
 zkevm.sequencer-timeout-on-empty-tx-pool: 5ms
+
+zkevm.pre-run-address-list: ["0x8f8E2d6cF621f30e9a11309D6A56A876281Fd534"]

--- a/test/config/xlayerconfig-mainnet.yaml
+++ b/test/config/xlayerconfig-mainnet.yaml
@@ -71,3 +71,6 @@ metrics.port: 9095
 yieldsize: 35
 zkevm.seal-batch-immediately-on-overflow: true
 zkevm.sequencer-timeout-on-empty-tx-pool: 1ms
+
+
+zkevm.pre-run-address-list: ["0xa03666Fb51Aa9aD2DE70e0434072A007b3C91A9E"]

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -335,6 +335,11 @@ var DefaultFlags = []cli.Flag{
 	&utils.SequencerReplayHaltOnBatchNumber,
 	&utils.SequencerReplayExternalDatastream,
 	&utils.SequencerReplayL1SyncOnly,
+	&utils.PreRunAddressList,
+	&utils.PreRunCacheSize,
+	&utils.PreRunCacheTTL,
+	&utils.PreRunChanNum,
+	&utils.PreRunTaskNum,
 
 	&utils.ACLPrintHistory,
 	&utils.InfoTreeUpdateInterval,

--- a/turbo/cli/flags_xlayer.go
+++ b/turbo/cli/flags_xlayer.go
@@ -30,6 +30,8 @@ func ApplyFlagsForEthXLayerConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		SequencerReplayL1SyncOnly:         ctx.Bool(utils.SequencerReplayL1SyncOnly.Name),
 	}
 
+	utils.SetPreRunList(ctx, cfg)
+
 	if ctx.IsSet(utils.ApolloNamespaceName.Name) {
 		ns := strings.Split(ctx.String(utils.ApolloNamespaceName.Name), ",")
 		for idx, item := range ns {

--- a/turbo/jsonrpc/eth_api.go
+++ b/turbo/jsonrpc/eth_api.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ledgerwatch/erigon-lib/common/hexutil"
+	"github.com/ledgerwatch/erigon/core/vm"
 	"github.com/ledgerwatch/erigon/zk/sequencer"
 
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -386,8 +387,10 @@ type APIImpl struct {
 	DisableVirtualCounters        bool
 
 	// For X Layer
-	L2GasPricer   gasprice.L2GasPricer
-	EnableInnerTx bool
+	L2GasPricer     gasprice.L2GasPricer
+	EnableInnerTx   bool
+	PreRunList      map[common.Address]struct{}
+	preRunProcessor *PreRunProcessor
 }
 
 // NewEthAPI returns APIImpl instance
@@ -439,6 +442,11 @@ func NewEthAPI(base *BaseAPI, db kv.RoDB, eth rpchelper.ApiBackend, txPool txpoo
 	GasPricerOnce.Do(func() {
 		if sequencer.IsSequencer() {
 			apii.runL2GasPricerForXLayer()
+			vm.InitPrecompiledCache(ethCfg.XLayer.PreRunCacheSize, ethCfg.XLayer.PreRunCacheTTL)
+			apii.initPreRunWorkers(ethCfg.XLayer.PreRunChanNum, ethCfg.XLayer.PreRunTaskNum)
+			log.Info(fmt.Sprintf("XLayer pre run list:%v, cache size:%v, ttl:%v, chan:%v, task:%v",
+				apii.PreRunList, ethCfg.XLayer.PreRunCacheSize, ethCfg.XLayer.PreRunCacheTTL,
+				ethCfg.XLayer.PreRunChanNum, ethCfg.XLayer.PreRunTaskNum))
 		}
 	})
 

--- a/turbo/jsonrpc/eth_api.go
+++ b/turbo/jsonrpc/eth_api.go
@@ -444,7 +444,7 @@ func NewEthAPI(base *BaseAPI, db kv.RoDB, eth rpchelper.ApiBackend, txPool txpoo
 			apii.runL2GasPricerForXLayer()
 			vm.InitPrecompiledCache(ethCfg.XLayer.PreRunCacheSize, ethCfg.XLayer.PreRunCacheTTL)
 			apii.initPreRunWorkers(ethCfg.XLayer.PreRunChanNum, ethCfg.XLayer.PreRunTaskNum)
-			log.Info(fmt.Sprintf("XLayer pre run list:%v, cache size:%v, ttl:%v, chan:%v, task:%v",
+			log.Info(fmt.Sprintf("prerun list:%v, cache size:%v, ttl:%v, chan:%v, task:%v",
 				apii.PreRunList, ethCfg.XLayer.PreRunCacheSize, ethCfg.XLayer.PreRunCacheTTL,
 				ethCfg.XLayer.PreRunChanNum, ethCfg.XLayer.PreRunTaskNum))
 		}

--- a/turbo/jsonrpc/eth_api.go
+++ b/turbo/jsonrpc/eth_api.go
@@ -434,6 +434,7 @@ func NewEthAPI(base *BaseAPI, db kv.RoDB, eth rpchelper.ApiBackend, txPool txpoo
 		// For X Layer
 		L2GasPricer:   gasprice.NewL2GasPriceSuggester(context.Background(), ethCfg.GPO),
 		EnableInnerTx: ethCfg.XLayer.EnableInnerTx,
+		PreRunList:    ethCfg.XLayer.PreRunList,
 	}
 
 	// For X Layer

--- a/turbo/jsonrpc/eth_api.go
+++ b/turbo/jsonrpc/eth_api.go
@@ -443,11 +443,13 @@ func NewEthAPI(base *BaseAPI, db kv.RoDB, eth rpchelper.ApiBackend, txPool txpoo
 	GasPricerOnce.Do(func() {
 		if sequencer.IsSequencer() {
 			apii.runL2GasPricerForXLayer()
-			vm.InitPrecompiledCache(ethCfg.XLayer.PreRunCacheSize, ethCfg.XLayer.PreRunCacheTTL)
-			apii.initPreRunWorkers(ethCfg.XLayer.PreRunChanNum, ethCfg.XLayer.PreRunTaskNum)
-			log.Info(fmt.Sprintf("prerun list:%v, cache size:%v, ttl:%v, chan:%v, task:%v",
-				apii.PreRunList, ethCfg.XLayer.PreRunCacheSize, ethCfg.XLayer.PreRunCacheTTL,
-				ethCfg.XLayer.PreRunChanNum, ethCfg.XLayer.PreRunTaskNum))
+			if len(ethCfg.XLayer.PreRunList) > 0 {
+				vm.InitPrecompiledCache(ethCfg.XLayer.PreRunCacheSize, ethCfg.XLayer.PreRunCacheTTL)
+				apii.initPreRunWorkers(ethCfg.XLayer.PreRunChanNum, ethCfg.XLayer.PreRunTaskNum)
+				log.Info(fmt.Sprintf("prerun list:%v, cache size:%v, ttl:%v, chan:%v, task:%v",
+					apii.PreRunList, ethCfg.XLayer.PreRunCacheSize, ethCfg.XLayer.PreRunCacheTTL,
+					ethCfg.XLayer.PreRunChanNum, ethCfg.XLayer.PreRunTaskNum))
+			}
 		}
 	})
 

--- a/turbo/jsonrpc/pre_run_xlayer.go
+++ b/turbo/jsonrpc/pre_run_xlayer.go
@@ -1,0 +1,179 @@
+package jsonrpc
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ledgerwatch/erigon-lib/chain"
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/common/hexutil"
+	"github.com/ledgerwatch/erigon-lib/common/hexutility"
+	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/erigon/core/state"
+	"github.com/ledgerwatch/erigon/core/types"
+	"github.com/ledgerwatch/erigon/rpc"
+	ethapi2 "github.com/ledgerwatch/erigon/turbo/adapter/ethapi"
+	"github.com/ledgerwatch/erigon/turbo/rpchelper"
+	"github.com/ledgerwatch/erigon/turbo/transactions"
+	"github.com/ledgerwatch/log/v3"
+)
+
+type PreRunProcessor struct {
+	taskChan chan preRunTask
+	api      *APIImpl
+}
+
+type preRunTask struct {
+	txn     types.Transaction
+	chainId *big.Int
+}
+
+func NewPreRunProcessor(api *APIImpl, chanNum int, taskNum int) *PreRunProcessor {
+	p := &PreRunProcessor{
+		taskChan: make(chan preRunTask, chanNum),
+		api:      api,
+	}
+
+	for i := 0; i < taskNum; i++ {
+		go p.processLoop()
+	}
+
+	return p
+}
+
+func (p *PreRunProcessor) processLoop() {
+	for task := range p.taskChan {
+		_, _ = p.api.preRunWorker(task.txn, task.chainId)
+	}
+}
+
+func (p *PreRunProcessor) Submit(txn types.Transaction, chainId *big.Int) {
+	select {
+	case p.taskChan <- preRunTask{txn: txn, chainId: chainId}:
+	default:
+		log.Warn("PreRun task queue is full, skipping preRun")
+	}
+}
+
+func (api *APIImpl) initPreRunWorkers(chanNum int, taskNum int) {
+	api.preRunProcessor = NewPreRunProcessor(api, chanNum, taskNum)
+}
+
+func (api *APIImpl) preRun(txn types.Transaction, chainId *big.Int) {
+	api.preRunProcessor.Submit(txn, chainId)
+}
+
+func (api *APIImpl) preRunWorker(txn types.Transaction, chainId *big.Int) (hexutil.Uint64, error) {
+	signer := types.LatestSignerForChainID(chainId)
+	fromAddress, err := txn.Sender(*signer)
+	if err != nil {
+		return 0, err
+	}
+	fromAddressHex := libcommon.HexToAddress(fromAddress.String())
+	gas := txn.GetGas()
+	gp := new(big.Int).SetBytes(txn.GetPrice().Bytes())
+	newGP := (*hexutil.Big)(gp)
+	value := new(big.Int).SetBytes(txn.GetValue().Bytes())
+	newValue := (*hexutil.Big)(value)
+	nonce := txn.GetNonce()
+
+	data := txn.GetData()
+	hexData := hexutil.Bytes(data)
+	hexUtilityData := (*hexutility.Bytes)(&hexData)
+	args := ethapi2.CallArgs{
+		From:     &fromAddressHex,
+		To:       txn.GetTo(),
+		Gas:      (*hexutil.Uint64)(&gas),
+		GasPrice: newGP,
+		Value:    newValue,
+		Nonce:    (*hexutil.Uint64)(&nonce),
+		Data:     hexUtilityData,
+		Input:    hexUtilityData,
+		ChainID:  (*hexutil.Big)(chainId),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	dbtx, err := api.db.BeginRo(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer dbtx.Rollback()
+
+	block, stateReader, chainConfig, err := api.prepareBlockAndState(ctx, dbtx)
+	if err != nil {
+		return 0, err
+	}
+
+	caller, err := transactions.NewReusableCaller(
+		api.engine(),
+		stateReader,
+		nil,
+		block.HeaderNoCopy(),
+		args,
+		api.GasCap,
+		latestNumOrHash,
+		dbtx,
+		api._blockReader,
+		chainConfig,
+		api.evmCallTimeout,
+		api.VirtualCountersSmtReduction,
+		false,
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	fixedGas := uint64(10000000)
+	result, err := caller.DoCallWithNewGas(ctx, fixedGas)
+	if err != nil {
+		return 0, err
+	}
+
+	if result.Failed() {
+		log.Error("Execution failed", "gas", fixedGas, "from", fromAddress, "to", txn.GetTo(), "revert", result.Revert())
+		if len(result.Revert()) > 0 {
+			return 0, ethapi2.NewRevertError(result)
+		}
+		return 0, result.Err
+	}
+
+	return hexutil.Uint64(fixedGas), nil
+}
+
+func (api *APIImpl) prepareBlockAndState(ctx context.Context, dbtx kv.Tx) (*types.Block, state.StateReader, *chain.Config, error) {
+	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+	latestCanBlockNumber, latestCanHash, isLatest, err := rpchelper.GetCanonicalBlockNumber_zkevm(bNrOrHash, dbtx, api.filters)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	block := api.tryBlockFromLru(latestCanHash)
+	if block == nil {
+		var err error
+		block, err = api.blockWithSenders(ctx, dbtx, latestCanHash, latestCanBlockNumber)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	}
+	if block == nil {
+		return nil, nil, nil, fmt.Errorf("could not find latest block")
+	}
+
+	chainConfig, err := api.chainConfig(ctx, dbtx)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	stateReader, err := rpchelper.CreateStateReaderFromBlockNumber(
+		ctx, dbtx, latestCanBlockNumber, isLatest, 0,
+		api.stateCache, api.historyV3(dbtx), chainConfig.ChainName,
+	)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return block, stateReader, chainConfig, nil
+}

--- a/turbo/jsonrpc/pre_run_xlayer.go
+++ b/turbo/jsonrpc/pre_run_xlayer.go
@@ -133,7 +133,7 @@ func (api *APIImpl) preRunWorker(txn types.Transaction, chainId *big.Int) (hexut
 	}
 
 	if result.Failed() {
-		log.Error("Execution failed", "gas", fixedGas, "from", fromAddress, "to", txn.GetTo(), "revert", result.Revert())
+		log.Error("Prerun execution failed", "gas", fixedGas, "from", fromAddress, "to", txn.GetTo(), "revert", result.Revert())
 		if len(result.Revert()) > 0 {
 			return 0, ethapi2.NewRevertError(result)
 		}

--- a/turbo/jsonrpc/send_transaction.go
+++ b/turbo/jsonrpc/send_transaction.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/common/hexutility"
 	txPoolProto "github.com/ledgerwatch/erigon-lib/gointerfaces/txpool"
 
+	utils2 "github.com/ledgerwatch/erigon/cmd/utils"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/params"
 	"github.com/ledgerwatch/erigon/rpc"
@@ -121,6 +122,10 @@ func (api *APIImpl) SendRawTransaction(ctx context.Context, encodedTx hexutility
 	}
 	if badTxHashCounter >= api.BadTxAllowance {
 		return common.Hash{}, errors.New("transaction uses too many counters to fit into a batch")
+	}
+
+	if len(api.PreRunList) > 0 && utils2.CheckAddressExists(api.PreRunList, txn.GetTo()) {
+		api.preRun(txn, chainId)
 	}
 
 	res, err := api.txPool.Add(ctx, &txPoolProto.AddRequest{RlpTxs: [][]byte{encodedTx}})

--- a/turbo/jsonrpc/send_transaction.go
+++ b/turbo/jsonrpc/send_transaction.go
@@ -124,7 +124,7 @@ func (api *APIImpl) SendRawTransaction(ctx context.Context, encodedTx hexutility
 		return common.Hash{}, errors.New("transaction uses too many counters to fit into a batch")
 	}
 
-	if len(api.PreRunList) > 0 && utils2.CheckAddressExists(api.PreRunList, txn.GetTo()) {
+	if len(api.PreRunList) > 0 && utils2.CheckAddressExists(api.PreRunList, sender) {
 		api.preRun(txn, chainId)
 	}
 


### PR DESCRIPTION
Introduces pre-run processing functionality for X Layer transactions with configurable options:
- Added new CLI flags for pre-run configuration
- Implemented a pre-run processor with configurable cache and task settings
- Added support for pre-running transactions for specific addresses
- Integrated precompiled cache for EVM operations
- Updated configuration to support pre-run list and related parameters