### PR TITLE
RPC blockhash mismatch

### DIFF
--- a/zk/datastream/client/stream_client.go
+++ b/zk/datastream/client/stream_client.go
@@ -544,7 +544,7 @@ LOOP:
 		if readNewProto {
 			if parsedProto, entryNum, err = ReadParsedProto(c); err != nil {
 				if err == ErrReachedEntryNumberLimit {
-					return c.trySendChannelEOF()
+					return c.trySendStopSignal()
 				}
 				return err
 			}
@@ -576,7 +576,7 @@ LOOP:
 		if c.header.TotalEntries == entryNum+1 {
 			log.Trace("[Datastream client] reached the current end of the stream", "header_totalEntries", c.header.TotalEntries, "entryNum", entryNum)
 
-			if err := c.trySendChannelEOF(); err != nil {
+			if err := c.trySendStopSignal(); err != nil {
 				return err
 			}
 			break LOOP
@@ -586,7 +586,7 @@ LOOP:
 	return nil
 }
 
-func (c *StreamClient) trySendChannelEOF() error {
+func (c *StreamClient) trySendStopSignal() error {
 	retries := 0
 	for {
 		select {

--- a/zk/datastream/client/stream_client.go
+++ b/zk/datastream/client/stream_client.go
@@ -35,9 +35,9 @@ const (
 
 var (
 	// ErrFileEntryNotFound denotes error that is returned when the certain file entry is not found in the datastream
-	ErrFileEntryNotFound = errors.New("file entry not found")
-
-	minimumCheckTimeout = 500 * time.Millisecond
+	ErrFileEntryNotFound       = errors.New("file entry not found")
+	ErrReachedEntryNumberLimit = errors.New("reached entry number limit")
+	minimumCheckTimeout        = 500 * time.Millisecond
 )
 
 type StreamClient struct {
@@ -543,6 +543,9 @@ LOOP:
 
 		if readNewProto {
 			if parsedProto, entryNum, err = ReadParsedProto(c); err != nil {
+				if err == ErrReachedEntryNumberLimit {
+					return c.trySendChannelEOF()
+				}
 				return err
 			}
 			readNewProto = false
@@ -573,26 +576,31 @@ LOOP:
 		if c.header.TotalEntries == entryNum+1 {
 			log.Trace("[Datastream client] reached the current end of the stream", "header_totalEntries", c.header.TotalEntries, "entryNum", entryNum)
 
-			retries := 0
-		INTERNAL_LOOP:
-			for {
-				select {
-				case c.entryChan <- nil:
-					break INTERNAL_LOOP
-				default:
-					if retries > 5 {
-						return errors.New("[Datastream client] failed to write final entry to channel after 5 retries")
-					}
-					retries++
-					log.Warn("[Datastream client] Channel is full, waiting to write nil and end stream client read")
-					time.Sleep(1 * time.Second)
-				}
+			if err := c.trySendChannelEOF(); err != nil {
+				return err
 			}
 			break LOOP
 		}
 	}
 
 	return nil
+}
+
+func (c *StreamClient) trySendChannelEOF() error {
+	retries := 0
+	for {
+		select {
+		case c.entryChan <- nil:
+			return nil
+		default:
+			if retries > 5 {
+				return errors.New("[Datastream client] failed to write final entry to channel after 5 retries")
+			}
+			retries++
+			log.Warn("[Datastream client] Channel is full, waiting to write nil and end stream client read")
+			time.Sleep(1 * time.Second)
+		}
+	}
 }
 
 func (c *StreamClient) HandleStart() error {
@@ -728,7 +736,8 @@ func ReadParsedProto(iterator FileEntryIterator) (
 				return
 			}
 			if entryNum == iterator.GetEntryNumberLimit() {
-				break LOOP
+				err = ErrReachedEntryNumberLimit
+				return
 			}
 		}
 


### PR DESCRIPTION
**Reason of the issue**
The reason for the blockhash mismatch in RPC is as follows: Currently, when the RPC datastream client processes an EntryTypeL2Block, it enters a loop to read entries such as L2Tx. However, if the entry number limit is reached, the client stops reading, even if some L2Tx entries in the block have not been read. It then considers the transactions it has read so far as the complete set for that block. Consequently, when RPC recalculates the blockhash, it does so with an incomplete transaction list, resulting in a computed blockhash that doesn’t match the claimed blockhash.

**Solution**
The solution is as follows: If the entry number limit is reached during reading, discard the L2Tx entries retrieved in that round and return nil to the entry channel. In the next synchronization round, the client will attempt to read again. If the entry number limit is sufficient to cover all L2Tx in the block, the reading will succeed.