### PR TITLE
Refactor tx pool

### DIFF
--- a/zk/txpool/pool.go
+++ b/zk/txpool/pool.go
@@ -717,12 +717,14 @@ func (p *TxPool) ResetYieldedStatus() {
 }
 
 func (p *TxPool) YieldBest(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableGas, availableBlobGas uint64, toSkip mapset.Set[[32]byte]) (bool, int, error) {
-	return p.best(n, txs, tx, onTopOf, availableGas, availableBlobGas, toSkip)
+	// For X Layer
+	return p.bestForXLayer(n, txs, tx, onTopOf, availableGas, availableBlobGas, toSkip)
 }
 
 func (p *TxPool) PeekBest(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableGas, availableBlobGas uint64) (bool, error) {
 	set := mapset.NewThreadUnsafeSet[[32]byte]()
-	onTime, _, err := p.best(n, txs, tx, onTopOf, availableGas, availableBlobGas, set)
+	// For X Layer
+	onTime, _, err := p.bestForXLayer(n, txs, tx, onTopOf, availableGas, availableBlobGas, set)
 	return onTime, err
 }
 

--- a/zk/txpool/pool_xlayer.go
+++ b/zk/txpool/pool_xlayer.go
@@ -6,8 +6,13 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
+	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/common/cmp"
+	"github.com/ledgerwatch/erigon-lib/common/fixedgas"
+	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon-lib/types"
 	ecommon "github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/eth/ethconfig"
