### PR TITLE
Add configure for the batch counter limit percentage

### DIFF
--- a/cmd/utils/flags_xlayer.go
+++ b/cmd/utils/flags_xlayer.go
@@ -308,6 +308,11 @@ var (
 		Usage: "Max block seal time. Defaults to 6s",
 		Value: "6s",
 	}
+	SequencerBatchCounterPercentage = cli.IntFlag{
+		Name:  "zkevm.sequencer-batch-counter-percentage",
+		Usage: "Percentage of the sequencer's counter to be used for the batch",
+		Value: 100,
+	}
 )
 
 func setGPOXLayer(ctx *cli.Context, cfg *gaspricecfg.Config) {

--- a/core/vm/zk_counters_limits.go
+++ b/core/vm/zk_counters_limits.go
@@ -114,7 +114,8 @@ func getTotalSteps(forkId uint16) int {
 	// we need to remove some steps as these will always be used during batch execution
 	totalSteps -= stepDeduction
 
-	return totalSteps
+	// X Layer is using counterPercentage of the limits
+	return rewriteTotalSteps(totalSteps)
 }
 
 func applyDeduction(fork uint16, input int) int {

--- a/core/vm/zk_counters_limits_xlayer.go
+++ b/core/vm/zk_counters_limits_xlayer.go
@@ -1,0 +1,29 @@
+package vm
+
+import (
+	"fmt"
+)
+
+const (
+	MinPercentage = 20
+	MaxPercentage = 100
+)
+
+var (
+	gCounterLimitPercentage = 100
+)
+
+func rewriteTotalSteps(totalSteps int) int {
+	percentage := float64(gCounterLimitPercentage) / 100.0
+	return int(float64(totalSteps) * percentage)
+}
+
+func SetBatchCounterLimitPercentage(factor int) error {
+	if factor < MinPercentage || factor > MaxPercentage {
+		return fmt.Errorf("counter limits percentage should be between %d and %d", MinPercentage, MaxPercentage)
+	}
+
+	gCounterLimitPercentage = factor
+
+	return nil
+}

--- a/core/vm/zk_counters_limits_xlayer_test.go
+++ b/core/vm/zk_counters_limits_xlayer_test.go
@@ -1,0 +1,48 @@
+package vm
+
+import (
+	"testing"
+)
+
+func TestSetBatchCounterLimitPercentage(t *testing.T) {
+	tests := []struct {
+		input       int
+		expectError bool
+	}{
+		{50, false},
+		{20, false},
+		{100, false},
+		{10, true},
+		{110, true},
+	}
+
+	for _, tt := range tests {
+		err := SetBatchCounterLimitPercentage(tt.input)
+		if tt.expectError && err == nil {
+			t.Errorf("expected error for input %d, got nil", tt.input)
+		}
+		if !tt.expectError && err != nil {
+			t.Errorf("did not expect error for input %d, got %v", tt.input, err)
+		}
+	}
+}
+
+func TestRewriteTotalSteps(t *testing.T) {
+	_ = SetBatchCounterLimitPercentage(50)
+	total := 200
+	expected := 100
+
+	result := rewriteTotalSteps(total)
+	if result != expected {
+		t.Errorf("expected %d, got %d", expected, result)
+	}
+
+	_ = SetBatchCounterLimitPercentage(25)
+	total = 400
+	expected = 100
+
+	result = rewriteTotalSteps(total)
+	if result != expected {
+		t.Errorf("expected %d, got %d", expected, result)
+	}
+}

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -351,6 +351,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.EnableAddTxNotify,
 	&utils.SequencerSkipEmptyBlocks,
 	&utils.SequencerMaxBlockSealTime,
+	&utils.SequencerBatchCounterPercentage,
 
 	&utils.ACLPrintHistory,
 	&utils.InfoTreeUpdateInterval,

--- a/turbo/cli/flags_xlayer.go
+++ b/turbo/cli/flags_xlayer.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ledgerwatch/erigon/cmd/utils"
+	"github.com/ledgerwatch/erigon/core/vm"
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
 	"github.com/ledgerwatch/erigon/node/nodecfg"
 	"github.com/ledgerwatch/erigon/smt/pkg/blockinfo"
@@ -19,6 +20,12 @@ func ApplyFlagsForEthXLayerConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 	sequencerMaxBlockSealTime, err := time.ParseDuration(sequencerMaxBlockSealTimeVal)
 	if err != nil || sequencerBlockSealTime > sequencerMaxBlockSealTime || sequencerMaxBlockSealTime > sequencerBatchSealTime {
 		panic(fmt.Sprintf("Got error: %v, sequencer-block-seal-time: %s, sequencer-max-block-seal-time: %s, sequencer-batch-seal-time: %s", err, sequencerBlockSealTime, sequencerMaxBlockSealTime, sequencerBatchSealTime))
+	}
+
+	sequencerBatchCounterPercentage := ctx.Int(utils.SequencerBatchCounterPercentage.Name)
+	err = vm.SetBatchCounterLimitPercentage(sequencerBatchCounterPercentage)
+	if err != nil {
+		panic(fmt.Sprintf("Got error: %v, sequencer-batch-counter-percentage: %d", err, sequencerBatchCounterPercentage))
 	}
 
 	cfg.XLayer = ethconfig.XLayerConfig{


### PR DESCRIPTION
# Backgroud
In order to decrease the latecy for the RPC, we introduce a configure to decrease the zkp counters.