### PR TITLE
RPC: Fix ds stuck when block time is small

### DIFF
--- a/zk/datastream/client/stream_client.go
+++ b/zk/datastream/client/stream_client.go
@@ -574,7 +574,7 @@ LOOP:
 			time.Sleep(10 * time.Microsecond)
 		}
 
-		if c.header.TotalEntries == entryNum+1 {
+		if c.header.TotalEntries > entryNum {
 			log.Trace("[Datastream client] reached the current end of the stream", "header_totalEntries", c.header.TotalEntries, "entryNum", entryNum)
 
 			// For X Layer, fix ds receive issue

--- a/zk/datastream/client/stream_client.go
+++ b/zk/datastream/client/stream_client.go
@@ -574,7 +574,7 @@ LOOP:
 			time.Sleep(10 * time.Microsecond)
 		}
 
-		if c.header.TotalEntries > entryNum {
+		if c.header.TotalEntries < entryNum {
 			log.Trace("[Datastream client] reached the current end of the stream", "header_totalEntries", c.header.TotalEntries, "entryNum", entryNum)
 
 			// For X Layer, fix ds receive issue


### PR DESCRIPTION
## Summary

- This PR fixes the issue: https://github.com/okx/xlayer-erigon/issues/464#issuecomment-2840618295
- The issue arises when block time is very small, the datastream server/relayer total file entries increase at a much faster rate. This causes the server header information when retrieved to be potentially in the midst of a ds sync with the sequencer, causing the header total file entries to potentially be at an inner file entry number
- This becomes an issue because the ds client only breaks out of the connection loop if the file entry number matches the current entryNum + 1. Thus it endlessly gets stuck inside the download loop once the entryNum can never match the total entries number obtained from the server header information