### PR TITLE
set unlimited counter overflow check for lrp

### DIFF
--- a/eth/ethconfig/config_zkevm.go
+++ b/eth/ethconfig/config_zkevm.go
@@ -118,7 +118,7 @@ var DefaultZkConfig = Zk{
 }
 
 func (c *Zk) ShouldCountersBeUnlimited(l1Recovery bool) bool {
-	return l1Recovery || (c.DisableVirtualCounters && !c.ExecutorStrictMode && !c.HasExecutors())
+	return l1Recovery || (c.DisableVirtualCounters && !c.ExecutorStrictMode && !c.HasExecutors()) || c.XLayer.SequencerReplay
 }
 
 func (c *Zk) HasExecutors() bool {


### PR DESCRIPTION
Background: During LRP, occasionally some txs are abandoned because they overflow the zk counter. This is weird, they were included to the blocks before and they were fine at that time. 
Root cause: Each time this issue occurs, it’s the Poseidon counter that overflows. How this Poseidon counter deduct the counters actually depends on the current SMT depth which I believe is already different from the time when they were packed into the mainnet blocks. So, some small fraction of txs will meet this issue during LRP.
Solution: By setting unlimited counter overflow check for local replay, since they were already packed into mainnet blocks, the check itself is unnecessary.