### PR TITLE
Add txpool.enabletimsort flag and use timsort when it is enabled

### DIFF
--- a/cmd/utils/flags_xlayer.go
+++ b/cmd/utils/flags_xlayer.go
@@ -103,6 +103,11 @@ var (
 		Name:  "txpool.freegaslist",
 		Usage: "FreeGasList Project in JSON Format",
 	}
+	TxPoolEnableTimsort = cli.BoolFlag{
+		Name:  "txpool.enabletimsort",
+		Usage: "EnableTimsort enable timsort to instead of built-in sorting",
+		Value: false,
+	}
 	// Gas Pricer
 	GpoTypeFlag = cli.StringFlag{
 		Name:  "gpo.type",
@@ -386,6 +391,9 @@ func setTxPoolXLayer(ctx *cli.Context, cfg *ethconfig.DeprecatedTxPoolConfig) {
 				panic("unable to unmarshal freeGasList:" + err.Error())
 			}
 		}
+	}
+	if ctx.IsSet(TxPoolEnableTimsort.Name) {
+		cfg.EnableTimsort = ctx.Bool(TxPoolEnableTimsort.Name)
 	}
 }
 

--- a/eth/ethconfig/tx_pool.go
+++ b/eth/ethconfig/tx_pool.go
@@ -67,6 +67,8 @@ type DeprecatedTxPoolConfig struct {
 	EnableFreeGasList bool
 	// FreeGasList project name to FreeGasInfo
 	FreeGasList []FreeGasInfo
+	// EnableTimsort is the switch to use timsort on the best slice of txpool
+	EnableTimsort bool
 }
 
 // FreeGasInfo contains the details for what tx should be free

--- a/go.mod
+++ b/go.mod
@@ -277,6 +277,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
+	github.com/psilva261/timsort/v2 v2.0.1 // indirect
 	github.com/quic-go/qpack v0.4.0 // indirect
 	github.com/quic-go/qtls-go1-20 v0.3.3 // indirect
 	github.com/quic-go/quic-go v0.38.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -945,6 +945,8 @@ github.com/prysmaticlabs/go-bitfield v0.0.0-20210809151128-385d8c5e3fb7 h1:0tVE4
 github.com/prysmaticlabs/go-bitfield v0.0.0-20210809151128-385d8c5e3fb7/go.mod h1:wmuf/mdK4VMD+jA9ThwcUKjg3a2XWM9cVfFYjDyY4j4=
 github.com/prysmaticlabs/gohashtree v0.0.3-alpha.0.20230502123415-aafd8b3ca202 h1:ZsFouPKy81vvQo/Zup5gASVdOm6aiuwUhp7GxvQmjIA=
 github.com/prysmaticlabs/gohashtree v0.0.3-alpha.0.20230502123415-aafd8b3ca202/go.mod h1:4pWaT30XoEx1j8KNJf3TV+E3mQkaufn7mf+jRNb/Fuk=
+github.com/psilva261/timsort/v2 v2.0.1 h1:yXOIbHYTmcLweKP8WM77UVpMlsySgvBT/9WJbKOs3Os=
+github.com/psilva261/timsort/v2 v2.0.1/go.mod h1:YBxAWUUK+z+XD9PrMgBQXquJ+ZBeiJ5SGtdwcdhsUtQ=
 github.com/quasilyte/go-ruleguard/dsl v0.3.22 h1:wd8zkOhSNr+I+8Qeciml08ivDt1pSXe60+5DqOpCjPE=
 github.com/quasilyte/go-ruleguard/dsl v0.3.22/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/quic-go/qpack v0.4.0 h1:Cr9BXA1sQS2SmDUWjSofMPNKmvF6IiIfDRmgU0w1ZCo=

--- a/test/config/test.erigon.seq.config.yaml
+++ b/test/config/test.erigon.seq.config.yaml
@@ -102,3 +102,6 @@ zkevm.seal-batch-immediately-on-overflow: true
 zkevm.sequencer-timeout-on-empty-tx-pool: 5ms
 zkevm.pre-run-address-list: ["0x8f8E2d6cF621f30e9a11309D6A56A876281Fd534"]
 zkevm.block-info-concurrent: true
+
+# to reduce lock race in stress test
+txpool.enabletimsort: true

--- a/test/config/xlayerconfig-mainnet.yaml
+++ b/test/config/xlayerconfig-mainnet.yaml
@@ -76,3 +76,6 @@ zkevm.sequencer-timeout-on-empty-tx-pool: 1ms
 
 zkevm.pre-run-address-list: ["0xa03666Fb51Aa9aD2DE70e0434072A007b3C91A9E"]
 zkevm.block-info-concurrent: true
