### PR TITLE
Support DS block range download in RPC sync

### DIFF
--- a/zk/datastream/client/commands.go
+++ b/zk/datastream/client/commands.go
@@ -9,6 +9,7 @@ const (
 	CmdStartBookmark // CmdStartBookmark for the start from bookmark TCP client command
 	CmdEntry         // CmdEntry for the get entry TCP client command
 	CmdBookmark      // CmdBookmark for the get bookmark TCP client command
+	CmdRangeBookmark // CmdRangeBookmark for the start and end bookmarks TCP client command
 )
 
 // sendHeaderCmd sends the header command to the server.
@@ -37,6 +38,33 @@ func (c *StreamClient) sendBookmarkCmd(bookmark []byte, streaming bool) error {
 
 	// Send the bookmark to retrieve
 	return c.writeToConn(bookmark)
+}
+
+// sendRangeBookmarkCmd sends the CmdRangeBookmark with the start and end bookmark value.
+func (c *StreamClient) sendRangeBookmarkCmd(startBookmark []byte, endBookmark []byte) error {
+	command := CmdRangeBookmark
+	// Send the command
+	if err := c.sendCommand(command); err != nil {
+		return err
+	}
+
+	// Send start bookmark
+	if err := c.writeToConn(uint32(len(startBookmark))); err != nil {
+		return err
+	}
+	if err := c.writeToConn(startBookmark); err != nil {
+		return err
+	}
+
+	// Send end bookmark
+	if err := c.writeToConn(uint32(len(endBookmark))); err != nil {
+		return err
+	}
+	if err := c.writeToConn(endBookmark); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // sendStartCmd sends a start command to the server, indicating

--- a/zk/datastream/client/stream_client.go
+++ b/zk/datastream/client/stream_client.go
@@ -493,6 +493,46 @@ func (c *StreamClient) readAllEntriesToChannel() (err error) {
 	return
 }
 
+// Get all entries from the DS server from the current stage progress until to block number,
+// and sends the data into FllL2Blocks with transactions into the channel.
+func (c *StreamClient) ReadRangeEntriesToChannel(to uint64) (err error) {
+	defer func() {
+		if err != nil {
+			c.lastError = err
+		}
+	}()
+	select {
+	case <-c.ctx.Done():
+		return fmt.Errorf("context done - stopping")
+	default:
+	}
+
+	if err = c.readRangeEntriesToChannel(to); err != nil {
+		return fmt.Errorf("readRangeEntriesToChannel: %w", err)
+	}
+
+	return
+}
+
+func (c *StreamClient) readRangeEntriesToChannel(to uint64) error {
+	c.stopReadingToChannel.Store(false)
+
+	// Send start command
+	toEntry, err := c.initiateRangeDownload(to)
+	if err != nil {
+		return err
+	}
+
+	err = c.readRangeFullL2BlocksToChannel(toEntry)
+	c.setStreaming(false)
+
+	if err != nil {
+		return fmt.Errorf("readRangeFullL2BlocksToChannel: %w", err)
+	}
+
+	return nil
+}
+
 // runs the prerequisites for entries download
 func (c *StreamClient) initiateDownloadBookmark(bookmark []byte) (*types.ResultEntry, error) {
 	if err := c.stopStreaming(); err != nil {
@@ -502,6 +542,27 @@ func (c *StreamClient) initiateDownloadBookmark(bookmark []byte) (*types.ResultE
 	// send CmdStartBookmark command
 	if err := c.sendBookmarkCmd(bookmark, true); err != nil {
 		return nil, fmt.Errorf("sendBookmarkCmd: %w", err)
+	}
+
+	c.setStreaming(true)
+
+	re, err := c.afterStartCommand()
+	if err != nil {
+		return re, fmt.Errorf("afterStartCommand: %w", err)
+	}
+
+	return re, nil
+}
+
+// Runs the prerequisites for range entries download (excluding end)
+func (c *StreamClient) initiateRangeDownloadBookmark(startBookmark []byte, endBookmark []byte) (*types.ResultEntry, error) {
+	if err := c.stopStreaming(); err != nil {
+		return nil, fmt.Errorf("stopStreaming: %w", err)
+	}
+
+	// send CmdStartBookmark command
+	if err := c.sendRangeBookmarkCmd(startBookmark, endBookmark); err != nil {
+		return nil, fmt.Errorf("sendRangeBookmarkCmd: %w", err)
 	}
 
 	c.setStreaming(true)
@@ -545,7 +606,7 @@ LOOP:
 			if parsedProto, entryNum, err = ReadParsedProto(c); err != nil {
 				// For X Layer, fix ds receive issue
 				if err == ErrReachedEntryNumberLimit {
-					return c.trySendStopSignal()
+					return c.TrySendStopSignal()
 				}
 				return err
 			}
@@ -574,11 +635,11 @@ LOOP:
 			time.Sleep(10 * time.Microsecond)
 		}
 
-		if c.header.TotalEntries < entryNum {
+		if c.header.TotalEntries <= entryNum {
 			log.Trace("[Datastream client] reached the current end of the stream", "header_totalEntries", c.header.TotalEntries, "entryNum", entryNum)
 
 			// For X Layer, fix ds receive issue
-			if err := c.trySendStopSignal(); err != nil {
+			if err := c.TrySendStopSignal(); err != nil {
 				return err
 			}
 			break LOOP
@@ -588,8 +649,106 @@ LOOP:
 	return nil
 }
 
-// For X Layer, fix ds receive issue
-func (c *StreamClient) trySendStopSignal() error {
+// Read all entries from the server until the end of the range toBlock.
+// Parses the data into FullL2Blocks with transactions and sends them to a channel
+func (c *StreamClient) readRangeFullL2BlocksToChannel(toEntry uint64) (err error) {
+	readNewProto := true
+	entryNum := uint64(0)
+	parsedProto := interface{}(nil)
+LOOP:
+	for {
+		select {
+		default:
+		case <-c.ctx.Done():
+			return fmt.Errorf("context done - stopping")
+		}
+
+		if c.stopReadingToChannel.Load() {
+			break LOOP
+		}
+
+		if err := c.resetReadTimeout(); err != nil {
+			return err
+		}
+
+		if readNewProto {
+			if parsedProto, entryNum, err = ReadParsedProto(c); err != nil {
+				if err == ErrReachedEntryNumberLimit {
+					return c.TrySendStopSignal()
+				}
+				return err
+			}
+			readNewProto = false
+		}
+		c.lastWrittenTime.Store(time.Now().UnixNano())
+
+		switch parsedProto := parsedProto.(type) {
+		case *types.BookmarkProto:
+			readNewProto = true
+			continue
+		case *types.BatchStart:
+			c.currentFork = parsedProto.ForkId
+		case *types.GerUpdate:
+		case *types.BatchEnd:
+		case *types.FullL2Block:
+			parsedProto.ForkId = c.currentFork
+			log.Trace("[Datastream client] writing block to channel", "blockNumber", parsedProto.L2BlockNumber, "batchNumber", parsedProto.BatchNumber)
+		default:
+			return fmt.Errorf("unexpected entry type: %v", parsedProto)
+		}
+		select {
+		case c.entryChan <- parsedProto:
+			readNewProto = true
+		default:
+			time.Sleep(10 * time.Microsecond)
+		}
+
+		// Reach the end of range
+		if entryNum == toEntry || c.header.TotalEntries <= entryNum+1 {
+			log.Trace("[Datastream client] reached the current end of the stream", "header_totalEntries", c.header.TotalEntries, "entryNum", entryNum)
+
+			if err := c.TrySendStopSignal(); err != nil {
+				return err
+			}
+			break LOOP
+		}
+	}
+
+	return nil
+}
+
+func (c *StreamClient) initiateRangeDownload(to uint64) (uint64, error) {
+	var start *types.BookmarkProto
+	progress := c.progress.Load()
+	if progress == 0 {
+		start = types.NewBookmarkProto(0, datastream.BookmarkType_BOOKMARK_TYPE_BATCH)
+	} else {
+		start = types.NewBookmarkProto(progress+1, datastream.BookmarkType_BOOKMARK_TYPE_L2_BLOCK)
+	}
+
+	sb, err := start.Marshal()
+	if err != nil {
+		return 0, err
+	}
+
+	end := types.NewBookmarkProto(to, datastream.BookmarkType_BOOKMARK_TYPE_L2_BLOCK)
+	eb, err := end.Marshal()
+	if err != nil {
+		return 0, err
+	}
+
+	if _, err := c.initiateRangeDownloadBookmark(sb, eb); err != nil {
+		return 0, fmt.Errorf("initiateRangeDownloadBookmark: %w", err)
+	}
+
+	packet, err := c.readBuffer(8)
+	if err != nil {
+		return 0, err
+	}
+	return types.UnmarshalToEntryNumber(packet)
+}
+
+func (c *StreamClient) TrySendStopSignal() error {
 	retries := 0
 	for {
 		select {
@@ -626,6 +785,10 @@ func (c *StreamClient) HandleStart() error {
 	}
 
 	return nil
+}
+
+func (c *StreamClient) HandleRestart() error {
+	return c.tryReConnect()
 }
 
 func (c *StreamClient) tryReConnect() (err error) {

--- a/zk/datastream/types/file.go
+++ b/zk/datastream/types/file.go
@@ -97,3 +97,7 @@ func DecodeFileEntry(b []byte) (*FileEntry, error) {
 		Data:       data,
 	}, nil
 }
+
+func UnmarshalToEntryNumber(data []byte) (uint64, error) {
+	return binary.BigEndian.Uint64(data[:8]), nil
+}

--- a/zk/stages/stage_batches.go
+++ b/zk/stages/stage_batches.go
@@ -61,14 +61,18 @@ type HermezDb interface {
 type DatastreamClient interface {
 	RenewEntryChannel()
 	ReadAllEntriesToChannel() error
+	ReadRangeEntriesToChannel(to uint64) error
 	StopReadingToChannel()
 	GetEntryChan() *chan interface{}
+	GetHeader() (*types.HeaderEntry, error)
 	GetL2BlockByNumber(blockNum uint64) (*types.FullL2Block, error)
 	GetLatestL2Block() (*types.FullL2Block, error)
 	GetProgressAtomic() *atomic.Uint64
 	Start() error
 	Stop() error
 	HandleStart() error
+	HandleRestart() error
+	TrySendStopSignal() error
 }
 
 type dsClientCreatorHandler func(context.Context, *ethconfig.Zk, uint64) (DatastreamClient, error)
@@ -278,13 +282,16 @@ func SpawnStageBatches(
 		return fmt.Errorf("NewBatchesProcessor: %w", err)
 	}
 
-	// start routine to download blocks and push them in a channel
+	// Set maximum block range to be 50% of the entry channel capacity
+	dsQueryClient.RenewEntryChannel()
+	entryChan := dsQueryClient.GetEntryChan()
+	blockRange := uint64(cap(*entryChan) / 2)
+
+	// start routine to download blocks and push them to the channel
 	errorChan := make(chan struct{})
 	dsClientRunner := NewDatastreamClientRunner(dsQueryClient, logPrefix)
-	dsClientRunner.StartRead(errorChan)
+	dsClientRunner.StartRangeRead(errorChan, highestDSL2Block, blockRange)
 	defer dsClientRunner.StopRead()
-
-	entryChan := dsQueryClient.GetEntryChan()
 
 	prevAmountBlocksWritten := uint64(0)
 	endLoop := false

--- a/zk/stages/stage_batches_datastream.go
+++ b/zk/stages/stage_batches_datastream.go
@@ -5,8 +5,9 @@ import (
 	"math/rand"
 	"sync/atomic"
 
-	"github.com/ledgerwatch/log/v3"
 	"time"
+
+	"github.com/ledgerwatch/log/v3"
 )
 
 type DatastreamClientRunner struct {
@@ -24,7 +25,6 @@ func NewDatastreamClientRunner(dsClient DatastreamClient, logPrefix string) *Dat
 }
 
 func (r *DatastreamClientRunner) StartRead(errorChan chan struct{}) error {
-	r.dsClient.RenewEntryChannel()
 	if r.isReading.Load() {
 		return fmt.Errorf("tried starting datastream client runner thread while another is running")
 	}
@@ -44,6 +44,72 @@ func (r *DatastreamClientRunner) StartRead(errorChan chan struct{}) error {
 			time.Sleep(1 * time.Second)
 			errorChan <- struct{}{}
 			log.Warn(fmt.Sprintf("[%s] Error downloading blocks from datastream", r.logPrefix), "error", err)
+		}
+	}()
+
+	return nil
+}
+
+func (r *DatastreamClientRunner) StartRangeRead(
+	errorChan chan struct{},
+	highestDSL2Block uint64,
+	blockRange uint64,
+) error {
+	if r.isReading.Load() {
+		return fmt.Errorf("tried starting datastream client runner thread while another is running")
+	}
+
+	r.stopRunner.Store(false)
+
+	entryChan := r.dsClient.GetEntryChan()
+
+	go func() {
+		routineId := rand.Intn(1000000)
+
+		log.Info(fmt.Sprintf("[%s] Started downloading L2Blocks routine ID: %d", r.logPrefix, routineId))
+		defer log.Info(fmt.Sprintf("[%s] Ended downloading L2Blocks routine ID: %d", r.logPrefix, routineId))
+
+		r.isReading.Store(true)
+		defer r.isReading.Store(false)
+
+		// first load up the header of the stream
+		if _, err := r.dsClient.GetHeader(); err != nil {
+			errorChan <- struct{}{}
+			log.Warn(fmt.Sprintf("[%s] Error getting block header from datastream", r.logPrefix), "error", err)
+			return
+		}
+
+		progress := r.dsClient.GetProgressAtomic()
+		for !r.stopRunner.Load() {
+			// Wait until all entries in entryChan is consumed
+			for len(*entryChan) > 0 {
+				time.Sleep(100 * time.Millisecond)
+				if r.stopRunner.Load() {
+					return
+				}
+			}
+
+			from := progress.Load()
+			if from >= highestDSL2Block {
+				return
+			}
+
+			to := min(from+blockRange, highestDSL2Block)
+			r.dsClient.HandleRestart()
+			if err := r.dsClient.ReadRangeEntriesToChannel(to); err != nil {
+				time.Sleep(1 * time.Second)
+				errorChan <- struct{}{}
+				log.Warn(fmt.Sprintf("[%s] Error downloading blocks from datastream", r.logPrefix), "error", err)
+				return
+			}
+		}
+
+		// Send stop signal
+		if err := r.dsClient.TrySendStopSignal(); err != nil {
+			time.Sleep(1 * time.Second)
+			errorChan <- struct{}{}
+			log.Warn(fmt.Sprintf("[%s] Error sending stop signal", r.logPrefix), "error", err)
+			return
 		}
 	}()
 

--- a/zk/stages/test_utils.go
+++ b/zk/stages/test_utils.go
@@ -51,6 +51,10 @@ func (c *TestDatastreamClient) ReadAllEntriesToChannel() error {
 	return nil
 }
 
+func (c *TestDatastreamClient) ReadRangeEntriesToChannel(from uint64, to uint64) error {
+	return nil
+}
+
 func (c *TestDatastreamClient) RenewEntryChannel() {
 }
 
@@ -60,6 +64,10 @@ func (c *TestDatastreamClient) StopReadingToChannel() {
 
 func (c *TestDatastreamClient) GetEntryChan() *chan interface{} {
 	return &c.entriesChan
+}
+
+func (c *TestDatastreamClient) GetHeader() (*types.HeaderEntry, error) {
+	return nil, nil
 }
 
 func (c *TestDatastreamClient) GetErrChan() chan error {
@@ -110,5 +118,13 @@ func (c *TestDatastreamClient) PrepUnwind() {
 }
 
 func (c *TestDatastreamClient) HandleStart() error {
+	return nil
+}
+
+func (c *TestDatastreamClient) HandleRestart() error {
+	return nil
+}
+
+func (c *TestDatastreamClient) TrySendStopSignal() error {
 	return nil
 }


### PR DESCRIPTION
## Summary

- Cherry-pick PR: https://github.com/0xPolygonHermez/cdk-erigon/pull/1857
- For more context, refer to the upstream PR
- Tested to be fully compatible and working with the DS fixes with https://github.com/okx/xlayer-data-streamer/pull/12