### PR TITLE
Fix issue #383

### DIFF
--- a/cmd/utils/flags_xlayer.go
+++ b/cmd/utils/flags_xlayer.go
@@ -456,7 +456,7 @@ func SetPreRunList(ctx *cli.Context, cfg *ethconfig.Config) {
 
 func SetBulkAddTxs(ctx *cli.Context, cfg *ethconfig.Config) {
 	cfg.XLayer.BulkAddTxs = ctx.Bool(BulkAddTxsFlag.Name)
-	cfg.XLayer.BulkAddTxsSize = ctx.Int(BulkAddTxsFlag.Name)
+	cfg.XLayer.BulkAddTxsSize = ctx.Int(BulkAddTxsSizeFlag.Name)
 	cfg.XLayer.BulkAddTxsWaitTime = ctx.Duration(BulkAddTxsWaitTimeFlag.Name)
 	cfg.XLayer.EnableAddTxNotify = ctx.Bool(EnableAddTxNotify.Name)
 }

--- a/turbo/cli/flags_xlayer.go
+++ b/turbo/cli/flags_xlayer.go
@@ -34,7 +34,7 @@ func ApplyFlagsForEthXLayerConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		BlockInfoConcurrent:               ctx.Bool(utils.BlockInfoConcurrent.Name),
 		EnableAsyncCommit:                 ctx.Bool(utils.EnableAsyncCommit.Name),
 		BulkAddTxs:                        ctx.Bool(utils.BulkAddTxsFlag.Name),
-		BulkAddTxsSize:                    ctx.Int(utils.BulkAddTxsFlag.Name),
+		BulkAddTxsSize:                    ctx.Int(utils.BulkAddTxsSizeFlag.Name),
 		BulkAddTxsWaitTime:                ctx.Duration(utils.BulkAddTxsWaitTimeFlag.Name),
 		EnableAddTxNotify:                 ctx.Bool(utils.EnableAddTxNotify.Name),
 	}

--- a/zk/txpool/pool.go
+++ b/zk/txpool/pool.go
@@ -978,16 +978,18 @@ func (p *TxPool) punishSpammer(spammer uint64) {
 }
 
 func fillDiscardReasons(reasons []DiscardReason, newTxs types.TxSlots, discardReasonsLRU *simplelru.LRU[string, DiscardReason]) []DiscardReason {
+	j := 0
 	for i := range reasons {
 		if reasons[i] != NotSet {
 			continue
 		}
-		reason, ok := discardReasonsLRU.Get(string(newTxs.Txs[i].IDHash[:]))
+		reason, ok := discardReasonsLRU.Get(string(newTxs.Txs[j].IDHash[:]))
 		if ok {
 			reasons[i] = reason
 		} else {
 			reasons[i] = Success
 		}
+		j++
 	}
 	return reasons
 }
@@ -1039,13 +1041,15 @@ func (p *TxPool) AddLocalTxs(ctx context.Context, newTransactions types.TxSlots,
 	p.promoted.AppendOther(announcements)
 
 	reasons = fillDiscardReasons(reasons, newTxs, p.discardReasonsLRU)
-	for i, reason := range reasons {
+	i := 0
+	for _, reason := range reasons {
 		if reason == Success {
 			txn := newTxs.Txs[i]
 			if txn.Traced {
 				log.Info(fmt.Sprintf("TX TRACING: AddLocalTxs promotes idHash=%x, senderId=%d", txn.IDHash, txn.SenderID))
 			}
 			p.promoted.Append(txn.Type, txn.Size, txn.IDHash[:])
+			i++
 		}
 	}
 	if p.promoted.Len() > 0 {


### PR DESCRIPTION
Fix issue #383 

This problem is because when verifying transactions now, multiple transactions will be verified in one verification function, and then invalid transactions will be eliminated, but the subsequent traversal operation will still access the transaction array after elimination according to the length before elimination, and the array will be out of bounds at this time.

When adding transactions serially, the array length before elimination is 1, and the last invalid transaction is not accessed during traversal, so it will not panic. However, in our case, invalid transactions will not always appear at the last element of the array, so it will panic.