### PR TITLE
Remove best tx hash check in `TestEnforceBestInvariantsAfterBestChanged`

### DIFF
--- a/zk/txpool/pool_test.go
+++ b/zk/txpool/pool_test.go
@@ -357,7 +357,7 @@ func TestEnforceBestInvariantsAfterBestChanged(t *testing.T) {
 
 	assert.True(t, isSorted(poolTimSort.best), "timsort.TimSort failed to sort bestSlice")
 	assert.True(t, isSorted(poolSort.best), "sort.Sort failed to sort bestSlice")
-	assert.Equal(t, poolSort.best.ms[0].Tx.IDHash, poolTimSort.best.ms[0].Tx.IDHash, "Best tx IDHash differs after removing best txs")
+	// assert.Equal(t, poolSort.best.ms[0].Tx.IDHash, poolTimSort.best.ms[0].Tx.IDHash, "Best tx IDHash differs after removing best txs")
 	assert.Greaterf(t, sortDuration, timSortDuration, "sort.Sort cost less time than timsort.TimSort")
 
 	t.Logf("sort.Sort duration(After BestRead): %v", sortDuration)


### PR DESCRIPTION
After merging PR #459, there is a issue when executing the unit test `TestEnforceBestInvariantsAfterBestChanged`. It occasionally fails due to a change in the sorting comparison logic. This causes the built-in sort and Timsort to produce different optimal transactions after sorting. However, these two transactions are identical except for differences in senderID and nonce. To ensure the transaction pool functionality remains unaffected, we decided to remove the cross-checking of the best transaction in the test.