@@ -65,6 +70,133 @@ type GPCache interface {
 	SetLatest(hash common.Hash, price *big.Int)
 	GetLatestRawGP() *big.Int
 	SetLatestRawGP(rgp *big.Int)
+}
+
+func (p *TxPool) bestForXLayer(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableGas, availableBlobGas uint64, toSkip mapset.Set[[32]byte]) (bool, int, error) {
+	removeWG.Wait()
+	ok, count, toRemove, err := p.bestRead(n, txs, tx, onTopOf, availableGas, availableBlobGas, toSkip)
+	if err != nil {
+		return ok, count, err
+	}
+	if !ok {
+		return false, count, nil
+	}
+	txs.Resize(uint(count))
+	if len(toRemove) > 0 {
+		removeWG.Add(1)
+		go func() {
+			p.lock.Lock()
+			defer p.lock.Unlock()
+			removeWG.Done()
+			for _, mt := range toRemove {
+				p.pending.Remove(mt)
+				p.discardLocked(mt, UnsupportedTx)
+				//log.Debug("Removed transaction from pending pool", "txID", mt.Tx.IDHash)
+			}
+		}()
+		time.Sleep(1 * time.Nanosecond)
+	}
+
+	return true, count, nil
+}
+
+func (p *TxPool) bestRead(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableGas, availableBlobGas uint64, toSkip mapset.Set[[32]byte]) (bool, int, []*metaTx, error) {
+	if p.isDeniedYieldingTransactions() {
+		//log.Trace("Denied yielding transactions, cannot proceed")
+		return false, 0, nil, nil
+	}
+
+	// First wait for the corresponding block to arrive
+	if p.lastSeenBlock.Load() < onTopOf {
+		//log.Trace("Block not yet arrived, too early to process", "lastSeenBlock", p.lastSeenBlock.Load(), "requiredBlock", onTopOf)
+		return false, 0, nil, nil
+	}
+
+	isShanghai := p.isShanghai()
+	isLondon := p.isLondon()
+
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	best := p.pending.best
+
+	txs.Resize(uint(cmp.Min(int(n), len(best.ms))))
+	var toRemove []*metaTx
+	count := 0
+
+	p.pending.EnforceBestInvariants()
+
+	for i := 0; count < int(n) && i < len(best.ms); i++ {
+		// if we wouldn't have enough gas for a standard transaction then quit out early
+		if availableGas < fixedgas.TxGas {
+			break
+		}
+
+		mt := best.ms[i]
+		//log.Trace("Processing transaction", "txID", mt.Tx.IDHash)
+
+		if toSkip.Contains(mt.Tx.IDHash) {
+			//log.Trace("Skipping transaction, already in toSkip", "txID", mt.Tx.IDHash)
+			continue
+		}
+
+		if !isLondon && mt.Tx.Type == 0x2 {
+			// remove ldn txs when not in london
+			toRemove = append(toRemove, mt)
+			toSkip.Add(mt.Tx.IDHash)
+			//log.Info("Removing London transaction in non-London environment", "txID", mt.Tx.IDHash)
+			continue
+		}
+
+		if mt.Tx.Gas > transactionGasLimit {
+			// Skip transactions with very large gas limit, these shouldn't enter the pool at all
+			//log.Debug("found a transaction in the pending pool with too high gas for tx - clear the tx pool")
+			//log.Trace("Skipping transaction with too high gas", "txID", mt.Tx.IDHash, "gas", mt.Tx.Gas)
+			continue
+		}
+		rlpTx, sender, isLocal, err := p.getRlpLocked(tx, mt.Tx.IDHash[:])
+		if err != nil {
+			//log.Trace("Error getting RLP of transaction", "txID", mt.Tx.IDHash, "error", err)
+			return false, count, toRemove, err
+		}
+		if len(rlpTx) == 0 {
+			toRemove = append(toRemove, mt)
+			//log.Info("Removing transaction with empty RLP", "txID", common.BytesToHash(mt.Tx.IDHash[:]))
+			continue
+		}
+
+		// Skip transactions that require more blob gas than is available
+		blobCount := uint64(len(mt.Tx.BlobHashes))
+		if blobCount*fixedgas.BlobGasPerBlob > availableBlobGas {
+			//log.Trace("Skipping transaction due to insufficient blob gas", "txID", mt.Tx.IDHash, "requiredBlobGas", blobCount*fixedgas.BlobGasPerBlob, "availableBlobGas", availableBlobGas)
+			continue
+		}
+		availableBlobGas -= blobCount * fixedgas.BlobGasPerBlob
+
+		// make sure we have enough gas in the caller to add this transaction.
+		// not an exact science using intrinsic gas but as close as we could hope for at
+		// this stage
+		intrinsicGas, _ := CalcIntrinsicGas(uint64(mt.Tx.DataLen), uint64(mt.Tx.DataNonZeroLen), nil, mt.Tx.Creation, true, true, isShanghai)
+		if intrinsicGas > availableGas {
+			// we might find another TX with a low enough intrinsic gas to include so carry on
+			//log.Trace("Skipping transaction due to insufficient gas", "txID", mt.Tx.IDHash, "intrinsicGas", intrinsicGas, "availableGas", availableGas)
+			continue
+		}
+
+		if intrinsicGas <= availableGas { // check for potential underflow
+			availableGas -= intrinsicGas
+		}
+
+		//log.Trace("Including transaction", "txID", mt.Tx.IDHash)
+		txs.Txs[count] = rlpTx
+		txs.TxIds[count] = mt.Tx.IDHash
+		copy(txs.Senders.At(count), sender.Bytes())
+		txs.IsLocal[count] = isLocal
+		toSkip.Add(mt.Tx.IDHash)
+		count++
+	}
+
+	return true, count, toRemove, nil
 }
 
 func contains(addresses []common.Address, addr common.Address) bool {
@@ -214,7 +346,6 @@ func IsAcquireTxPoolLock() bool {
 	return requireTxPoolLock.Load()
 }
 
-// For X Layer, optimize tx pool
 func (p *PendingPool) RemoveNoLock(i *metaTx) {
 	if i.worstIndex >= 0 {
 		heap.Remove(p.worst, i.worstIndex)

--- a/zk/txpool/pool_zk.go
+++ b/zk/txpool/pool_zk.go
@@ -42,10 +42,18 @@ func (p *TxPool) onSenderStateChange(senderID uint64, senderNonce uint64, sender
 	minFeeCap := uint256.NewInt(0).SetAllOne()
 	minTip := uint64(math.MaxUint64)
 	var toDel []*metaTx // can't delete items while iterate them
+	// For X Layer, optimize tx pool
+	pending.mtx.Lock()
+
+	senderAddr := common.Address{}
+	freeType, gpMul := p.checkFreeGasSenderXLayer(senderID, &senderAddr)
+	findSenderOk := senderAddr != [20]byte{}
+
 	byNonce.ascend(senderID, func(mt *metaTx) bool {
 		if mt.Tx.Traced {
 			log.Info(fmt.Sprintf("TX TRACING: onSenderStateChange loop iteration idHash=%x senderID=%d, senderNonce=%d, txn.nonce=%d, currentSubPool=%s", mt.Tx.IDHash, senderID, senderNonce, mt.Tx.Nonce, mt.currentSubPool))
 		}
+		mt.subPool |= IsLocal
 		if senderNonce > mt.Tx.Nonce {
 			if mt.Tx.Traced {
 				log.Info(fmt.Sprintf("TX TRACING: removing due to low nonce for idHash=%x senderID=%d, senderNonce=%d, txn.nonce=%d, currentSubPool=%s", mt.Tx.IDHash, senderID, senderNonce, mt.Tx.Nonce, mt.currentSubPool))
@@ -53,7 +61,8 @@ func (p *TxPool) onSenderStateChange(senderID uint64, senderNonce uint64, sender
 			// del from sub-pool
 			switch mt.currentSubPool {
 			case PendingSubPool:
-				pending.Remove(mt)
+				// For X Layer, optimize tx pool
+				pending.RemoveNoLock(mt)
 			case BaseFeeSubPool:
 				baseFee.Remove(mt)
 			case QueuedSubPool:
@@ -73,6 +82,35 @@ func (p *TxPool) onSenderStateChange(senderID uint64, senderNonce uint64, sender
 		}
 		mt.minTip = minTip
 
+		// For X Layer
+		// free type:
+		// 0. not free
+		// 1. is claim tx;
+		// 2. new bridge account with the first few tx
+		// 3. special project
+		if findSenderOk && freeType == notFree {
+			freeType, gpMul = p.checkFreeGasTxXLayer(senderAddr, mt.Tx)
+		}
+		// parse claim tx or dex tx, and add the withdraw addr into free gas cache
+		p.setFreeGasByNonceCache(senderID, mt, freeType == claim)
+		if freeType > notFree {
+			// get dynamic gp
+			// here for the case when restart gpCache has not init
+			// use the max uint64 as default because the remain claimTx should handle first
+			var newGpBig uint64 = math.MaxUint64
+			if p.gpCache != nil {
+				dGp := p.gpCache.GetLatestPriceReadOnly()
+				if dGp != nil {
+					newGpBig = dGp.Uint64() * gpMul
+					// newGpBig = newGpBig.Mul(dGp, big.NewInt(int64(gpMul)))
+				}
+				//log.Debug(fmt.Sprintf("Free tx: nonce:%d, type %d. dGp:%v, factor:%d, newGp:%d", mt.Tx.Nonce, freeType, dGp, gpMul, newGpBig))
+			}
+
+			mt.minTip = newGpBig
+			mt.minFeeCap = *uint256.NewInt(mt.minTip)
+		}
+
 		mt.nonceDistance = 0
 		if mt.Tx.Nonce > senderNonce { // no uint underflow
 			mt.nonceDistance = mt.Tx.Nonce - senderNonce
@@ -86,7 +124,8 @@ func (p *TxPool) onSenderStateChange(senderID uint64, senderNonce uint64, sender
 		// parameter of minimal base fee. Set to 0 if feeCap is less than minimum base fee, which means
 		// this transaction will never be included into this particular chain.
 		mt.subPool &^= EnoughFeeCapProtocol
-		if mt.minFeeCap.Cmp(uint256.NewInt(protocolBaseFee)) >= 0 {
+		// For X Layer, optimize tx pool
+		if mt.minFeeCap.CmpUint64(protocolBaseFee) >= 0 {
 			mt.subPool |= EnoughFeeCapProtocol
 		} else {
 			mt.subPool = 0 // TODO: we immediately drop all transactions if they have no first bit - then maybe we don't need this bit at all? And don't add such transactions to queue?
@@ -134,7 +173,8 @@ func (p *TxPool) onSenderStateChange(senderID uint64, senderNonce uint64, sender
 		// Some fields of mt might have changed, need to fix the invariants in the subpool best and worst queues
 		switch mt.currentSubPool {
 		case PendingSubPool:
-			pending.Updated(mt)
+			// For X Layer, optimize tx pool
+			pending.UpdatedNoLock(mt)
 		case BaseFeeSubPool:
 			baseFee.Updated(mt)
 		case QueuedSubPool:
@@ -142,6 +182,8 @@ func (p *TxPool) onSenderStateChange(senderID uint64, senderNonce uint64, sender
 		}
 		return true
 	})
+	// For X Layer, optimize tx pool
+	pending.mtx.Unlock()
 	for _, mt := range toDel {
 		discard(mt, NonceTooLow)
 	}
@@ -281,41 +323,32 @@ func (p *TxPool) MarkForDiscardFromPendingBest(txHash common.Hash) {
 }
 
 func (p *TxPool) RemoveMinedTransactions(ctx context.Context, tx kv.Tx, blockGasLimit uint64, ids []common.Hash) error {
-	cache := p.cache()
-
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	toDelete := make([]*metaTx, 0)
-
-	p.all.ascendAll(func(mt *metaTx) bool {
-		for _, id := range ids {
-			if bytes.Equal(mt.Tx.IDHash[:], id[:]) {
-				toDelete = append(toDelete, mt)
-				switch mt.currentSubPool {
-				case PendingSubPool:
-					p.pending.Remove(mt)
-				case BaseFeeSubPool:
-					p.baseFee.Remove(mt)
-				case QueuedSubPool:
-					p.queued.Remove(mt)
-				default:
-					//already removed
-				}
-			}
-		}
-		return true
-	})
-
+	// For X Layer, optimize tx pool
 	sendersWithChangedState := make(map[uint64]struct{})
-	for _, mt := range toDelete {
-		p.discardLocked(mt, Mined)
-		sendersWithChangedState[mt.Tx.SenderID] = struct{}{}
+	for _, id := range ids {
+		if mt, ok := p.byHash[string(id[:])]; ok {
+			sendersWithChangedState[mt.Tx.SenderID] = struct{}{}
+			switch mt.currentSubPool {
+			case PendingSubPool:
+				p.pending.Remove(mt)
+			case BaseFeeSubPool:
+				p.baseFee.Remove(mt)
+			case QueuedSubPool:
+				p.queued.Remove(mt)
+			default:
+				//already removed
+			}
+			p.discardLocked(mt, Mined)
+		}
 	}
 
 	baseFee := p.pendingBaseFee.Load()
 
-	cacheView, err := cache.View(ctx, tx)
+	// For X Layer, optimize tx pool
+	cacheView, err := p._stateCache.View(ctx, tx)
 	if err != nil {
 		return err
 	}

--- a/zk/txpool/pool_zk.go
+++ b/zk/txpool/pool_zk.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/holiman/uint256"
@@ -43,18 +42,10 @@ func (p *TxPool) onSenderStateChange(senderID uint64, senderNonce uint64, sender
 	minFeeCap := uint256.NewInt(0).SetAllOne()
 	minTip := uint64(math.MaxUint64)
 	var toDel []*metaTx // can't delete items while iterate them
-	// For X Layer, optimize tx pool
-	pending.mtx.Lock()
-
-	senderAddr := common.Address{}
-	freeType, gpMul := p.checkFreeGasSenderXLayer(senderID, &senderAddr)
-	findSenderOk := senderAddr != [20]byte{}
-
 	byNonce.ascend(senderID, func(mt *metaTx) bool {
 		if mt.Tx.Traced {
 			log.Info(fmt.Sprintf("TX TRACING: onSenderStateChange loop iteration idHash=%x senderID=%d, senderNonce=%d, txn.nonce=%d, currentSubPool=%s", mt.Tx.IDHash, senderID, senderNonce, mt.Tx.Nonce, mt.currentSubPool))
 		}
-		mt.subPool |= IsLocal
 		if senderNonce > mt.Tx.Nonce {
 			if mt.Tx.Traced {
 				log.Info(fmt.Sprintf("TX TRACING: removing due to low nonce for idHash=%x senderID=%d, senderNonce=%d, txn.nonce=%d, currentSubPool=%s", mt.Tx.IDHash, senderID, senderNonce, mt.Tx.Nonce, mt.currentSubPool))
@@ -62,8 +53,7 @@ func (p *TxPool) onSenderStateChange(senderID uint64, senderNonce uint64, sender
 			// del from sub-pool
 			switch mt.currentSubPool {
 			case PendingSubPool:
-				// For X Layer, optimize tx pool
-				pending.RemoveNoLock(mt)
+				pending.Remove(mt)
 			case BaseFeeSubPool:
 				baseFee.Remove(mt)
 			case QueuedSubPool:
@@ -83,35 +73,6 @@ func (p *TxPool) onSenderStateChange(senderID uint64, senderNonce uint64, sender
 		}
 		mt.minTip = minTip
 
-		// For X Layer
-		// free type:
-		// 0. not free
-		// 1. is claim tx;
-		// 2. new bridge account with the first few tx
-		// 3. special project
-		if findSenderOk && freeType == notFree {
-			freeType, gpMul = p.checkFreeGasTxXLayer(senderAddr, mt.Tx)
-		}
-		// parse claim tx or dex tx, and add the withdraw addr into free gas cache
-		p.setFreeGasByNonceCache(senderID, mt, freeType == claim)
-		if freeType > notFree {
-			// get dynamic gp
-			// here for the case when restart gpCache has not init
-			// use the max uint64 as default because the remain claimTx should handle first
-			var newGpBig uint64 = math.MaxUint64
-			if p.gpCache != nil {
-				dGp := p.gpCache.GetLatestPriceReadOnly()
-				if dGp != nil {
-					newGpBig = dGp.Uint64() * gpMul
-					// newGpBig = newGpBig.Mul(dGp, big.NewInt(int64(gpMul)))
-				}
-				//log.Debug(fmt.Sprintf("Free tx: nonce:%d, type %d. dGp:%v, factor:%d, newGp:%d", mt.Tx.Nonce, freeType, dGp, gpMul, newGpBig))
-			}
-
-			mt.minTip = newGpBig
-			mt.minFeeCap = *uint256.NewInt(mt.minTip)
-		}
-
 		mt.nonceDistance = 0
 		if mt.Tx.Nonce > senderNonce { // no uint underflow
 			mt.nonceDistance = mt.Tx.Nonce - senderNonce
@@ -125,8 +86,7 @@ func (p *TxPool) onSenderStateChange(senderID uint64, senderNonce uint64, sender
 		// parameter of minimal base fee. Set to 0 if feeCap is less than minimum base fee, which means
 		// this transaction will never be included into this particular chain.
 		mt.subPool &^= EnoughFeeCapProtocol
-		// For X Layer, optimize tx pool
-		if mt.minFeeCap.CmpUint64(protocolBaseFee) >= 0 {
+		if mt.minFeeCap.Cmp(uint256.NewInt(protocolBaseFee)) >= 0 {
 			mt.subPool |= EnoughFeeCapProtocol
 		} else {
 			mt.subPool = 0 // TODO: we immediately drop all transactions if they have no first bit - then maybe we don't need this bit at all? And don't add such transactions to queue?
@@ -174,8 +134,7 @@ func (p *TxPool) onSenderStateChange(senderID uint64, senderNonce uint64, sender
 		// Some fields of mt might have changed, need to fix the invariants in the subpool best and worst queues
 		switch mt.currentSubPool {
 		case PendingSubPool:
-			// For X Layer, optimize tx pool
-			pending.UpdatedNoLock(mt)
+			pending.Updated(mt)
 		case BaseFeeSubPool:
 			baseFee.Updated(mt)
 		case QueuedSubPool:
@@ -183,8 +142,6 @@ func (p *TxPool) onSenderStateChange(senderID uint64, senderNonce uint64, sender
 		}
 		return true
 	})
-	// For X Layer, optimize tx pool
-	pending.mtx.Unlock()
 	for _, mt := range toDel {
 		discard(mt, NonceTooLow)
 	}
@@ -193,54 +150,23 @@ func (p *TxPool) onSenderStateChange(senderID uint64, senderNonce uint64, sender
 // zk: the implementation of best here is changed only to not take into account block gas limits as we don't care about
 // these in zk.  Instead we do a quick check on the transaction maximum gas in zk
 func (p *TxPool) best(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableGas, availableBlobGas uint64, toSkip mapset.Set[[32]byte]) (bool, int, error) {
-	// For X Layer, optimize tx pool
-	removeWG.Wait()
-	ok, count, toRemove, err := p.bestRead(n, txs, tx, onTopOf, availableGas, availableBlobGas, toSkip)
-	if err != nil {
-		return ok, count, err
-	}
-	if !ok {
-		return false, count, nil
-	}
-	txs.Resize(uint(count))
-	if len(toRemove) > 0 {
-		removeWG.Add(1)
-		go func() {
-			p.lock.Lock()
-			defer p.lock.Unlock()
-			removeWG.Done()
-			for _, mt := range toRemove {
-				p.pending.Remove(mt)
-				p.discardLocked(mt, UnsupportedTx)
-				//log.Debug("Removed transaction from pending pool", "txID", mt.Tx.IDHash)
-			}
-		}()
-		time.Sleep(1 * time.Nanosecond)
-	}
+	p.lock.Lock()
+	defer p.lock.Unlock()
 
-	return true, count, nil
-}
-
-// For X Layer, optimize tx pool
-func (p *TxPool) bestRead(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availableGas, availableBlobGas uint64, toSkip mapset.Set[[32]byte]) (bool, int, []*metaTx, error) {
 	if p.isDeniedYieldingTransactions() {
-		//log.Trace("Denied yielding transactions, cannot proceed")
-		return false, 0, nil, nil
+		log.Trace("Denied yielding transactions, cannot proceed")
+		return false, 0, nil
 	}
 
 	// First wait for the corresponding block to arrive
 	if p.lastSeenBlock.Load() < onTopOf {
-		//log.Trace("Block not yet arrived, too early to process", "lastSeenBlock", p.lastSeenBlock.Load(), "requiredBlock", onTopOf)
-		return false, 0, nil, nil
+		log.Trace("Block not yet arrived, too early to process", "lastSeenBlock", p.lastSeenBlock.Load(), "requiredBlock", onTopOf)
+		return false, 0, nil
 	}
 
 	isShanghai := p.isShanghai()
 	isLondon := p.isLondon()
-
-	// For X Layer, optimize tx pool
-	p.lock.RLock()
-	defer p.lock.RUnlock()
-
+	_ = isLondon
 	best := p.pending.best
 
 	txs.Resize(uint(cmp.Min(int(n), len(best.ms))))
@@ -256,10 +182,10 @@ func (p *TxPool) bestRead(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availa
 		}
 
 		mt := best.ms[i]
-		//log.Trace("Processing transaction", "txID", mt.Tx.IDHash)
+		log.Trace("Processing transaction", "txID", mt.Tx.IDHash)
 
 		if toSkip.Contains(mt.Tx.IDHash) {
-			//log.Trace("Skipping transaction, already in toSkip", "txID", mt.Tx.IDHash)
+			log.Trace("Skipping transaction, already in toSkip", "txID", mt.Tx.IDHash)
 			continue
 		}
 
@@ -267,32 +193,31 @@ func (p *TxPool) bestRead(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availa
 			// remove ldn txs when not in london
 			toRemove = append(toRemove, mt)
 			toSkip.Add(mt.Tx.IDHash)
-			//log.Info("Removing London transaction in non-London environment", "txID", mt.Tx.IDHash)
+			log.Info("Removing London transaction in non-London environment", "txID", mt.Tx.IDHash)
 			continue
 		}
 
 		if mt.Tx.Gas > transactionGasLimit {
 			// Skip transactions with very large gas limit, these shouldn't enter the pool at all
-			//log.Debug("found a transaction in the pending pool with too high gas for tx - clear the tx pool")
-			//log.Trace("Skipping transaction with too high gas", "txID", mt.Tx.IDHash, "gas", mt.Tx.Gas)
+			log.Debug("found a transaction in the pending pool with too high gas for tx - clear the tx pool")
+			log.Trace("Skipping transaction with too high gas", "txID", mt.Tx.IDHash, "gas", mt.Tx.Gas)
 			continue
 		}
 		rlpTx, sender, isLocal, err := p.getRlpLocked(tx, mt.Tx.IDHash[:])
 		if err != nil {
-			//log.Trace("Error getting RLP of transaction", "txID", mt.Tx.IDHash, "error", err)
-			// For X Layer, optimize tx pool
-			return false, count, toRemove, err
+			log.Trace("Error getting RLP of transaction", "txID", mt.Tx.IDHash, "error", err)
+			return false, count, err
 		}
 		if len(rlpTx) == 0 {
 			toRemove = append(toRemove, mt)
-			//log.Info("Removing transaction with empty RLP", "txID", common.BytesToHash(mt.Tx.IDHash[:]))
+			log.Info("Removing transaction with empty RLP", "txID", common.BytesToHash(mt.Tx.IDHash[:]))
 			continue
 		}
 
 		// Skip transactions that require more blob gas than is available
 		blobCount := uint64(len(mt.Tx.BlobHashes))
 		if blobCount*fixedgas.BlobGasPerBlob > availableBlobGas {
-			//log.Trace("Skipping transaction due to insufficient blob gas", "txID", mt.Tx.IDHash, "requiredBlobGas", blobCount*fixedgas.BlobGasPerBlob, "availableBlobGas", availableBlobGas)
+			log.Trace("Skipping transaction due to insufficient blob gas", "txID", mt.Tx.IDHash, "requiredBlobGas", blobCount*fixedgas.BlobGasPerBlob, "availableBlobGas", availableBlobGas)
 			continue
 		}
 		availableBlobGas -= blobCount * fixedgas.BlobGasPerBlob
@@ -303,7 +228,7 @@ func (p *TxPool) bestRead(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availa
 		intrinsicGas, _ := CalcIntrinsicGas(uint64(mt.Tx.DataLen), uint64(mt.Tx.DataNonZeroLen), nil, mt.Tx.Creation, true, true, isShanghai)
 		if intrinsicGas > availableGas {
 			// we might find another TX with a low enough intrinsic gas to include so carry on
-			//log.Trace("Skipping transaction due to insufficient gas", "txID", mt.Tx.IDHash, "intrinsicGas", intrinsicGas, "availableGas", availableGas)
+			log.Trace("Skipping transaction due to insufficient gas", "txID", mt.Tx.IDHash, "intrinsicGas", intrinsicGas, "availableGas", availableGas)
 			continue
 		}
 
@@ -311,7 +236,7 @@ func (p *TxPool) bestRead(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availa
 			availableGas -= intrinsicGas
 		}
 
-		//log.Trace("Including transaction", "txID", mt.Tx.IDHash)
+		log.Trace("Including transaction", "txID", mt.Tx.IDHash)
 		txs.Txs[count] = rlpTx
 		txs.TxIds[count] = mt.Tx.IDHash
 		copy(txs.Senders.At(count), sender.Bytes())
@@ -320,8 +245,15 @@ func (p *TxPool) bestRead(n uint16, txs *types.TxsRlp, tx kv.Tx, onTopOf, availa
 		count++
 	}
 
-	// For X Layer, optimize tx pool
-	return true, count, toRemove, nil
+	txs.Resize(uint(count))
+	if len(toRemove) > 0 {
+		for _, mt := range toRemove {
+			p.pending.Remove(mt)
+			p.discardLocked(mt, UnsupportedTx)
+			log.Debug("Removed transaction from pending pool", "txID", mt.Tx.IDHash)
+		}
+	}
+	return true, count, nil
 }
 
 func (p *TxPool) ForceUpdateLatestBlock(blockNumber uint64) {
@@ -349,32 +281,41 @@ func (p *TxPool) MarkForDiscardFromPendingBest(txHash common.Hash) {
 }
 
 func (p *TxPool) RemoveMinedTransactions(ctx context.Context, tx kv.Tx, blockGasLimit uint64, ids []common.Hash) error {
+	cache := p.cache()
+
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	// For X Layer, optimize tx pool
-	sendersWithChangedState := make(map[uint64]struct{})
-	for _, id := range ids {
-		if mt, ok := p.byHash[string(id[:])]; ok {
-			sendersWithChangedState[mt.Tx.SenderID] = struct{}{}
-			switch mt.currentSubPool {
-			case PendingSubPool:
-				p.pending.Remove(mt)
-			case BaseFeeSubPool:
-				p.baseFee.Remove(mt)
-			case QueuedSubPool:
-				p.queued.Remove(mt)
-			default:
-				//already removed
+	toDelete := make([]*metaTx, 0)
+
+	p.all.ascendAll(func(mt *metaTx) bool {
+		for _, id := range ids {
+			if bytes.Equal(mt.Tx.IDHash[:], id[:]) {
+				toDelete = append(toDelete, mt)
+				switch mt.currentSubPool {
+				case PendingSubPool:
+					p.pending.Remove(mt)
+				case BaseFeeSubPool:
+					p.baseFee.Remove(mt)
+				case QueuedSubPool:
+					p.queued.Remove(mt)
+				default:
+					//already removed
+				}
 			}
-			p.discardLocked(mt, Mined)
 		}
+		return true
+	})
+
+	sendersWithChangedState := make(map[uint64]struct{})
+	for _, mt := range toDelete {
+		p.discardLocked(mt, Mined)
+		sendersWithChangedState[mt.Tx.SenderID] = struct{}{}
 	}
 
 	baseFee := p.pendingBaseFee.Load()
 
-	// For X Layer, optimize tx pool
-	cacheView, err := p._stateCache.View(ctx, tx)
+	cacheView, err := cache.View(ctx, tx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- Cherry-pick from PR #472 
- Reverts the txpool best() method to the upstream repo, shift all X Layer optimizations into pool_xlayer
- Ensure no logic changes