### PR TITLE
Add new realtime sendRawTransaction API which directly return receipt

### DIFF
--- a/turbo/jsonrpc/zkevm_api_xlayer.go
+++ b/turbo/jsonrpc/zkevm_api_xlayer.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
+	"github.com/ledgerwatch/erigon-lib/common/hexutility"
 	"github.com/ledgerwatch/erigon/rpc"
 	types "github.com/ledgerwatch/erigon/zk/rpcdaemon"
+	"github.com/ledgerwatch/log/v3"
 )
 
 func (api *ZkEvmAPIImpl) GetBatchSealTime(ctx context.Context, batchNumber rpc.BlockNumber) (types.ArgUint64, error) {
@@ -36,4 +39,41 @@ func (api *ZkEvmAPIImpl) GetBatchSealTime(ctx context.Context, batchNumber rpc.B
 	}
 
 	return lastBlock.Timestamp, nil
+}
+
+func (api *ZkEvmAPIImpl) SendRawTransaction(ctx context.Context, encodedTx hexutility.Bytes) (map[string]interface{}, error) {
+	start := time.Now()
+	defer func() {
+		log.Info("SendRawTransaction completed", "duration", time.Since(start))
+	}()
+
+	txnHash, err := api.ethApi.sendRawTransactionSingle(ctx, encodedTx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send raw transaction: %w for tx %s", err, txnHash.Hex())
+	}
+
+	// Poll for the transaction receipt for up to 3 seconds
+	timeout := 3 * time.Second
+	pollingInterval := 100 * time.Millisecond // Poll every 100ms
+	startTime := time.Now()
+
+	for time.Since(startTime) < timeout {
+		receipt, err := api.ethApi.GetTransactionReceipt(ctx, txnHash)
+		if err != nil {
+			log.Debug("Error fetching transaction receipt, will retry", "hash", txnHash, "err", err)
+		}
+
+		if receipt != nil {
+			return receipt, nil // Receipt found
+		}
+
+		select {
+		case <-time.After(pollingInterval):
+			// Continue to next iteration
+		case <-ctx.Done():
+			return nil, fmt.Errorf("context cancelled while polling for receipt: %w of tx %s", ctx.Err(), txnHash.Hex())
+		}
+	}
+
+	return nil, fmt.Errorf("transaction receipt not available after %v for tx %s", timeout, txnHash.Hex())
 }


### PR DESCRIPTION
To test the latency of this new `zkevm_sendRawTransaction` API compared with previous `eth_sendRawTransaction` & `eth_getTransactionReceipt` under make run test env. I run 10 times each for request sending to seq & rpc.

1. legacy way: first `eth_sendRawTransaction`, then polling `eth_getTransactionReceipt` with 500ms interval

Sent to seq:
- min: 517.32ms
- max: 1019.63ms
- avg: 567.30ms

Sent to rpc:
- min: 3.56s
- max: 4.09s
- avg: 3.61s

2. realtime way: `zkevm_sendRawTransaction`

Sent to seq:
- min: 101.32ms
- max: 717.77ms
- avg: 317.40ms

Sent to rpc:
- min: 3.14s
- max: 4.06s
- avg: 3.49s

The test script is low.

```javascript
const { ethers } = require("ethers");
const axios = require("axios");
require('dotenv').config();

const RPC_URL = "http://localhost:8124"; // https://rpc.xlayer.tech http://localhost:8123

const privateKey = process.env.PRIVATE_KEY

const wallet = new ethers.Wallet(privateKey);

const toAddress = "TO_ADDRESS";
const valueEth = "0.001";

async function waitForReceipt(txHash, maxAttempts = 60) {
  for (let i = 0; i < maxAttempts; i++) {
    const receiptRes = await axios.post(RPC_URL, {
      jsonrpc: "2.0",
      method: "eth_getTransactionReceipt",
      params: [txHash],
      id: 3
    });

    if (receiptRes.data.result) {
      return receiptRes.data.result;
    }

    console.log(`Waiting for receipt... Attempt ${i + 1}/${maxAttempts}`);
    await new Promise(resolve => setTimeout(resolve, 500));
  }
  throw new Error("Timeout waiting for transaction receipt");
}

(async () => {
    console.log("Wallet address:", wallet.address);

    const nonceRes = await axios.post(RPC_URL, {
        jsonrpc: "2.0",
        method: "eth_getTransactionCount",
        params: [wallet.address, "latest"],
        id: 1
    });

    const nonce = parseInt(nonceRes.data.result, 16);
    console.log(`Nonce: ${nonce}`);

    const tx = {
        nonce,
        to: toAddress,
        value: ethers.parseEther(valueEth).toString(),
        gasLimit: "21000",
        gasPrice: ethers.parseUnits("5", "gwei").toString(),
        chainId: 195,
        type: 0,
    };

    console.log("Transaction object:", JSON.stringify(tx, null, 2));

    const signedTx = await wallet.signTransaction(tx);
    console.log("Signed Tx:", signedTx);

    const sendRes = await axios.post(RPC_URL, {
        jsonrpc: "2.0",
        method: "zkevm_sendRawTransaction",
        params: [signedTx],
        id: 2
    });

    // console.log("Full response:", JSON.stringify(sendRes.data, null, 2));

    if (sendRes.data.error) {
        console.error("Transaction error:", sendRes.data.error);
        const errorMessage = sendRes.data.error.message;
        const txHashMatch = errorMessage.match(/0x[a-fA-F0-9]{64}/);
        if (txHashMatch) {
            const txHash = txHashMatch[0];
            console.log("Extracted Transaction Hash:", txHash);
            
            try {
                const receipt = await waitForReceipt(txHash);
                console.log("Transaction Receipt:", receipt);
            } catch (error) {
                console.error("Error waiting for receipt:", error.message);
            }
        }
    } else {
        console.log("Transaction Result:", sendRes.data.result);
    }
})();
```
