### PR TITLE
Fix ds client handling incorrect header bytes

### DIFF
--- a/zk/datastream/client/stream_client.go
+++ b/zk/datastream/client/stream_client.go
@@ -360,6 +360,7 @@ func (c *StreamClient) GetHeader() (*types.HeaderEntry, error) {
 	}
 
 	c.header = h
+	log.Info("[Datastream client] getHeader", "header", c.header)
 
 	return h, nil
 }
@@ -522,6 +523,8 @@ func (c *StreamClient) afterStartCommand() (*types.ResultEntry, error) {
 // reads all entries from the server and sends them to a channel
 // sends the parsed FullL2Blocks with transactions to a channel
 func (c *StreamClient) readAllFullL2BlocksToChannel() (err error) {
+	log.Info("[Datastream client] reading full L2 blocks to channel", "header_totalEntries", c.header.TotalEntries)
+
 	readNewProto := true
 	entryNum := uint64(0)
 	parsedProto := interface{}(nil)

--- a/zk/datastream/client/stream_client.go
+++ b/zk/datastream/client/stream_client.go
@@ -845,6 +845,10 @@ func (c *StreamClient) readHeaderEntry() (h *types.HeaderEntry, err error) {
 	}
 
 	headLength := binary.BigEndian.Uint32(binaryHeader[1:5])
+	if headLength != types.HeaderSize && headLength != types.HeaderSizePreEtrog {
+		return h, fmt.Errorf("read header bytes error, unexpected header size: %d", headLength)
+	}
+
 	if headLength == types.HeaderSize {
 		// Read the rest of fixed size fields
 		buffer, err := c.readBuffer(types.HeaderSize - types.HeaderSizePreEtrog)


### PR DESCRIPTION
## Summary

- Fixes the issue that DS gets stuck, causing RPC to get stuck in the loop
- DS client reads the header bytes and decodes them incorrectly, causing total entries number to incorrectly have an extremely large value
- Resolves https://github.com/okx/xlayer-erigon/issues/464