+
+# to reduce lock race in stress test
+txpool.enabletimsort: true

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -329,6 +329,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.TxPoolFreeGasLimit,
 	&utils.TxPoolEnableFreeGasList,
 	&utils.TxPoolFreeGasList,
+	&utils.TxPoolEnableTimsort,
 	&utils.HTTPApiKeysFlag,
 	&utils.MethodRateLimitFlag,
 	&utils.SequencerReplay,

--- a/zk/txpool/pool.go
+++ b/zk/txpool/pool.go
@@ -42,6 +42,7 @@ import (
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
 	"github.com/ledgerwatch/erigon/eth/gasprice/gaspricecfg"
 	"github.com/ledgerwatch/log/v3"
+	"github.com/psilva261/timsort/v2"
 	"github.com/status-im/keycard-go/hexutils"
 
 	"github.com/ledgerwatch/erigon-lib/chain"
@@ -387,7 +388,7 @@ func New(newTxs chan types.Announcements, coreDB kv.RoDB, cfg txpoolcfg.Config, 
 		discardReasonsLRU:       discardHistory,
 		all:                     byNonce,
 		recentlyConnectedPeers:  &recentlyConnectedPeers{},
-		pending:                 NewPendingSubPool(PendingSubPool, cfg.PendingSubPoolLimit),
+		pending:                 NewPendingSubPool(PendingSubPool, cfg.PendingSubPoolLimit, ethCfg.DeprecatedTxPool.EnableTimsort),
 		baseFee:                 NewSubPool(BaseFeeSubPool, cfg.BaseFeeSubPoolLimit),
 		queued:                  NewSubPool(QueuedSubPool, cfg.QueuedSubPoolLimit),
 		newPendingTxs:           newTxs,
@@ -2260,17 +2261,18 @@ func (b *BySenderAndNonce) replaceOrInsert(mt *metaTx) *metaTx {
 // It's more expensive to maintain "slice sort" invariant, but it allow do cheap copy of
 // pending.best slice for mining (because we consider txs and metaTx are immutable)
 type PendingPool struct {
-	sorted atomic.Bool // means `PendingPool.best` is sorted or not
-	best   *bestSlice
-	worst  *WorstQueue
-	limit  int
-	t      SubPoolType
-	mtx    sync.RWMutex
+	sorted        atomic.Bool // means `PendingPool.best` is sorted or not
+	best          *bestSlice
+	worst         *WorstQueue
+	limit         int
+	t             SubPoolType
+	mtx           sync.RWMutex
+	enbaleTimsort bool
 }
 
-func NewPendingSubPool(t SubPoolType, limit int) *PendingPool {
-	log.Info("new sub pool", "SubPoolType", PendingSubPool, "limit", limit)
-	return &PendingPool{limit: limit, t: t, best: &bestSlice{ms: []*metaTx{}}, worst: &WorstQueue{ms: []*metaTx{}}}
+func NewPendingSubPool(t SubPoolType, limit int, enableTimsort bool) *PendingPool {
+	log.Info("new sub pool", "SubPoolType", PendingSubPool, "limit", limit, "enableTimsort", enableTimsort)
+	return &PendingPool{limit: limit, t: t, best: &bestSlice{ms: []*metaTx{}}, worst: &WorstQueue{ms: []*metaTx{}}, enbaleTimsort: enableTimsort}
 }
 
 // bestSlice - is similar to best queue, but with O(n log n) complexity and
@@ -2310,7 +2312,11 @@ func (p *PendingPool) EnforceBestInvariants() {
 		p.mtx.Lock()
 		defer p.mtx.Unlock()
 
-		sort.Sort(p.best)
+		if p.enbaleTimsort {
+			timsort.TimSort(p.best)
+		} else {
+			sort.Sort(p.best)
+		}
 		p.sorted.Swap(true)
 	}
 }

--- a/zk/txpool/pool_test.go
+++ b/zk/txpool/pool_test.go
@@ -262,16 +262,25 @@ func generateRandomMetaTx(id int, senderNonceMap map[uint64]uint64) *metaTx {
 		panic(fmt.Sprintf("Failed to generate random IDHash: %v", err))
 	}
 
+	minFeeCap := uint64(rand.Intn(1000000)) // [0, 999999]
+
+	var minTip uint64
+	if minFeeCap > 0 {
+		minTip = uint64(rand.Intn(int(minFeeCap))) // [0, minFeeCap-1]
+	} else {
+		minTip = 0
+	}
+
 	return &metaTx{
 		Tx: &types.TxSlot{
 			IDHash:   idHash,
 			SenderID: senderID,
 			Nonce:    nonce,
 		},
-		minFeeCap:                 *uint256.NewInt(uint64(rand.Intn(1000000))),
-		nonceDistance:             uint64(rand.Intn(100)),
-		cumulativeBalanceDistance: uint64(rand.Intn(1000)),
-		minTip:                    uint64(rand.Intn(100)),
+		minFeeCap:                 *uint256.NewInt(minFeeCap),
+		nonceDistance:             0,
+		cumulativeBalanceDistance: 0,
+		minTip:                    minTip,
 		bestIndex:                 -1,
 		worstIndex:                -1,
 		timestamp:                 uint64(time.Now().UnixNano()),
@@ -283,14 +292,15 @@ func generateRandomMetaTx(id int, senderNonceMap map[uint64]uint64) *metaTx {
 
 func isSorted(slice *bestSlice) bool {
 	for i := 1; i < slice.Len(); i++ {
-		if !slice.Less(i-1, i) {
+		if slice.Less(i, i-1) {
+			fmt.Printf("Unsorted at %d: %+v < %+v\n", i, slice.ms[i-1], slice.ms[i])
 			return false
 		}
 	}
 	return true
 }
 
-func TestEnforceBestInvariantsAfterRemoveBestTxs(t *testing.T) {
+func TestEnforceBestInvariantsAfterBestChanged(t *testing.T) {
 	const txCount = 1_000_000
 	rand.Seed(uint64(time.Now().UnixNano()))
 
@@ -310,33 +320,130 @@ func TestEnforceBestInvariantsAfterRemoveBestTxs(t *testing.T) {
 		poolTimSort.Add(&txCopy)
 	}
 
-	poolSort.EnforceBestInvariants()
 	poolTimSort.EnforceBestInvariants()
-
-	assert.True(t, isSorted(poolSort.best), "sort.Sort failed to sort bestSlice")
 	assert.True(t, isSorted(poolTimSort.best), "timsort.TimSort failed to sort bestSlice")
 
-	assert.Equal(t, poolSort.best.ms[0].Tx.IDHash, poolTimSort.best.ms[0].Tx.IDHash, "Best tx IDHash differs before removing best txs")
-	assert.Equal(t, poolSort.best.ms[txCount-1].Tx.IDHash, poolTimSort.best.ms[txCount-1].Tx.IDHash, "Worst tx IDHash differs before removing best txs")
+	poolSort.EnforceBestInvariants()
+	assert.True(t, isSorted(poolSort.best), "sort.Sort failed to sort bestSlice")
 
-	for i := 0; i < 30; i++ {
+	assert.Equal(t, poolSort.best.ms[0].Tx.IDHash, poolTimSort.best.ms[0].Tx.IDHash, "Best tx IDHash differs before removing best txs")
+
+	// remove top 30 transactions
+	for i := 0; i < 1000; i++ {
 		poolSort.Remove(poolSort.Best())
-		poolTimSort.Remove(poolSort.Best())
+		poolTimSort.Remove(poolTimSort.Best())
+	}
+
+	// add 30 new transacions
+	for i := 0; i < 500; i++ {
+		tx := generateRandomMetaTx(i, senderNonceMap)
+		txCopy := *tx
+		txCopy.Tx = &types.TxSlot{
+			IDHash:   tx.Tx.IDHash,
+			SenderID: tx.Tx.SenderID,
+			Nonce:    tx.Tx.Nonce,
+		}
+		poolSort.Add(tx)
+		poolTimSort.Add(&txCopy)
 	}
 
 	start := time.Now()
-	poolSort.EnforceBestInvariants()
-	sortDuration := time.Since(start)
-
-	start = time.Now()
 	poolTimSort.EnforceBestInvariants()
 	timSortDuration := time.Since(start)
 
-	assert.True(t, isSorted(poolSort.best), "sort.Sort failed to sort bestSlice")
+	start = time.Now()
+	poolSort.EnforceBestInvariants()
+	sortDuration := time.Since(start)
+
 	assert.True(t, isSorted(poolTimSort.best), "timsort.TimSort failed to sort bestSlice")
+	assert.True(t, isSorted(poolSort.best), "sort.Sort failed to sort bestSlice")
 	assert.Equal(t, poolSort.best.ms[0].Tx.IDHash, poolTimSort.best.ms[0].Tx.IDHash, "Best tx IDHash differs after removing best txs")
 	assert.Greaterf(t, sortDuration, timSortDuration, "sort.Sort cost less time than timsort.TimSort")
 
 	t.Logf("sort.Sort duration(After BestRead): %v", sortDuration)
 	t.Logf("timsort.TimSort duration(After BestRead): %v", timSortDuration)
+}
+
+func BenchmarkSortingPerformance(b *testing.B) {
+	const (
+		txCount     = 100_000 // Reduced for benchmark speed; adjust as needed
+		removeCount = 1_000   // Number of transactions to remove
+		addCount    = 500     // Number of transactions to add back
+	)
+
+	// Seed random generator
+	rand.Seed(uint64(time.Now().UnixNano()))
+
+	// Run benchmark for both sorting methods
+	b.Run("sort.Sort", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			// Initialize pool
+			pool := NewPendingSubPool(PendingSubPool, txCount+addCount, false)
+			senderNonceMap := make(map[uint64]uint64)
+
+			// Add initial transactions
+			for j := 0; j < txCount; j++ {
+				tx := generateRandomMetaTx(j, senderNonceMap)
+				pool.Add(tx)
+			}
+
+			// First sort
+			pool.EnforceBestInvariants()
+			assert.True(b, isSorted(pool.best), "Initial sort.Sort failed")
+
+			// Remove some transactions
+			for j := 0; j < removeCount && pool.best.Len() > 0; j++ {
+				pool.Remove(pool.Best())
+			}
+
+			// Add new transactions
+			for j := 0; j < addCount; j++ {
+				tx := generateRandomMetaTx(txCount+j, senderNonceMap)
+				pool.Add(tx)
+			}
+
+			// Second sort (benchmark this)
+			b.StartTimer()
+			pool.EnforceBestInvariants()
+			b.StopTimer()
+
+			assert.True(b, isSorted(pool.best), "Second sort.Sort failed")
+		}
+	})
+
+	b.Run("timsort.TimSort", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			// Initialize pool
+			pool := NewPendingSubPool(PendingSubPool, txCount+addCount, true)
+			senderNonceMap := make(map[uint64]uint64)
+
+			// Add initial transactions
+			for j := 0; j < txCount; j++ {
+				tx := generateRandomMetaTx(j, senderNonceMap)
+				pool.Add(tx)
+			}
+
+			// First sort
+			pool.EnforceBestInvariants()
+			assert.True(b, isSorted(pool.best), "Initial timsort.TimSort failed")
+
+			// Remove some transactions
+			for j := 0; j < removeCount && pool.best.Len() > 0; j++ {
+				pool.Remove(pool.Best())
+			}
+
+			// Add new transactions
+			for j := 0; j < addCount; j++ {
+				tx := generateRandomMetaTx(txCount+j, senderNonceMap)
+				pool.Add(tx)
+			}
+
+			// Second sort (benchmark this)
+			b.StartTimer()
+			pool.EnforceBestInvariants()
+			b.StopTimer()
+
+			assert.True(b, isSorted(pool.best), "Second timsort.TimSort failed")
+		}
+	})
 }

--- a/zk/txpool/pool_test.go
+++ b/zk/txpool/pool_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"golang.org/x/exp/rand"
 	"google.golang.org/grpc"
 )
 
@@ -243,4 +244,99 @@ func TestOnNewBlock(t *testing.T) {
 	err := fetch.handleStateChanges(ctx, stateChanges)
 	assert.ErrorIs(t, io.EOF, err)
 	assert.Equal(t, 3, len(minedTxs.Txs))
+}
+
+// For X Layer
+
+func generateRandomMetaTx(id int, senderNonceMap map[uint64]uint64) *metaTx {
+	senderID := uint64(rand.Intn(1000))
+	nonce, exists := senderNonceMap[senderID]
+	if !exists {
+		nonce = 0
+	}
+	senderNonceMap[senderID] = nonce + 1
+
+	var idHash [32]byte
+	_, err := rand.Read(idHash[:])
+	if err != nil {
+		panic(fmt.Sprintf("Failed to generate random IDHash: %v", err))
+	}
+
+	return &metaTx{
+		Tx: &types.TxSlot{
+			IDHash:   idHash,
+			SenderID: senderID,
+			Nonce:    nonce,
+		},
+		minFeeCap:                 *uint256.NewInt(uint64(rand.Intn(1000000))),
+		nonceDistance:             uint64(rand.Intn(100)),
+		cumulativeBalanceDistance: uint64(rand.Intn(1000)),
+		minTip:                    uint64(rand.Intn(100)),
+		bestIndex:                 -1,
+		worstIndex:                -1,
+		timestamp:                 uint64(time.Now().UnixNano()),
+		created:                   uint64(time.Now().Unix()),
+		subPool:                   0,
+		currentSubPool:            PendingSubPool,
+	}
+}
+
+func isSorted(slice *bestSlice) bool {
+	for i := 1; i < slice.Len(); i++ {
+		if !slice.Less(i-1, i) {
+			return false
+		}
+	}
+	return true
+}
+
+func TestEnforceBestInvariantsAfterRemoveBestTxs(t *testing.T) {
+	const txCount = 1_000_000
+	rand.Seed(uint64(time.Now().UnixNano()))
+
+	poolSort := NewPendingSubPool(PendingSubPool, txCount+1, false)
+	poolTimSort := NewPendingSubPool(PendingSubPool, txCount+1, true)
+
+	senderNonceMap := make(map[uint64]uint64)
+	for i := 0; i < txCount; i++ {
+		tx := generateRandomMetaTx(i, senderNonceMap)
+		txCopy := *tx
+		txCopy.Tx = &types.TxSlot{
+			IDHash:   tx.Tx.IDHash,
+			SenderID: tx.Tx.SenderID,
+			Nonce:    tx.Tx.Nonce,
+		}
+		poolSort.Add(tx)
+		poolTimSort.Add(&txCopy)
+	}
+
+	poolSort.EnforceBestInvariants()
+	poolTimSort.EnforceBestInvariants()
+
+	assert.True(t, isSorted(poolSort.best), "sort.Sort failed to sort bestSlice")
+	assert.True(t, isSorted(poolTimSort.best), "timsort.TimSort failed to sort bestSlice")
+
+	assert.Equal(t, poolSort.best.ms[0].Tx.IDHash, poolTimSort.best.ms[0].Tx.IDHash, "Best tx IDHash differs before removing best txs")
+	assert.Equal(t, poolSort.best.ms[txCount-1].Tx.IDHash, poolTimSort.best.ms[txCount-1].Tx.IDHash, "Worst tx IDHash differs before removing best txs")
+
+	for i := 0; i < 30; i++ {
+		poolSort.Remove(poolSort.Best())
+		poolTimSort.Remove(poolSort.Best())
+	}
+
+	start := time.Now()
+	poolSort.EnforceBestInvariants()
+	sortDuration := time.Since(start)
+
+	start = time.Now()
+	poolTimSort.EnforceBestInvariants()
+	timSortDuration := time.Since(start)
+
+	assert.True(t, isSorted(poolSort.best), "sort.Sort failed to sort bestSlice")
+	assert.True(t, isSorted(poolTimSort.best), "timsort.TimSort failed to sort bestSlice")
+	assert.Equal(t, poolSort.best.ms[0].Tx.IDHash, poolTimSort.best.ms[0].Tx.IDHash, "Best tx IDHash differs after removing best txs")
+	assert.Greaterf(t, sortDuration, timSortDuration, "sort.Sort cost less time than timsort.TimSort")
+
+	t.Logf("sort.Sort duration(After BestRead): %v", sortDuration)
+	t.Logf("timsort.TimSort duration(After BestRead): %v", timSortDuration)
 }

--- a/zk/txpool/pool_xlayer.go
+++ b/zk/txpool/pool_xlayer.go
@@ -47,6 +47,8 @@ type XLayerConfig struct {
 	EnableFreeGasList  bool
 	FreeGasFromNameMap map[string]string                 // map[from]projectName
 	FreeGasList        map[string]*ethconfig.FreeGasInfo // map[projectName]FreeGasInfo
+	// EnableTimsort is the switch to use timsort on the best slice of txpool
+	EnableTimsort bool
 }
 
 type GPCache interface {


### PR DESCRIPTION
Currently, pending.best is sorted using a built-in sorting algorithm, which performs poorly when pending.best has accumulated transactions. Because each time a transaction is obtained from pending.best, it needs to be sorted, and then the best transaction is obtained from the sorted slice, so pending.best is always mostly ordered when there are accumulated transactions, and the built-in sorting algorithm does not perform as well as timsort in this scenario. The following are the benchmark test results of the two sorting methods in the scenario where the pending pool has accumulated 100,000 transactions.
![image](https://github.com/user-attachments/assets/bda7ea9b-cab6-48f0-8e66-975263784d7b)
