### PR TITLE
Fix ds download rpc

### DIFF
--- a/zk/datastream/client/stream_client.go
+++ b/zk/datastream/client/stream_client.go
@@ -574,7 +574,7 @@ LOOP:
 			time.Sleep(10 * time.Microsecond)
 		}
 
-		if c.header.TotalEntries < entryNum {
+		if c.header.TotalEntries <= entryNum+1 {
 			log.Trace("[Datastream client] reached the current end of the stream", "header_totalEntries", c.header.TotalEntries, "entryNum", entryNum)
 
 			// For X Layer, fix ds receive issue


### PR DESCRIPTION
## Summary

- Fixes issue: https://github.com/okx/xlayer-erigon/issues/487
- Previous RPC entryNum check was incorrect, skipping the header totalEntries number. Thus the DS download is stuck in a second loop of download, until the next block from the sequencer is added