### PR TITLE
Niven/state cache db

### DIFF
--- a/core/state/plain_state_reader_xlayer.go
+++ b/core/state/plain_state_reader_xlayer.go
@@ -118,7 +118,7 @@ func (cache *PlainStateCache) ApplyChangesetToAccountData(changeset *zktypes.Cha
 	}
 
 	// Apply code hash changes
-	for address, codeHash := range changeset.CodeChanges {
+	for address, codeHash := range changeset.CodeHashChanges {
 		if _, ok := changeset.DeletedAccounts[address]; ok {
 			continue
 		}
@@ -127,7 +127,7 @@ func (cache *PlainStateCache) ApplyChangesetToAccountData(changeset *zktypes.Cha
 		if err != nil {
 			return fmt.Errorf("apply code hash changes failed: %v", err)
 		}
-		account.CodeHash = libcommon.BytesToHash(codeHash)
+		account.CodeHash = codeHash
 	}
 
 	// Apply incarnation changes
@@ -218,10 +218,10 @@ func (cache *PlainStateCache) ReadAccountIncarnation(address libcommon.Address) 
 	return cache.snapshotReader.ReadAccountIncarnation(address)
 }
 
-func (cache *PlainStateCache) readAccountData(address libcommon.Address) (*accounts.Account, error) {
+func (cache *PlainStateCache) unsafeReadAccountData(address libcommon.Address) (*accounts.Account, error) {
 	acc, ok := cache.accountCache[address]
 	if ok {
-		return accounts.DeepCopyAccount(acc), nil
+		return acc, nil
 	}
 
 	// Cache miss, read from snapshot
@@ -232,7 +232,7 @@ func (cache *PlainStateCache) getOrCreateAccount(address libcommon.Address, addr
 	account, ok := addressChanges[address]
 	if !ok {
 		var err error
-		account, err = cache.readAccountData(address)
+		account, err = cache.unsafeReadAccountData(address)
 		if err != nil {
 			return nil, err
 		}

--- a/core/state/plain_state_reader_xlayer.go
+++ b/core/state/plain_state_reader_xlayer.go
@@ -156,10 +156,12 @@ func (cache *PlainStateCache) ApplyChangesetToAccountData(changeset *zktypes.Cha
 func (cache *PlainStateCache) ReadAccountData(address libcommon.Address) (*accounts.Account, error) {
 	cache.cacheLock.RLock()
 	acc, ok := cache.accountCache[address]
-	cache.cacheLock.RUnlock()
 	if ok {
-		return accounts.DeepCopyAccount(acc), nil
+		accCopy := accounts.DeepCopyAccount(acc)
+		cache.cacheLock.RUnlock()
+		return accCopy, nil
 	}
+	cache.cacheLock.RUnlock()
 
 	// Cache miss, read from snapshot
 	return cache.snapshotReader.ReadAccountData(address)
@@ -170,10 +172,12 @@ func (cache *PlainStateCache) ReadAccountStorage(address libcommon.Address, inca
 
 	cache.cacheLock.RLock()
 	storage, ok := cache.storageCache[string(compositeKey)]
-	cache.cacheLock.RUnlock()
 	if ok {
-		return libcommon.Copy(storage.Bytes()), nil
+		storageCopy := libcommon.Copy(storage.Bytes())
+		cache.cacheLock.RUnlock()
+		return storageCopy, nil
 	}
+	cache.cacheLock.RUnlock()
 
 	// Cache miss, read from snapshot
 	return cache.snapshotReader.ReadAccountStorage(address, incarnation, key)
@@ -186,10 +190,12 @@ func (cache *PlainStateCache) ReadAccountCode(address libcommon.Address, incarna
 
 	cache.cacheLock.RLock()
 	code, ok := cache.codeCache[codeHash]
-	cache.cacheLock.RUnlock()
 	if ok {
-		return libcommon.Copy(code), nil
+		codeCopy := libcommon.Copy(code)
+		cache.cacheLock.RUnlock()
+		return codeCopy, nil
 	}
+	cache.cacheLock.RUnlock()
 
 	// Cache miss, read from snapshot
 	return cache.snapshotReader.ReadAccountCode(address, incarnation, codeHash)
@@ -212,11 +218,21 @@ func (cache *PlainStateCache) ReadAccountIncarnation(address libcommon.Address) 
 	return cache.snapshotReader.ReadAccountIncarnation(address)
 }
 
+func (cache *PlainStateCache) readAccountData(address libcommon.Address) (*accounts.Account, error) {
+	acc, ok := cache.accountCache[address]
+	if ok {
+		return accounts.DeepCopyAccount(acc), nil
+	}
+
+	// Cache miss, read from snapshot
+	return cache.snapshotReader.ReadAccountData(address)
+}
+
 func (cache *PlainStateCache) getOrCreateAccount(address libcommon.Address, addressChanges map[libcommon.Address]*accounts.Account) (*accounts.Account, error) {
 	account, ok := addressChanges[address]
 	if !ok {
 		var err error
-		account, err = cache.ReadAccountData(address)
+		account, err = cache.readAccountData(address)
 		if err != nil {
 			return nil, err
 		}

--- a/core/state/plain_state_reader_xlayer.go
+++ b/core/state/plain_state_reader_xlayer.go
@@ -25,16 +25,10 @@ type PlainStateCache struct {
 	snapshotHeight uint64
 	snapshotReader *PlainStateReader
 
-	accountLock  sync.RWMutex
-	accountCache map[libcommon.Address]*accounts.Account
-
-	storageLock  sync.RWMutex
-	storageCache map[string]*uint256.Int
-
-	codeLock  sync.RWMutex
-	codeCache map[libcommon.Hash][]byte
-
-	incarnationLock  sync.RWMutex
+	cacheLock        sync.RWMutex
+	accountCache     map[libcommon.Address]*accounts.Account
+	storageCache     map[string]*uint256.Int
+	codeCache        map[libcommon.Hash][]byte
 	incarnationCache map[libcommon.Address]uint64
 }
 
@@ -51,13 +45,52 @@ func NewPlainStateCache(db kv.Getter, snapshotHeight uint64) *PlainStateCache {
 
 func (cache *PlainStateCache) ApplyChangeset(changeset *zktypes.Changeset) error {
 	// Handle account data changes
+	addressChanges := make(map[libcommon.Address]*accounts.Account)
+	cache.ApplyChangesetToAccountData(changeset, addressChanges)
+
+	cache.cacheLock.Lock()
+	defer cache.cacheLock.Unlock()
+
+	// Apply code changes
+	for address, code := range changeset.CodeChanges {
+		if _, ok := changeset.DeletedAccounts[address]; ok {
+			continue
+		}
+
+		account, ok := addressChanges[address]
+		if !ok {
+			return fmt.Errorf("apply code changes failed: no codehash received")
+		}
+		cache.codeCache[account.CodeHash] = code
+	}
+
+	// Apply storage changes
+	for address, storage := range changeset.StorageChanges {
+		if _, ok := changeset.DeletedAccounts[address]; ok {
+			continue
+		}
+
+		account, err := cache.getOrCreateAccount(address, addressChanges)
+		if err != nil {
+			return fmt.Errorf("apply storage changes failed: %v", err)
+		}
+
+		for key, value := range storage {
+			compositeKey := dbutils.PlainGenerateCompositeStorageKey(address.Bytes(), account.Incarnation, key.Bytes())
+			cache.storageCache[string(compositeKey)] = value
+		}
+	}
+
+	// Apply account changes
+	for address, account := range addressChanges {
+		delete(cache.accountCache, address)
+		cache.accountCache[address] = account
+	}
 
 	return nil
 }
 
-func (cache *PlainStateCache) ApplyChangesetToAccountData(changeset *zktypes.Changeset) (err error) {
-	addressChanges := make(map[libcommon.Address]*accounts.Account)
-
+func (cache *PlainStateCache) ApplyChangesetToAccountData(changeset *zktypes.Changeset, addressChanges map[libcommon.Address]*accounts.Account) (err error) {
 	// Apply balance changes
 	for address, balance := range changeset.BalanceChanges {
 		if _, ok := changeset.DeletedAccounts[address]; ok {
@@ -85,58 +118,45 @@ func (cache *PlainStateCache) ApplyChangesetToAccountData(changeset *zktypes.Cha
 	}
 
 	// Apply code hash changes
+	for address, codeHash := range changeset.CodeChanges {
+		if _, ok := changeset.DeletedAccounts[address]; ok {
+			continue
+		}
 
-	// Apply code changes
+		account, err := cache.getOrCreateAccount(address, addressChanges)
+		if err != nil {
+			return fmt.Errorf("apply code hash changes failed: %v", err)
+		}
+		account.CodeHash = libcommon.BytesToHash(codeHash)
+	}
 
 	// Apply incarnation changes
+	for address, incarnation := range changeset.IncarnationChanges {
+		if _, ok := changeset.DeletedAccounts[address]; ok {
+			continue
+		}
 
-	// Apply storage changes
+		account, err := cache.getOrCreateAccount(address, addressChanges)
+		if err != nil {
+			return fmt.Errorf("apply incarnation changes failed: %v", err)
+		}
+		account.PrevIncarnation = incarnation - 1
+		account.Incarnation = incarnation
+	}
+
+	// Apply deleted accounts changes
+	for address := range changeset.DeletedAccounts {
+		// Non-existent / deleted accounts are set to nil
+		addressChanges[address] = nil
+	}
 
 	return nil
 }
 
-// func (cache *PlainStateCache) UpdateAccountData(address libcommon.Address, _, account *accounts.Account) error {
-// 	cache.accountLock.Lock()
-// 	cache.accountCache[address] = account
-// 	cache.accountLock.Unlock()
-
-// 	// Override original and assume updating account state incarnation is the latest one
-// 	cache.accountIncarnationLock.Lock()
-// 	cache.accountIncarnationCache[address] = account.Incarnation
-// 	cache.accountIncarnationLock.Unlock()
-
-// 	return nil
-// }
-
-// func (cache *PlainStateCache) DeleteAccount(address libcommon.Address, original *accounts.Account) error {
-// 	cache.accountLock.Lock()
-// 	defer cache.accountLock.Unlock()
-
-// 	// Non-existent / deleted accounts are set to nil
-// 	cache.accountCache[address] = nil
-// 	return nil
-// }
-
-// func (cache *PlainStateCache) WriteAccountStorage(address libcommon.Address, incarnation uint64, key *libcommon.Hash, original, value *uint256.Int) error {
-// 	cache.storageLock.Lock()
-// 	defer cache.storageLock.Unlock()
-
-// 	cache.storageCache[string(dbutils.PlainGenerateCompositeStorageKey(address.Bytes(), incarnation, key.Bytes()))] = value
-// 	return nil
-// }
-
-// func (cache *PlainStateCache) CreateContract(codeHash libcommon.Hash, code []byte) error {
-// 	cache.codeLock.Lock()
-// 	defer cache.codeLock.Unlock()
-
-// 	cache.codeCache[codeHash] = code
-// 	return nil
-// }
-
 func (cache *PlainStateCache) ReadAccountData(address libcommon.Address) (*accounts.Account, error) {
-	cache.accountLock.RLock()
+	cache.cacheLock.RLock()
 	acc, ok := cache.accountCache[address]
-	cache.accountLock.RUnlock()
+	cache.cacheLock.RUnlock()
 	if ok {
 		return accounts.DeepCopyAccount(acc), nil
 	}
@@ -148,9 +168,9 @@ func (cache *PlainStateCache) ReadAccountData(address libcommon.Address) (*accou
 func (cache *PlainStateCache) ReadAccountStorage(address libcommon.Address, incarnation uint64, key *libcommon.Hash) ([]byte, error) {
 	compositeKey := dbutils.PlainGenerateCompositeStorageKey(address.Bytes(), incarnation, key.Bytes())
 
-	cache.storageLock.RLock()
+	cache.cacheLock.RLock()
 	storage, ok := cache.storageCache[string(compositeKey)]
-	cache.storageLock.RUnlock()
+	cache.cacheLock.RUnlock()
 	if ok {
 		return libcommon.Copy(storage.Bytes()), nil
 	}
@@ -164,9 +184,9 @@ func (cache *PlainStateCache) ReadAccountCode(address libcommon.Address, incarna
 		return nil, nil
 	}
 
-	cache.codeLock.RLock()
+	cache.cacheLock.RLock()
 	code, ok := cache.codeCache[codeHash]
-	cache.codeLock.RUnlock()
+	cache.cacheLock.RUnlock()
 	if ok {
 		return libcommon.Copy(code), nil
 	}
@@ -181,9 +201,9 @@ func (cache *PlainStateCache) ReadAccountCodeSize(address libcommon.Address, inc
 }
 
 func (cache *PlainStateCache) ReadAccountIncarnation(address libcommon.Address) (uint64, error) {
-	cache.incarnationLock.RLock()
+	cache.cacheLock.RLock()
 	incarnation, ok := cache.incarnationCache[address]
-	cache.incarnationLock.RUnlock()
+	cache.cacheLock.RUnlock()
 	if ok {
 		return incarnation, nil
 	}
@@ -215,17 +235,10 @@ func (cache *PlainStateCache) getOrCreateAccount(address libcommon.Address, addr
 }
 
 func (cache *PlainStateCache) createAccount(address libcommon.Address) (*accounts.Account, error) {
-	prevIncarnation, err := cache.ReadAccountIncarnation(address)
-	if err != nil {
-		return nil, fmt.Errorf("createAccount failed: %v", err)
-	}
-
 	return &accounts.Account{
-		Initialised:     true,
-		Nonce:           0,
-		Root:            libcommon.BytesToHash(trie.EmptyRoot[:]),
-		CodeHash:        libcommon.BytesToHash(emptyCodeHash),
-		PrevIncarnation: prevIncarnation,
-		Incarnation:     prevIncarnation + 1,
+		Initialised: true,
+		Nonce:       0,
+		Root:        libcommon.BytesToHash(trie.EmptyRoot[:]),
+		CodeHash:    libcommon.BytesToHash(emptyCodeHash),
 	}, nil
 }

--- a/core/state/plain_state_reader_xlayer.go
+++ b/core/state/plain_state_reader_xlayer.go
@@ -1,0 +1,121 @@
+package state
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/erigon-lib/kv/dbutils"
+	"github.com/ledgerwatch/erigon/core/types/accounts"
+)
+
+const (
+	DefaultRealtimeCacheSize = 1_000_000
+)
+
+type PlainStateCacheReader struct {
+	db             kv.Getter
+	accountChanges map[libcommon.Address][]byte
+	storageChanged map[libcommon.Address]bool
+	storageChanges map[string][]byte
+}
+
+func NewPlainStateCacheReader(db kv.Getter) *PlainStateCacheReader {
+	return &PlainStateCacheReader{
+		db:             db,
+		accountChanges: make(map[libcommon.Address][]byte, DefaultRealtimeCacheSize),
+		storageChanged: make(map[libcommon.Address]bool, DefaultRealtimeCacheSize),
+		storageChanges: make(map[string][]byte, DefaultRealtimeCacheSize),
+	}
+}
+
+func (cache *PlainStateCacheReader) ReadAccountData(address libcommon.Address) (*accounts.Account, error) {
+	if account, ok := cache.accountChanges[address]; ok {
+		var acc accounts.Account
+		if err := acc.DecodeForStorage(account); err != nil {
+			return nil, err
+		}
+		return &acc, nil
+	}
+
+	// Cache miss, read from snapshot and load to cache
+	enc, err := cache.db.GetOne(kv.PlainState, address.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	if len(enc) == 0 {
+		return nil, nil
+	}
+	var a accounts.Account
+	if err = a.DecodeForStorage(enc); err != nil {
+		return nil, err
+	}
+	cache.accountChanges[address] = enc
+
+	return &a, nil
+
+}
+
+func (cache *PlainStateCacheReader) ReadAccountStorage(address libcommon.Address, incarnation uint64, key *libcommon.Hash) ([]byte, error) {
+	compositeKey := dbutils.PlainGenerateCompositeStorageKey(address.Bytes(), incarnation, key.Bytes())
+	if enc, ok := cache.storageChanges[string(compositeKey)]; ok {
+		return enc, nil
+	}
+
+	// Cache miss, read from snapshot and load to cache
+	enc, err := cache.db.GetOne(kv.PlainState, compositeKey)
+	if err != nil {
+		return nil, err
+	}
+	if len(enc) == 0 {
+		return nil, nil
+	}
+	return enc, nil
+}
+
+func (cache *PlainStateCacheReader) ReadAccountCode(address libcommon.Address, incarnation uint64, codeHash libcommon.Hash) ([]byte, error) {
+	if bytes.Equal(codeHash.Bytes(), emptyCodeHash) {
+		return nil, nil
+	}
+
+	if account, ok := cache.accountChanges[address]; ok {
+		var acc accounts.Account
+		if err := acc.DecodeForStorage(account); err != nil {
+			return nil, err
+		}
+		return acc.CodeHash.Bytes(), nil
+	}
+
+	// Cache miss, read from snapshot and load to cache
+	code, err := cache.db.GetOne(kv.Code, codeHash.Bytes())
+	if len(code) == 0 {
+		return nil, nil
+	}
+	return code, err
+}
+
+func (cache *PlainStateCacheReader) ReadAccountCodeSize(address libcommon.Address, incarnation uint64, codeHash libcommon.Hash) (int, error) {
+	code, err := cache.ReadAccountCode(address, incarnation, codeHash)
+	return len(code), err
+}
+
+func (cache *PlainStateCacheReader) ReadAccountIncarnation(address libcommon.Address) (uint64, error) {
+	if account, ok := cache.accountChanges[address]; ok {
+		var acc accounts.Account
+		if err := acc.DecodeForStorage(account); err != nil {
+			return 0, err
+		}
+		return acc.Incarnation, nil
+	}
+
+	// Cache miss, read from snapshot and load to cache
+	b, err := cache.db.GetOne(kv.IncarnationMap, address.Bytes())
+	if err != nil {
+		return 0, err
+	}
+	if len(b) == 0 {
+		return 0, nil
+	}
+	return binary.BigEndian.Uint64(b), nil
+}

--- a/core/state/plain_state_reader_xlayer.go
+++ b/core/state/plain_state_reader_xlayer.go
@@ -3,7 +3,10 @@ package state
 import (
 	"bytes"
 	"encoding/binary"
+	"sync"
 
+	"github.com/holiman/uint256"
+	"github.com/ledgerwatch/erigon-lib/common"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon-lib/kv/dbutils"
@@ -14,30 +17,83 @@ const (
 	DefaultRealtimeCacheSize = 1_000_000
 )
 
-type PlainStateCacheReader struct {
+// PlainStateCache implements the plain state reader and writer. The cache holds a snapshot
+// of the statedb, with a cache layer that stores in-memory the state changeset.
+type PlainStateCache struct {
 	db             kv.Getter
-	accountChanges map[libcommon.Address][]byte
-	storageChanges map[string][]byte
+	snapshotHeight uint64
+
+	accountLock  sync.RWMutex
+	accountCache map[libcommon.Address]*accounts.Account
+
+	storageLock  sync.RWMutex
+	storageCache map[string]*uint256.Int
+
+	codeLock  sync.RWMutex
+	codeCache map[libcommon.Hash][]byte
+
+	accountIncarnationLock  sync.RWMutex
+	accountIncarnationCache map[libcommon.Address]uint64
 }
 
-func NewPlainStateCacheReader(db kv.Getter) *PlainStateCacheReader {
-	return &PlainStateCacheReader{
+func NewPlainStateCache(db kv.Getter, snapshotHeight uint64) *PlainStateCache {
+
+	return &PlainStateCache{
 		db:             db,
-		accountChanges: make(map[libcommon.Address][]byte, DefaultRealtimeCacheSize),
-		storageChanges: make(map[string][]byte, DefaultRealtimeCacheSize),
+		snapshotHeight: snapshotHeight,
+		accountCache:   make(map[libcommon.Address]*accounts.Account, DefaultRealtimeCacheSize),
+		storageCache:   make(map[string]*uint256.Int, DefaultRealtimeCacheSize),
+		codeCache:      make(map[libcommon.Hash][]byte, DefaultRealtimeCacheSize),
 	}
 }
 
-func (cache *PlainStateCacheReader) ReadAccountData(address libcommon.Address) (*accounts.Account, error) {
-	if account, ok := cache.accountChanges[address]; ok {
-		var acc accounts.Account
-		if err := acc.DecodeForStorage(account); err != nil {
-			return nil, err
-		}
-		return &acc, nil
+func (cache *PlainStateCache) UpdateAccountData(address common.Address, _, account *accounts.Account) error {
+	cache.accountLock.Lock()
+	cache.accountCache[address] = account
+	cache.accountLock.Unlock()
+
+	// Override original and assume updating account state incarnation is the latest one
+	cache.accountIncarnationLock.Lock()
+	cache.accountIncarnationCache[address] = account.Incarnation
+	cache.accountIncarnationLock.Unlock()
+
+	return nil
+}
+
+func (cache *PlainStateCache) DeleteAccount(address common.Address, original *accounts.Account) error {
+	cache.accountLock.Lock()
+	defer cache.accountLock.Unlock()
+
+	// Non-existent / deleted accounts are set to nil
+	cache.accountCache[address] = nil
+	return nil
+}
+
+func (cache *PlainStateCache) WriteAccountStorage(address common.Address, incarnation uint64, key *common.Hash, original, value *uint256.Int) error {
+	cache.storageLock.Lock()
+	defer cache.storageLock.Unlock()
+
+	cache.storageCache[string(dbutils.PlainGenerateCompositeStorageKey(address.Bytes(), incarnation, key.Bytes()))] = value
+	return nil
+}
+
+func (cache *PlainStateCache) CreateContract(codeHash common.Hash, code []byte) error {
+	cache.codeLock.Lock()
+	defer cache.codeLock.Unlock()
+
+	cache.codeCache[codeHash] = code
+	return nil
+}
+
+func (cache *PlainStateCache) ReadAccountData(address libcommon.Address) (*accounts.Account, error) {
+	cache.accountLock.RLock()
+	account, ok := cache.accountCache[address]
+	cache.accountLock.RUnlock()
+	if ok {
+		return account, nil
 	}
 
-	// Cache miss, read from snapshot and load to cache
+	// Cache miss, read from snapshot
 	enc, err := cache.db.GetOne(kv.PlainState, address.Bytes())
 	if err != nil {
 		return nil, err
@@ -45,23 +101,28 @@ func (cache *PlainStateCacheReader) ReadAccountData(address libcommon.Address) (
 	if len(enc) == 0 {
 		return nil, nil
 	}
-	var a accounts.Account
-	if err = a.DecodeForStorage(enc); err != nil {
+	acc := &accounts.Account{}
+	if err = acc.DecodeForStorage(enc); err != nil {
 		return nil, err
 	}
-	cache.accountChanges[address] = enc
 
-	return &a, nil
+	// Load to cache
+	acc = cache.loadAccountFromSnapshot(address, acc)
 
+	return acc, nil
 }
 
-func (cache *PlainStateCacheReader) ReadAccountStorage(address libcommon.Address, incarnation uint64, key *libcommon.Hash) ([]byte, error) {
+func (cache *PlainStateCache) ReadAccountStorage(address libcommon.Address, incarnation uint64, key *libcommon.Hash) ([]byte, error) {
 	compositeKey := dbutils.PlainGenerateCompositeStorageKey(address.Bytes(), incarnation, key.Bytes())
-	if enc, ok := cache.storageChanges[string(compositeKey)]; ok {
-		return enc, nil
+
+	cache.storageLock.RLock()
+	storage, ok := cache.storageCache[string(compositeKey)]
+	cache.storageLock.RUnlock()
+	if ok {
+		return storage.Bytes(), nil
 	}
 
-	// Cache miss, read from snapshot and load to cache
+	// Cache miss, read from snapshot
 	enc, err := cache.db.GetOne(kv.PlainState, compositeKey)
 	if err != nil {
 		return nil, err
@@ -69,45 +130,51 @@ func (cache *PlainStateCacheReader) ReadAccountStorage(address libcommon.Address
 	if len(enc) == 0 {
 		return nil, nil
 	}
+
+	// Load to cache
+	enc = cache.loadStorageFromSnapshot(string(compositeKey), enc)
+
 	return enc, nil
 }
 
-func (cache *PlainStateCacheReader) ReadAccountCode(address libcommon.Address, incarnation uint64, codeHash libcommon.Hash) ([]byte, error) {
+func (cache *PlainStateCache) ReadAccountCode(address libcommon.Address, incarnation uint64, codeHash libcommon.Hash) ([]byte, error) {
 	if bytes.Equal(codeHash.Bytes(), emptyCodeHash) {
 		return nil, nil
 	}
 
-	if account, ok := cache.accountChanges[address]; ok {
-		var acc accounts.Account
-		if err := acc.DecodeForStorage(account); err != nil {
-			return nil, err
-		}
-		return acc.CodeHash.Bytes(), nil
+	cache.codeLock.RLock()
+	code, ok := cache.codeCache[codeHash]
+	cache.codeLock.RUnlock()
+	if ok {
+		return code, nil
 	}
 
-	// Cache miss, read from snapshot and load to cache
-	code, err := cache.db.GetOne(kv.Code, codeHash.Bytes())
-	if len(code) == 0 {
+	// Cache miss, read from snapshot
+	enc, err := cache.db.GetOne(kv.Code, codeHash.Bytes())
+	if len(enc) == 0 {
 		return nil, nil
 	}
+
+	// Load to cache
+	code = cache.loadCodeFromSnapshot(codeHash, enc)
+
 	return code, err
 }
 
-func (cache *PlainStateCacheReader) ReadAccountCodeSize(address libcommon.Address, incarnation uint64, codeHash libcommon.Hash) (int, error) {
+func (cache *PlainStateCache) ReadAccountCodeSize(address libcommon.Address, incarnation uint64, codeHash libcommon.Hash) (int, error) {
 	code, err := cache.ReadAccountCode(address, incarnation, codeHash)
 	return len(code), err
 }
 
-func (cache *PlainStateCacheReader) ReadAccountIncarnation(address libcommon.Address) (uint64, error) {
-	if account, ok := cache.accountChanges[address]; ok {
-		var acc accounts.Account
-		if err := acc.DecodeForStorage(account); err != nil {
-			return 0, err
-		}
-		return acc.Incarnation, nil
+func (cache *PlainStateCache) ReadAccountIncarnation(address libcommon.Address) (uint64, error) {
+	cache.accountIncarnationLock.RLock()
+	incarnation, ok := cache.accountIncarnationCache[address]
+	cache.accountIncarnationLock.RUnlock()
+	if ok {
+		return incarnation, nil
 	}
 
-	// Cache miss, read from snapshot and load to cache
+	// Cache miss, read from snapshot
 	b, err := cache.db.GetOne(kv.IncarnationMap, address.Bytes())
 	if err != nil {
 		return 0, err
@@ -115,5 +182,63 @@ func (cache *PlainStateCacheReader) ReadAccountIncarnation(address libcommon.Add
 	if len(b) == 0 {
 		return 0, nil
 	}
-	return binary.BigEndian.Uint64(b), nil
+	incarnation = binary.BigEndian.Uint64(b)
+
+	// Load to cache
+	incarnation = cache.loadAccountIncarnationFromSnapshot(address, incarnation)
+
+	return incarnation, nil
+}
+
+func (cache *PlainStateCache) loadAccountFromSnapshot(address libcommon.Address, accountSnapshot *accounts.Account) *accounts.Account {
+	cache.accountLock.Lock()
+	defer cache.accountLock.Unlock()
+	if account, ok := cache.accountCache[address]; ok {
+		// Cache hit
+		return account
+	}
+
+	// Load to cache
+	cache.accountCache[address] = accountSnapshot
+	return accountSnapshot
+}
+
+func (cache *PlainStateCache) loadStorageFromSnapshot(key string, encSnapshot []byte) []byte {
+	cache.storageLock.Lock()
+	defer cache.storageLock.Unlock()
+	if value, ok := cache.storageCache[key]; ok {
+		// Cache hit
+		return value.Bytes()
+	}
+
+	// Load to cache
+	valueSnapshot := uint256.NewInt(0).SetBytes(encSnapshot)
+	cache.storageCache[key] = valueSnapshot
+	return encSnapshot
+}
+
+func (cache *PlainStateCache) loadCodeFromSnapshot(key libcommon.Hash, codeSnapshot []byte) []byte {
+	cache.codeLock.Lock()
+	defer cache.codeLock.Unlock()
+	if code, ok := cache.codeCache[key]; ok {
+		// Cache hit
+		return code
+	}
+
+	// Load to cache
+	cache.codeCache[key] = codeSnapshot
+	return codeSnapshot
+}
+
+func (cache *PlainStateCache) loadAccountIncarnationFromSnapshot(address libcommon.Address, incarnationSnapshot uint64) uint64 {
+	cache.accountIncarnationLock.Lock()
+	defer cache.accountIncarnationLock.Unlock()
+	if incarnation, ok := cache.accountIncarnationCache[address]; ok {
+		// Cache hit
+		return incarnation
+	}
+
+	// Load to cache
+	cache.accountIncarnationCache[address] = incarnationSnapshot
+	return incarnationSnapshot
 }

--- a/core/state/plain_state_reader_xlayer.go
+++ b/core/state/plain_state_reader_xlayer.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"bytes"
+	"fmt"
 	"sync"
 
 	"github.com/holiman/uint256"
@@ -9,6 +10,8 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon-lib/kv/dbutils"
 	"github.com/ledgerwatch/erigon/core/types/accounts"
+	"github.com/ledgerwatch/erigon/turbo/trie"
+	zktypes "github.com/ledgerwatch/erigon/zk/types"
 )
 
 const (
@@ -31,35 +34,66 @@ type PlainStateCache struct {
 	codeLock  sync.RWMutex
 	codeCache map[libcommon.Hash][]byte
 
-	accountIncarnationLock  sync.RWMutex
-	accountIncarnationCache map[libcommon.Address]uint64
+	incarnationLock  sync.RWMutex
+	incarnationCache map[libcommon.Address]uint64
 }
 
 func NewPlainStateCache(db kv.Getter, snapshotHeight uint64) *PlainStateCache {
 	return &PlainStateCache{
-		snapshotHeight: snapshotHeight,
-		snapshotReader: NewPlainStateReader(db),
-		accountCache:   make(map[libcommon.Address]*accounts.Account, DefaultRealtimeCacheSize),
-		storageCache:   make(map[string]*uint256.Int, DefaultRealtimeCacheSize),
-		codeCache:      make(map[libcommon.Hash][]byte, DefaultRealtimeCacheSize),
+		snapshotHeight:   snapshotHeight,
+		snapshotReader:   NewPlainStateReader(db),
+		accountCache:     make(map[libcommon.Address]*accounts.Account, DefaultRealtimeCacheSize),
+		storageCache:     make(map[string]*uint256.Int, DefaultRealtimeCacheSize),
+		codeCache:        make(map[libcommon.Hash][]byte, DefaultRealtimeCacheSize),
+		incarnationCache: make(map[libcommon.Address]uint64, DefaultRealtimeCacheSize),
 	}
 }
 
-// func (cache *PlainStateCache) ApplyChangeset(changeset *zktypes.Changeset) error {
-// 	// // Handle account data changes
-// 	// cache.accountLock.Lock()
-// 	// for address, balances := range changeset.BalanceChanges {
-// 	// 	account, ok := cache.accountCache[address]
-// 	// 	if !ok {
-// 	// 		account = &accounts.Account{}
-// 	// 		cache.accountCache[address] = account
-// 	// 	}
-// 	// 	account.Balance.Set(balances)
-// 	// 	cache.accountCache[address] = account
-// 	// 	cache.accountLock.Unlock()
-// 	// }
-// 	return nil
-// }
+func (cache *PlainStateCache) ApplyChangeset(changeset *zktypes.Changeset) error {
+	// Handle account data changes
+
+	return nil
+}
+
+func (cache *PlainStateCache) ApplyChangesetToAccountData(changeset *zktypes.Changeset) (err error) {
+	addressChanges := make(map[libcommon.Address]*accounts.Account)
+
+	// Apply balance changes
+	for address, balance := range changeset.BalanceChanges {
+		if _, ok := changeset.DeletedAccounts[address]; ok {
+			continue
+		}
+
+		account, err := cache.getOrCreateAccount(address, addressChanges)
+		if err != nil {
+			return fmt.Errorf("apply balance changes failed: %v", err)
+		}
+		account.Balance.Set(balance)
+	}
+
+	// Apply nonce changes
+	for address, nonce := range changeset.NonceChanges {
+		if _, ok := changeset.DeletedAccounts[address]; ok {
+			continue
+		}
+
+		account, err := cache.getOrCreateAccount(address, addressChanges)
+		if err != nil {
+			return fmt.Errorf("apply nonce changes failed: %v", err)
+		}
+		account.Nonce = nonce
+	}
+
+	// Apply code hash changes
+
+	// Apply code changes
+
+	// Apply incarnation changes
+
+	// Apply storage changes
+
+	return nil
+}
 
 // func (cache *PlainStateCache) UpdateAccountData(address libcommon.Address, _, account *accounts.Account) error {
 // 	cache.accountLock.Lock()
@@ -107,12 +141,8 @@ func (cache *PlainStateCache) ReadAccountData(address libcommon.Address) (*accou
 		return accounts.DeepCopyAccount(acc), nil
 	}
 
-	// Cache miss, read from snapshot and load to cache
-	acc, err := cache.snapshotReader.ReadAccountData(address)
-	if err != nil {
-		return nil, err
-	}
-	return cache.loadAccountFromSnapshot(address, acc), nil
+	// Cache miss, read from snapshot
+	return cache.snapshotReader.ReadAccountData(address)
 }
 
 func (cache *PlainStateCache) ReadAccountStorage(address libcommon.Address, incarnation uint64, key *libcommon.Hash) ([]byte, error) {
@@ -125,12 +155,8 @@ func (cache *PlainStateCache) ReadAccountStorage(address libcommon.Address, inca
 		return libcommon.Copy(storage.Bytes()), nil
 	}
 
-	// Cache miss, read from snapshot and load to cache
-	enc, err := cache.snapshotReader.ReadAccountStorage(address, incarnation, key)
-	if err != nil {
-		return nil, err
-	}
-	return cache.loadStorageFromSnapshot(string(compositeKey), enc), nil
+	// Cache miss, read from snapshot
+	return cache.snapshotReader.ReadAccountStorage(address, incarnation, key)
 }
 
 func (cache *PlainStateCache) ReadAccountCode(address libcommon.Address, incarnation uint64, codeHash libcommon.Hash) ([]byte, error) {
@@ -145,12 +171,8 @@ func (cache *PlainStateCache) ReadAccountCode(address libcommon.Address, incarna
 		return libcommon.Copy(code), nil
 	}
 
-	// Cache miss, read from snapshot and load to cache
-	code, err := cache.snapshotReader.ReadAccountCode(address, incarnation, codeHash)
-	if err != nil {
-		return nil, err
-	}
-	return cache.loadCodeFromSnapshot(codeHash, code), err
+	// Cache miss, read from snapshot
+	return cache.snapshotReader.ReadAccountCode(address, incarnation, codeHash)
 }
 
 func (cache *PlainStateCache) ReadAccountCodeSize(address libcommon.Address, incarnation uint64, codeHash libcommon.Hash) (int, error) {
@@ -159,70 +181,51 @@ func (cache *PlainStateCache) ReadAccountCodeSize(address libcommon.Address, inc
 }
 
 func (cache *PlainStateCache) ReadAccountIncarnation(address libcommon.Address) (uint64, error) {
-	cache.accountIncarnationLock.RLock()
-	incarnation, ok := cache.accountIncarnationCache[address]
-	cache.accountIncarnationLock.RUnlock()
+	cache.incarnationLock.RLock()
+	incarnation, ok := cache.incarnationCache[address]
+	cache.incarnationLock.RUnlock()
 	if ok {
 		return incarnation, nil
 	}
 
-	// Cache miss, read from snapshot and load to cache
-	incarnation, err := cache.snapshotReader.ReadAccountIncarnation(address)
+	// Cache miss, read from snapshot
+	return cache.snapshotReader.ReadAccountIncarnation(address)
+}
+
+func (cache *PlainStateCache) getOrCreateAccount(address libcommon.Address, addressChanges map[libcommon.Address]*accounts.Account) (*accounts.Account, error) {
+	account, ok := addressChanges[address]
+	if !ok {
+		var err error
+		account, err = cache.ReadAccountData(address)
+		if err != nil {
+			return nil, err
+		}
+
+		if account == nil {
+			// Non-existent account, create new account
+			account, err = cache.createAccount(address)
+			if err != nil {
+				return nil, err
+			}
+		}
+		addressChanges[address] = account
+	}
+
+	return account, nil
+}
+
+func (cache *PlainStateCache) createAccount(address libcommon.Address) (*accounts.Account, error) {
+	prevIncarnation, err := cache.ReadAccountIncarnation(address)
 	if err != nil {
-		return 0, err
-	}
-	return cache.loadAccountIncarnationFromSnapshot(address, incarnation), nil
-}
-
-func (cache *PlainStateCache) loadAccountFromSnapshot(address libcommon.Address, accountSnapshot *accounts.Account) *accounts.Account {
-	cache.accountLock.Lock()
-	defer cache.accountLock.Unlock()
-	if account, ok := cache.accountCache[address]; ok {
-		// Cache hit
-		return accounts.DeepCopyAccount(account)
+		return nil, fmt.Errorf("createAccount failed: %v", err)
 	}
 
-	// Load to cache
-	cache.accountCache[address] = accountSnapshot
-	return accountSnapshot
-}
-
-func (cache *PlainStateCache) loadStorageFromSnapshot(key string, encSnapshot []byte) []byte {
-	cache.storageLock.Lock()
-	defer cache.storageLock.Unlock()
-	if value, ok := cache.storageCache[key]; ok {
-		// Cache hit
-		return libcommon.Copy(value.Bytes())
-	}
-
-	// Load to cache
-	vSnapshot := uint256.NewInt(0).SetBytes(encSnapshot)
-	cache.storageCache[key] = vSnapshot
-	return encSnapshot
-}
-
-func (cache *PlainStateCache) loadCodeFromSnapshot(key libcommon.Hash, codeSnapshot []byte) []byte {
-	cache.codeLock.Lock()
-	defer cache.codeLock.Unlock()
-	if code, ok := cache.codeCache[key]; ok {
-		// Cache hit
-		return libcommon.Copy(code)
-	}
-
-	// Load to cache
-	cache.codeCache[key] = codeSnapshot
-	return codeSnapshot
-}
-
-func (cache *PlainStateCache) loadAccountIncarnationFromSnapshot(address libcommon.Address, incarnationSnapshot uint64) uint64 {
-	cache.accountIncarnationLock.Lock()
-	defer cache.accountIncarnationLock.Unlock()
-	if incarnation, ok := cache.accountIncarnationCache[address]; ok {
-		// Cache hit
-		return incarnation
-	}
-
-	// Load to cache
-	cache.accountIncarnationCache[address] = incarnationSnapshot
-	return incarnationSnapshot
+	return &accounts.Account{
+		Initialised:     true,
+		Nonce:           0,
+		Root:            libcommon.BytesToHash(trie.EmptyRoot[:]),
+		CodeHash:        libcommon.BytesToHash(emptyCodeHash),
+		PrevIncarnation: prevIncarnation,
+		Incarnation:     prevIncarnation + 1,
+	}, nil
 }

--- a/core/state/plain_state_reader_xlayer.go
+++ b/core/state/plain_state_reader_xlayer.go
@@ -104,7 +104,7 @@ func (cache *PlainStateCache) ReadAccountData(address libcommon.Address) (*accou
 	acc, ok := cache.accountCache[address]
 	cache.accountLock.RUnlock()
 	if ok {
-		return deepCopyAccount(acc), nil
+		return accounts.DeepCopyAccount(acc), nil
 	}
 
 	// Cache miss, read from snapshot and load to cache
@@ -179,7 +179,7 @@ func (cache *PlainStateCache) loadAccountFromSnapshot(address libcommon.Address,
 	defer cache.accountLock.Unlock()
 	if account, ok := cache.accountCache[address]; ok {
 		// Cache hit
-		return deepCopyAccount(account)
+		return accounts.DeepCopyAccount(account)
 	}
 
 	// Load to cache

--- a/core/state/plain_state_reader_xlayer.go
+++ b/core/state/plain_state_reader_xlayer.go
@@ -17,7 +17,6 @@ const (
 type PlainStateCacheReader struct {
 	db             kv.Getter
 	accountChanges map[libcommon.Address][]byte
-	storageChanged map[libcommon.Address]bool
 	storageChanges map[string][]byte
 }
 
@@ -25,7 +24,6 @@ func NewPlainStateCacheReader(db kv.Getter) *PlainStateCacheReader {
 	return &PlainStateCacheReader{
 		db:             db,
 		accountChanges: make(map[libcommon.Address][]byte, DefaultRealtimeCacheSize),
-		storageChanged: make(map[libcommon.Address]bool, DefaultRealtimeCacheSize),
 		storageChanges: make(map[string][]byte, DefaultRealtimeCacheSize),
 	}
 }

--- a/core/state/plain_state_reader_xlayer.go
+++ b/core/state/plain_state_reader_xlayer.go
@@ -2,11 +2,9 @@ package state
 
 import (
 	"bytes"
-	"encoding/binary"
 	"sync"
 
 	"github.com/holiman/uint256"
-	"github.com/ledgerwatch/erigon-lib/common"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon-lib/kv/dbutils"
@@ -17,11 +15,12 @@ const (
 	DefaultRealtimeCacheSize = 1_000_000
 )
 
-// PlainStateCache implements the plain state reader and writer. The cache holds a snapshot
-// of the statedb, with a cache layer that stores in-memory the state changeset.
+// PlainStateCache implements the plain state reader with a changeset cache layer.
+// The cache holds a snapshot of the statedb, with a changeset cache layer that
+// stores in-memory the state changes.
 type PlainStateCache struct {
-	db             kv.Getter
 	snapshotHeight uint64
+	snapshotReader *PlainStateReader
 
 	accountLock  sync.RWMutex
 	accountCache map[libcommon.Address]*accounts.Account
@@ -37,79 +36,83 @@ type PlainStateCache struct {
 }
 
 func NewPlainStateCache(db kv.Getter, snapshotHeight uint64) *PlainStateCache {
-
 	return &PlainStateCache{
-		db:             db,
 		snapshotHeight: snapshotHeight,
+		snapshotReader: NewPlainStateReader(db),
 		accountCache:   make(map[libcommon.Address]*accounts.Account, DefaultRealtimeCacheSize),
 		storageCache:   make(map[string]*uint256.Int, DefaultRealtimeCacheSize),
 		codeCache:      make(map[libcommon.Hash][]byte, DefaultRealtimeCacheSize),
 	}
 }
 
-func (cache *PlainStateCache) UpdateAccountData(address common.Address, _, account *accounts.Account) error {
-	cache.accountLock.Lock()
-	cache.accountCache[address] = account
-	cache.accountLock.Unlock()
+// func (cache *PlainStateCache) ApplyChangeset(changeset *zktypes.Changeset) error {
+// 	// // Handle account data changes
+// 	// cache.accountLock.Lock()
+// 	// for address, balances := range changeset.BalanceChanges {
+// 	// 	account, ok := cache.accountCache[address]
+// 	// 	if !ok {
+// 	// 		account = &accounts.Account{}
+// 	// 		cache.accountCache[address] = account
+// 	// 	}
+// 	// 	account.Balance.Set(balances)
+// 	// 	cache.accountCache[address] = account
+// 	// 	cache.accountLock.Unlock()
+// 	// }
+// 	return nil
+// }
 
-	// Override original and assume updating account state incarnation is the latest one
-	cache.accountIncarnationLock.Lock()
-	cache.accountIncarnationCache[address] = account.Incarnation
-	cache.accountIncarnationLock.Unlock()
+// func (cache *PlainStateCache) UpdateAccountData(address libcommon.Address, _, account *accounts.Account) error {
+// 	cache.accountLock.Lock()
+// 	cache.accountCache[address] = account
+// 	cache.accountLock.Unlock()
 
-	return nil
-}
+// 	// Override original and assume updating account state incarnation is the latest one
+// 	cache.accountIncarnationLock.Lock()
+// 	cache.accountIncarnationCache[address] = account.Incarnation
+// 	cache.accountIncarnationLock.Unlock()
 
-func (cache *PlainStateCache) DeleteAccount(address common.Address, original *accounts.Account) error {
-	cache.accountLock.Lock()
-	defer cache.accountLock.Unlock()
+// 	return nil
+// }
 
-	// Non-existent / deleted accounts are set to nil
-	cache.accountCache[address] = nil
-	return nil
-}
+// func (cache *PlainStateCache) DeleteAccount(address libcommon.Address, original *accounts.Account) error {
+// 	cache.accountLock.Lock()
+// 	defer cache.accountLock.Unlock()
 
-func (cache *PlainStateCache) WriteAccountStorage(address common.Address, incarnation uint64, key *common.Hash, original, value *uint256.Int) error {
-	cache.storageLock.Lock()
-	defer cache.storageLock.Unlock()
+// 	// Non-existent / deleted accounts are set to nil
+// 	cache.accountCache[address] = nil
+// 	return nil
+// }
 
-	cache.storageCache[string(dbutils.PlainGenerateCompositeStorageKey(address.Bytes(), incarnation, key.Bytes()))] = value
-	return nil
-}
+// func (cache *PlainStateCache) WriteAccountStorage(address libcommon.Address, incarnation uint64, key *libcommon.Hash, original, value *uint256.Int) error {
+// 	cache.storageLock.Lock()
+// 	defer cache.storageLock.Unlock()
 
-func (cache *PlainStateCache) CreateContract(codeHash common.Hash, code []byte) error {
-	cache.codeLock.Lock()
-	defer cache.codeLock.Unlock()
+// 	cache.storageCache[string(dbutils.PlainGenerateCompositeStorageKey(address.Bytes(), incarnation, key.Bytes()))] = value
+// 	return nil
+// }
 
-	cache.codeCache[codeHash] = code
-	return nil
-}
+// func (cache *PlainStateCache) CreateContract(codeHash libcommon.Hash, code []byte) error {
+// 	cache.codeLock.Lock()
+// 	defer cache.codeLock.Unlock()
+
+// 	cache.codeCache[codeHash] = code
+// 	return nil
+// }
 
 func (cache *PlainStateCache) ReadAccountData(address libcommon.Address) (*accounts.Account, error) {
 	cache.accountLock.RLock()
-	account, ok := cache.accountCache[address]
+	acc, ok := cache.accountCache[address]
 	cache.accountLock.RUnlock()
 	if ok {
-		return account, nil
+		return deepCopyAccount(acc), nil
 	}
 
-	// Cache miss, read from snapshot
-	enc, err := cache.db.GetOne(kv.PlainState, address.Bytes())
+	// Cache miss, read from snapshot and load to cache
+	acc, err := cache.snapshotReader.ReadAccountData(address)
 	if err != nil {
 		return nil, err
 	}
-	if len(enc) == 0 {
-		return nil, nil
-	}
-	acc := &accounts.Account{}
-	if err = acc.DecodeForStorage(enc); err != nil {
-		return nil, err
-	}
-
-	// Load to cache
-	acc = cache.loadAccountFromSnapshot(address, acc)
-
-	return acc, nil
+	return cache.loadAccountFromSnapshot(address, acc), nil
 }
 
 func (cache *PlainStateCache) ReadAccountStorage(address libcommon.Address, incarnation uint64, key *libcommon.Hash) ([]byte, error) {
@@ -119,22 +122,15 @@ func (cache *PlainStateCache) ReadAccountStorage(address libcommon.Address, inca
 	storage, ok := cache.storageCache[string(compositeKey)]
 	cache.storageLock.RUnlock()
 	if ok {
-		return storage.Bytes(), nil
+		return libcommon.Copy(storage.Bytes()), nil
 	}
 
-	// Cache miss, read from snapshot
-	enc, err := cache.db.GetOne(kv.PlainState, compositeKey)
+	// Cache miss, read from snapshot and load to cache
+	enc, err := cache.snapshotReader.ReadAccountStorage(address, incarnation, key)
 	if err != nil {
 		return nil, err
 	}
-	if len(enc) == 0 {
-		return nil, nil
-	}
-
-	// Load to cache
-	enc = cache.loadStorageFromSnapshot(string(compositeKey), enc)
-
-	return enc, nil
+	return cache.loadStorageFromSnapshot(string(compositeKey), enc), nil
 }
 
 func (cache *PlainStateCache) ReadAccountCode(address libcommon.Address, incarnation uint64, codeHash libcommon.Hash) ([]byte, error) {
@@ -146,19 +142,15 @@ func (cache *PlainStateCache) ReadAccountCode(address libcommon.Address, incarna
 	code, ok := cache.codeCache[codeHash]
 	cache.codeLock.RUnlock()
 	if ok {
-		return code, nil
+		return libcommon.Copy(code), nil
 	}
 
-	// Cache miss, read from snapshot
-	enc, err := cache.db.GetOne(kv.Code, codeHash.Bytes())
-	if len(enc) == 0 {
-		return nil, nil
+	// Cache miss, read from snapshot and load to cache
+	code, err := cache.snapshotReader.ReadAccountCode(address, incarnation, codeHash)
+	if err != nil {
+		return nil, err
 	}
-
-	// Load to cache
-	code = cache.loadCodeFromSnapshot(codeHash, enc)
-
-	return code, err
+	return cache.loadCodeFromSnapshot(codeHash, code), err
 }
 
 func (cache *PlainStateCache) ReadAccountCodeSize(address libcommon.Address, incarnation uint64, codeHash libcommon.Hash) (int, error) {
@@ -174,20 +166,12 @@ func (cache *PlainStateCache) ReadAccountIncarnation(address libcommon.Address) 
 		return incarnation, nil
 	}
 
-	// Cache miss, read from snapshot
-	b, err := cache.db.GetOne(kv.IncarnationMap, address.Bytes())
+	// Cache miss, read from snapshot and load to cache
+	incarnation, err := cache.snapshotReader.ReadAccountIncarnation(address)
 	if err != nil {
 		return 0, err
 	}
-	if len(b) == 0 {
-		return 0, nil
-	}
-	incarnation = binary.BigEndian.Uint64(b)
-
-	// Load to cache
-	incarnation = cache.loadAccountIncarnationFromSnapshot(address, incarnation)
-
-	return incarnation, nil
+	return cache.loadAccountIncarnationFromSnapshot(address, incarnation), nil
 }
 
 func (cache *PlainStateCache) loadAccountFromSnapshot(address libcommon.Address, accountSnapshot *accounts.Account) *accounts.Account {
@@ -195,7 +179,7 @@ func (cache *PlainStateCache) loadAccountFromSnapshot(address libcommon.Address,
 	defer cache.accountLock.Unlock()
 	if account, ok := cache.accountCache[address]; ok {
 		// Cache hit
-		return account
+		return deepCopyAccount(account)
 	}
 
 	// Load to cache
@@ -208,12 +192,12 @@ func (cache *PlainStateCache) loadStorageFromSnapshot(key string, encSnapshot []
 	defer cache.storageLock.Unlock()
 	if value, ok := cache.storageCache[key]; ok {
 		// Cache hit
-		return value.Bytes()
+		return libcommon.Copy(value.Bytes())
 	}
 
 	// Load to cache
-	valueSnapshot := uint256.NewInt(0).SetBytes(encSnapshot)
-	cache.storageCache[key] = valueSnapshot
+	vSnapshot := uint256.NewInt(0).SetBytes(encSnapshot)
+	cache.storageCache[key] = vSnapshot
 	return encSnapshot
 }
 
@@ -222,7 +206,7 @@ func (cache *PlainStateCache) loadCodeFromSnapshot(key libcommon.Hash, codeSnaps
 	defer cache.codeLock.Unlock()
 	if code, ok := cache.codeCache[key]; ok {
 		// Cache hit
-		return code
+		return libcommon.Copy(code)
 	}
 
 	// Load to cache

--- a/core/types/accounts/account_xlayer.go
+++ b/core/types/accounts/account_xlayer.go
@@ -1,0 +1,22 @@
+package accounts
+
+import (
+	"github.com/holiman/uint256"
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
+)
+
+// Helper function for deep copy
+func DeepCopyAccount(acc *Account) *Account {
+	if acc == nil {
+		return nil
+	}
+	return &Account{
+		Initialised:     acc.Initialised,
+		Nonce:           acc.Nonce,
+		Balance:         *uint256.NewInt(0).Set(&acc.Balance),
+		Root:            libcommon.BytesToHash(acc.Root.Bytes()),
+		CodeHash:        libcommon.BytesToHash(acc.CodeHash.Bytes()),
+		Incarnation:     acc.Incarnation,
+		PrevIncarnation: acc.PrevIncarnation,
+	}
+}

--- a/turbo/stages/stageloop_xlayer.go
+++ b/turbo/stages/stageloop_xlayer.go
@@ -159,6 +159,8 @@ func ListenTxKafka(ctx context.Context, txKafkaConsumer *kafka.KafkaConsumer, co
 	errorChan := make(chan error, 1)
 	go txKafkaConsumer.ConsumeKafka(ctx, headersChan, txMsgsChan, errorChan, logger)
 
+	// TODO: Start snapshot and sync height with incoming kafka messages
+
 	for {
 		select {
 		case <-ctx.Done():

--- a/turbo/stages/stageloop_xlayer.go
+++ b/turbo/stages/stageloop_xlayer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ledgerwatch/log/v3"
 
 	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/erigon/core/state"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/zk/kafka"
 	kafkaTypes "github.com/ledgerwatch/erigon/zk/kafka/types"
@@ -141,7 +142,7 @@ func FlushDataToDB(ctx context.Context, db *mdbx.MdbxKV, logger log.Logger, cach
 	cache.TruncateSmtCacheList(saveData.BlockHeight)
 }
 
-func ListenTxKafka(ctx context.Context, txKafkaConsumer *kafka.KafkaConsumer, config ethconfig.XLayerConfig, logger log.Logger, txInfoMap *zktypes.TxInfoMap, headerMap *zktypes.HeaderMap) {
+func ListenTxKafka(ctx context.Context, txKafkaConsumer *kafka.KafkaConsumer, config ethconfig.XLayerConfig, logger log.Logger, txInfoMap *zktypes.TxInfoMap, headerMap *zktypes.HeaderMap, stateCache *state.PlainStateCache) {
 	if sequencer.IsSequencer() {
 		logger.Info("txKafkaConsumer is disabled on sequencer, skipping")
 		return
@@ -166,6 +167,7 @@ func ListenTxKafka(ctx context.Context, txKafkaConsumer *kafka.KafkaConsumer, co
 			headerMap.Put(header.Number.Uint64(), &header)
 			logger.Info("Received header message", "header", header)
 		case txMsg := <-txMsgsChan:
+			// 1. Process non-state data
 			tx, blockNumber, err := txMsg.GetTransaction()
 			if err != nil {
 				logger.Error("failed to consume transaction message from kafka", "error", err)
@@ -181,14 +183,16 @@ func ListenTxKafka(ctx context.Context, txKafkaConsumer *kafka.KafkaConsumer, co
 				logger.Error("failed to consume tx innerTxs message from kafka", "error", err)
 				continue
 			}
+			txInfoMap.Put(tx.Hash(), tx, receipt, innerTxs)
+
+			// 2. Process state data
 			changeset, err := txMsg.GetChangeset()
 			if err != nil {
 				logger.Error("failed to consume tx changeset message from kafka", "error", err)
 				continue
 			}
-			txInfoMap.Put(tx.Hash(), tx, receipt, innerTxs)
+			stateCache.ApplyChangeset(changeset)
 
-			// TODO: Use changeset to generate new state
 			logger.Info("Received transaction message", "tx", tx, "blockNumber", blockNumber, "receipt", receipt, "innerTxs", innerTxs, "changeset", changeset)
 		case err := <-errorChan:
 			logger.Error("kafka consumer failed", "error", err)


### PR DESCRIPTION
## Summary

- Add plain state reader with caching layer
- Add logic for consuming state changesets sent from the sequencer execution
- Add caching layer logic for storing and retrieving state from cache layer and snapshot
- TODO: to add pipeline to start state cache with snapshot, and sync snapshot height with incoming changeset height data from the sequencer