### PR TITLE
RPC: Optimize node sync on new DS blocks

### DIFF
--- a/zk/stages/stage_batches.go
+++ b/zk/stages/stage_batches.go
@@ -228,6 +228,7 @@ func SpawnStageBatches(
 				return nil
 			}
 		}
+		// For X Layer
 		time.Sleep(5 * time.Millisecond)
 	}
 

--- a/zk/stages/stage_batches.go
+++ b/zk/stages/stage_batches.go
@@ -228,7 +228,7 @@ func SpawnStageBatches(
 				return nil
 			}
 		}
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(5 * time.Millisecond)
 	}
 
 	log.Debug(fmt.Sprintf("[%s] Highest block in db and datastream", logPrefix), "datastreamBlock", highestDSL2Block, "dbBlock", stageProgressBlockNo)


### PR DESCRIPTION
## Summary

- Reduce wait time on new block sync triggers. With the reduced block time, the wait time for trying to get a new DS block height should also be reduced