### PR TITLE
Fixed the issue where seq would directly pnaic after frequent restart…

### DIFF
--- a/zk/txpool/txpool_grpc_server.go
+++ b/zk/txpool/txpool_grpc_server.go
@@ -193,6 +193,7 @@ func (s *GrpcServer) Add(ctx context.Context, in *txpool_proto.AddRequest) (*txp
 	parseCtx.ValidateRLP(s.txPool.ValidateSerializedTxn)
 
 	reply := &txpool_proto.AddReply{Imported: make([]txpool_proto.ImportResult, len(in.RlpTxs)), Errors: make([]string, len(in.RlpTxs))}
+	validIndices := make([]int, 0, len(in.RlpTxs))
 
 	j := 0
 	for i := 0; i < len(in.RlpTxs); i++ { // some incoming txs may be rejected, so - need secnod index
@@ -223,6 +224,7 @@ func (s *GrpcServer) Add(ctx context.Context, in *txpool_proto.AddRequest) (*txp
 		slots.Txs[j] = txSlot
 		copy(slots.Senders.At(j), senderSlice)
 		slots.IsLocal[j] = true
+		validIndices = append(validIndices, i)
 		j++
 	}
 
@@ -238,9 +240,11 @@ func (s *GrpcServer) Add(ctx context.Context, in *txpool_proto.AddRequest) (*txp
 			continue
 		}
 
-		reply.Imported[i] = mapDiscardReasonToProto(discardReasons[j])
-		reply.Errors[i] = discardReasons[j].String()
-		j++
+		if j < len(validIndices) && validIndices[j] == i {
+			reply.Imported[i] = mapDiscardReasonToProto(discardReasons[j])
+			reply.Errors[i] = discardReasons[j].String()
+			j++
+		}
 	}
 	return reply, nil
 }

--- a/zk/txpool/txpool_grpc_server.go
+++ b/zk/txpool/txpool_grpc_server.go
@@ -193,7 +193,6 @@ func (s *GrpcServer) Add(ctx context.Context, in *txpool_proto.AddRequest) (*txp
 	parseCtx.ValidateRLP(s.txPool.ValidateSerializedTxn)
 
 	reply := &txpool_proto.AddReply{Imported: make([]txpool_proto.ImportResult, len(in.RlpTxs)), Errors: make([]string, len(in.RlpTxs))}
-	validIndices := make([]int, 0, len(in.RlpTxs))
 
 	j := 0
 	for i := 0; i < len(in.RlpTxs); i++ { // some incoming txs may be rejected, so - need secnod index
@@ -224,7 +223,6 @@ func (s *GrpcServer) Add(ctx context.Context, in *txpool_proto.AddRequest) (*txp
 		slots.Txs[j] = txSlot
 		copy(slots.Senders.At(j), senderSlice)
 		slots.IsLocal[j] = true
-		validIndices = append(validIndices, i)
 		j++
 	}
 
@@ -236,15 +234,12 @@ func (s *GrpcServer) Add(ctx context.Context, in *txpool_proto.AddRequest) (*txp
 	j = 0
 	for i := range reply.Imported {
 		if reply.Imported[i] != txpool_proto.ImportResult_SUCCESS {
-			j++
 			continue
 		}
 
-		if j < len(validIndices) && validIndices[j] == i {
-			reply.Imported[i] = mapDiscardReasonToProto(discardReasons[j])
-			reply.Errors[i] = discardReasons[j].String()
-			j++
-		}
+		reply.Imported[i] = mapDiscardReasonToProto(discardReasons[j])
+		reply.Errors[i] = discardReasons[j].String()
+		j++
 	}
 	return reply, nil
 }


### PR DESCRIPTION
This is because GrpcServer.Add will first parse the incoming RlpTxs, which is the original transactions, and filter out illegal transactions, which will not be put into the slots slice. At this time, the length of slots will be less than or equal to the length of reply.Imported, and the length of slots is the same as the length of discardReasons. If the j++ line is not removed, the loop starting from line 235 will make reply.Imported and discardReasons not correspond correctly, resulting in an array out of bounds when discardReasons is accessed.