### PR TITLE
RPC: Handle kafka errors properly

### DIFF
--- a/cmd/utils/flags_xlayer.go
+++ b/cmd/utils/flags_xlayer.go
@@ -357,6 +357,11 @@ var (
 		Usage: "Kafka tx topic",
 		Value: "",
 	}
+	KafkaSyncErrorTopic = cli.StringFlag{
+		Name:  "kafka.sync-error-topic",
+		Usage: "Kafka error trigger topic",
+		Value: "",
+	}
 	KafkaSyncClientID = cli.StringFlag{
 		Name:  "kafka.sync-client-id",
 		Usage: "Kafka sync client id",

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -272,6 +272,7 @@ func splitAddrIntoHostAndPort(addr string) (host string, port int, err error) {
 }
 
 const blockBufferSize = 128
+const kafkaBufferSize = 10000
 
 // New creates a new Ethereum object (including the
 // initialisation of the common Ethereum object)
@@ -1235,8 +1236,8 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 					return nil, err
 				}
 				backend.txKafkaProducer = kafkaProducer
-				backend.headerChan = make(chan *types.Header, 10000)
-				backend.txInfoChan = make(chan *state.TxInfo, 10000)
+				backend.headerChan = make(chan *types.Header, kafkaBufferSize)
+				backend.txInfoChan = make(chan *state.TxInfo, kafkaBufferSize)
 			}
 
 			backend.syncStages = stages2.NewSequencerZkStages(

--- a/eth/ethconfig/config_xlayer.go
+++ b/eth/ethconfig/config_xlayer.go
@@ -76,5 +76,6 @@ type KafkaConfig struct {
 	BootstrapServers []string
 	BlockTopic       string
 	TxTopic          string
+	ErrorTopic       string
 	ClientID         string
 }

--- a/test/config/test.erigon.rpc.config.yaml
+++ b/test/config/test.erigon.rpc.config.yaml
@@ -87,4 +87,5 @@ kafka.sync-enable-flag: true
 kafka.sync-bootstrap-servers: "xlayer-kafka:9092"
 kafka.sync-tx-topic: xlayer-tx
 kafka.sync-block-topic: xlayer-header
+kafka.sync-error-topic: xlayer-error
 kafka.sync-client-id: "xlayer-consumer"

--- a/test/config/test.erigon.seq.config.yaml
+++ b/test/config/test.erigon.seq.config.yaml
@@ -115,4 +115,5 @@ kafka.sync-enable-flag: true
 kafka.sync-bootstrap-servers: "xlayer-kafka:9092"
 kafka.sync-tx-topic: xlayer-tx
 kafka.sync-block-topic: xlayer-header
+kafka.sync-error-topic: xlayer-error
 kafka.sync-client-id: "xlayer-producer"

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -368,5 +368,6 @@ var DefaultFlags = []cli.Flag{
 	&utils.KafkaSyncBootstrapServers,
 	&utils.KafkaSyncBlockTopic,
 	&utils.KafkaSyncTxTopic,
+	&utils.KafkaSyncErrorTopic,
 	&utils.KafkaSyncClientID,
 }

--- a/turbo/cli/flags_xlayer.go
+++ b/turbo/cli/flags_xlayer.go
@@ -65,6 +65,7 @@ func ApplyFlagsForEthXLayerConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 			BootstrapServers: strings.Split(ctx.String(utils.KafkaSyncBootstrapServers.Name), ","),
 			BlockTopic:       ctx.String(utils.KafkaSyncBlockTopic.Name),
 			TxTopic:          ctx.String(utils.KafkaSyncTxTopic.Name),
+			ErrorTopic:       ctx.String(utils.KafkaSyncErrorTopic.Name),
 			ClientID:         ctx.String(utils.KafkaSyncClientID.Name),
 		},
 	}

--- a/turbo/stages/stageloop_xlayer.go
+++ b/turbo/stages/stageloop_xlayer.go
@@ -156,8 +156,9 @@ func ListenTxKafkaConsumer(ctx context.Context, txKafkaConsumer *kafka.KafkaCons
 	// Start the kafka consumer
 	headersChan := make(chan types.Header, MaxKafkaChanSize)
 	txMsgsChan := make(chan kafkaTypes.TransactionMessage, MaxKafkaChanSize)
+	errorMsgsChan := make(chan kafkaTypes.ErrorTriggerMessage, MaxKafkaChanSize)
 	errorChan := make(chan error, 1)
-	go txKafkaConsumer.ConsumeKafka(ctx, headersChan, txMsgsChan, errorChan, logger)
+	go txKafkaConsumer.ConsumeKafka(ctx, headersChan, txMsgsChan, errorMsgsChan, errorChan, logger)
 
 	// TODO: Start snapshot and sync height with incoming kafka messages
 
@@ -196,6 +197,12 @@ func ListenTxKafkaConsumer(ctx context.Context, txKafkaConsumer *kafka.KafkaCons
 			stateCache.ApplyChangeset(changeset)
 
 			logger.Info("Received transaction message", "tx", tx, "blockNumber", blockNumber, "receipt", receipt, "innerTxs", innerTxs, "changeset", changeset)
+		case errorTriggerMsg := <-errorMsgsChan:
+			triggerHeight := errorTriggerMsg.BlockNumber
+			logger.Info("Received error trigger message", "triggerHeight", triggerHeight)
+
+			// TODO: handle trigger unwind here on producer side error
+
 		case err := <-errorChan:
 			logger.Error("kafka consumer failed", "error", err)
 			return
@@ -221,16 +228,30 @@ func ListenTxKafkaProducer(
 	}
 
 	for {
+		var err error
+		currHeight := uint64(0)
+
 		select {
 		case <-ctx.Done():
 			return
 		case header := <-headersChan:
+			currHeight = header.Number.Uint64()
 			// log.Info("Kafka prepare to send header", "header", header)
-			txKafkaProducer.SendKafkaBlockHeader(ctx, header)
+			err = txKafkaProducer.SendKafkaBlockHeader(ctx, header)
 		case txInfo := <-txInfoChan:
+			currHeight = txInfo.BlockNumber
 			changeset := state.CollectChangeset(txInfo.Entries)
 			// log.Info("Kafka prepare to send transaction", "txhash", txInfo.Tx.Hash(), "receipt", txInfo.Receipt, "innerTxs", txInfo.InnerTxs, "changeset", changeset)
-			txKafkaProducer.SendKafkaTransaction(ctx, txInfo.BlockNumber, txInfo.Tx, txInfo.Receipt, txInfo.InnerTxs, changeset)
+			err = txKafkaProducer.SendKafkaTransaction(ctx, txInfo.BlockNumber, txInfo.Tx, txInfo.Receipt, txInfo.InnerTxs, changeset)
+		}
+
+		if err != nil {
+			logger.Error("Failed to send kafka message, trigger error message", "error", err, "currHeight", currHeight)
+			err = txKafkaProducer.SendKafkaErrorTrigger(ctx, currHeight)
+			if err != nil {
+				logger.Error("Failed to send error trigger message", "error", err, "blockNumber", currHeight)
+			}
+			continue
 		}
 	}
 }

--- a/turbo/stages/zk_stages.go
+++ b/turbo/stages/zk_stages.go
@@ -116,8 +116,8 @@ func NewSequencerZkStages(ctx context.Context,
 	txPoolDb kv.RwDB,
 	infoTreeUpdater *l1infotree.Updater,
 	hook *Hook,
-	headerChan chan *types.Header,
-	txInfoChan chan *state2.TxInfo,
+	kafkaHeaderChan chan *types.Header,
+	kafkaTxInfoChan chan *state2.TxInfo,
 ) []*stagedsync.Stage {
 	dirs := cfg.Dirs
 	blockReader := freezeblocks.NewBlockReader(snapshots, nil)
@@ -158,8 +158,8 @@ func NewSequencerZkStages(ctx context.Context,
 			uint16(cfg.YieldSize),
 			infoTreeUpdater,
 			hook,
-			headerChan,
-			txInfoChan,
+			kafkaHeaderChan,
+			kafkaTxInfoChan,
 		),
 		stagedsync.StageHashStateCfg(db, dirs, cfg.HistoryV3, agg),
 		// For X Layer, split db and ac

--- a/zk/kafka/consumer.go
+++ b/zk/kafka/consumer.go
@@ -37,13 +37,15 @@ func NewKafkaConsumer(config ethconfig.KafkaConfig) (*KafkaConsumer, error) {
 }
 
 type consumerGroupHandler struct {
-	ctx         context.Context
-	headersChan chan types1.Header
-	txMsgsChan  chan kafkaTypes.TransactionMessage
-	errorChan   chan error
-	logger      log.Logger
-	txTopic     string
-	blockTopic  string
+	ctx           context.Context
+	headersChan   chan types1.Header
+	txMsgsChan    chan kafkaTypes.TransactionMessage
+	errorMsgsChan chan kafkaTypes.ErrorTriggerMessage
+	errorChan     chan error
+	logger        log.Logger
+	txTopic       string
+	blockTopic    string
+	errorTopic    string
 }
 
 func (h *consumerGroupHandler) Setup(session sarama.ConsumerGroupSession) error {
@@ -74,7 +76,7 @@ func (h *consumerGroupHandler) ConsumeClaim(session sarama.ConsumerGroupSession,
 					continue
 				}
 
-				// Send message to channel
+				// Send message to header channel
 				select {
 				case h.headersChan <- header:
 					session.MarkMessage(msg, "")
@@ -90,9 +92,25 @@ func (h *consumerGroupHandler) ConsumeClaim(session sarama.ConsumerGroupSession,
 					continue
 				}
 
-				// Send message to channel
+				// Send message to tx channel
 				select {
 				case h.txMsgsChan <- txMsg:
+					session.MarkMessage(msg, "")
+				case <-h.ctx.Done():
+					err := fmt.Errorf("context cancelled - stopping consume claim")
+					h.errorChan <- err
+					return err
+				}
+			case h.errorTopic:
+				var errorMsg kafkaTypes.ErrorTriggerMessage
+				if err := json.Unmarshal(msg.Value, &errorMsg); err != nil {
+					h.logger.Warn("consume claim error, unmarshaling error trigger message", "error", err)
+					continue
+				}
+
+				// Send message to error trigger channel
+				select {
+				case h.errorMsgsChan <- errorMsg:
 					session.MarkMessage(msg, "")
 				case <-h.ctx.Done():
 					err := fmt.Errorf("context cancelled - stopping consume claim")
@@ -109,18 +127,20 @@ func (h *consumerGroupHandler) ConsumeClaim(session sarama.ConsumerGroupSession,
 }
 
 // ConsumeKafka starts consuming kafka messages from the specified topics
-func (client *KafkaConsumer) ConsumeKafka(ctx context.Context, headersChan chan types1.Header, txMsgsChan chan kafkaTypes.TransactionMessage, errorChan chan error, logger log.Logger) {
+func (client *KafkaConsumer) ConsumeKafka(ctx context.Context, headersChan chan types1.Header, txMsgsChan chan kafkaTypes.TransactionMessage, errorMsgsChan chan kafkaTypes.ErrorTriggerMessage, errorChan chan error, logger log.Logger) {
 	handler := &consumerGroupHandler{
-		ctx:         ctx,
-		headersChan: headersChan,
-		txMsgsChan:  txMsgsChan,
-		errorChan:   errorChan,
-		logger:      logger,
-		txTopic:     client.config.TxTopic,
-		blockTopic:  client.config.BlockTopic,
+		ctx:           ctx,
+		headersChan:   headersChan,
+		txMsgsChan:    txMsgsChan,
+		errorMsgsChan: errorMsgsChan,
+		errorChan:     errorChan,
+		logger:        logger,
+		txTopic:       client.config.TxTopic,
+		blockTopic:    client.config.BlockTopic,
+		errorTopic:    client.config.ErrorTopic,
 	}
 
-	topics := []string{client.config.TxTopic, client.config.BlockTopic}
+	topics := []string{client.config.TxTopic, client.config.BlockTopic, client.config.ErrorTopic}
 	err := client.consumer.Consume(ctx, topics, handler)
 	if err != nil {
 		errorChan <- fmt.Errorf("ConsumeKafkaTransactions error: %v", err)

--- a/zk/kafka/kafka_test.go
+++ b/zk/kafka/kafka_test.go
@@ -84,9 +84,10 @@ func TestKafkaConsumer(t *testing.T) {
 	rightvrsTx.SetSender(testFromAddr)
 	cfg := ethconfig.KafkaConfig{
 		Enable:           true,
-		BootstrapServers: []string{"0.0.0.0:9095"},
+		BootstrapServers: []string{"0.0.0.0:9094"},
 		BlockTopic:       "xlayer-test-block",
 		TxTopic:          "xlayer-test-tx",
+		ErrorTopic:       "xlayer-test-error",
 		ClientID:         "xlayer-test-consumer",
 	}
 	consumer, err := NewKafkaConsumer(cfg)
@@ -94,8 +95,9 @@ func TestKafkaConsumer(t *testing.T) {
 	ctx, ctxWithCancel := context.WithCancel(context.Background())
 	headersChan := make(chan types1.Header, 10)
 	txMsgsChan := make(chan kafkaTypes.TransactionMessage, 10)
+	errorMsgsChan := make(chan kafkaTypes.ErrorTriggerMessage, 10)
 	errorChan := make(chan error, 10)
-	go consumer.ConsumeKafka(ctx, headersChan, txMsgsChan, errorChan, log.New())
+	go consumer.ConsumeKafka(ctx, headersChan, txMsgsChan, errorMsgsChan, errorChan, log.New())
 
 	// Verify tx messages
 	for i := 0; i < 10; i++ {
@@ -120,6 +122,16 @@ func TestKafkaConsumer(t *testing.T) {
 		}
 	}
 
+	// Verify error trigger messages
+	for i := 0; i < 10; i++ {
+		select {
+		case err := <-errorChan:
+			t.Fatalf("Received error from consumer: %v", err)
+		case errorMsg := <-errorMsgsChan:
+			assert.Equal(t, errorMsg.BlockNumber, uint64(i))
+		}
+	}
+
 	ctxWithCancel()
 	err = consumer.Close()
 	assert.NilError(t, err)
@@ -129,9 +141,10 @@ func TestKafkaProducer(t *testing.T) {
 	rightvrsTx.SetSender(testFromAddr)
 	cfg := ethconfig.KafkaConfig{
 		Enable:           true,
-		BootstrapServers: []string{"0.0.0.0:9095"},
+		BootstrapServers: []string{"0.0.0.0:9094"},
 		BlockTopic:       "xlayer-test-block",
 		TxTopic:          "xlayer-test-tx",
+		ErrorTopic:       "xlayer-test-error",
 		ClientID:         "xlayer-test-consumer",
 	}
 	producer, err := NewKafkaProducer(cfg)
@@ -142,6 +155,9 @@ func TestKafkaProducer(t *testing.T) {
 		assert.NilError(t, err)
 
 		err = producer.SendKafkaBlockHeader(context.Background(), blockHeader)
+		assert.NilError(t, err)
+
+		err = producer.SendKafkaErrorTrigger(context.Background(), uint64(i))
 		assert.NilError(t, err)
 	}
 

--- a/zk/kafka/producer.go
+++ b/zk/kafka/producer.go
@@ -89,3 +89,29 @@ func (client *KafkaProducer) SendKafkaBlockHeader(ctx context.Context, header *t
 
 	return nil
 }
+
+func (client *KafkaProducer) SendKafkaErrorTrigger(ctx context.Context, blockNumber uint64) error {
+	// Create error trigger message
+	msg := kafkaTypes.ErrorTriggerMessage{
+		BlockNumber: blockNumber,
+	}
+	jsonData, err := msg.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("error marshaling error trigger message: %v", err)
+	}
+
+	// Create Kafka message
+	kafkaMsg := &sarama.ProducerMessage{
+		Topic: client.config.ErrorTopic,
+		Value: sarama.StringEncoder(jsonData),
+		Key:   sarama.StringEncoder(fmt.Sprintf("%d", blockNumber)),
+	}
+
+	// Send message
+	_, _, err = client.producer.SendMessage(kafkaMsg)
+	if err != nil {
+		return fmt.Errorf("error sending message to Kafka: %v", err)
+	}
+
+	return nil
+}

--- a/zk/kafka/types/error.go
+++ b/zk/kafka/types/error.go
@@ -1,0 +1,18 @@
+package types
+
+import "encoding/json"
+
+type ErrorTriggerMessage struct {
+	BlockNumber uint64 `json:"blockNumber"`
+}
+
+func (msg ErrorTriggerMessage) MarshalJSON() ([]byte, error) {
+	type ErrorTriggerMessage struct {
+		BlockNumber uint64 `json:"blockNumber"`
+	}
+
+	var enc ErrorTriggerMessage
+	enc.BlockNumber = msg.BlockNumber
+
+	return json.Marshal(&enc)
+}

--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -457,7 +457,7 @@ BatchLoop:
 
 		// For X Layer, send kafka block header
 		if cfg.zk.XLayer.Kafka.Enable {
-			cfg.headerChan <- header
+			cfg.kafkaHeaderChan <- header
 		}
 
 	OuterLoopTransactions:

--- a/zk/stages/stage_sequence_execute_transactions.go
+++ b/zk/stages/stage_sequence_execute_transactions.go
@@ -287,7 +287,7 @@ func attemptAddTransaction(
 	}
 
 	if cfg.zk.XLayer.Kafka.Enable {
-		ibs.GenerateChangesetSinceSnapshotAndSendTxInfo(snapshot, cfg.txInfoChan, transaction, receipt, innerTxs)
+		ibs.GenerateChangesetSinceSnapshotAndSendTxInfo(snapshot, cfg.kafkaTxInfoChan, transaction, receipt, innerTxs)
 	}
 
 	ibs.FinalizeTx(evm.ChainRules(), noop)

--- a/zk/stages/stage_sequence_execute_utils.go
+++ b/zk/stages/stage_sequence_execute_utils.go
@@ -33,7 +33,6 @@ import (
 	"github.com/ledgerwatch/erigon/turbo/stages/headerdownload"
 	"github.com/ledgerwatch/erigon/zk/datastream/server"
 	"github.com/ledgerwatch/erigon/zk/hermez_db"
-	"github.com/ledgerwatch/erigon/zk/kafka"
 	"github.com/ledgerwatch/erigon/zk/l1infotree"
 	zktx "github.com/ledgerwatch/erigon/zk/tx"
 	"github.com/ledgerwatch/erigon/zk/txpool"
@@ -96,9 +95,9 @@ type SequenceBlockCfg struct {
 	decodedTxCache *expirable.LRU[common.Hash, *types.Transaction]
 	doneHook       DoneHook
 
-	txKafkaProducer *kafka.KafkaProducer
-	headerChan      chan *types.Header
-	txInfoChan      chan *state.TxInfo
+	// For X Layer, kafka
+	kafkaHeaderChan chan *types.Header
+	kafkaTxInfoChan chan *state.TxInfo
 }
 
 func StageSequenceBlocksCfg(
@@ -129,8 +128,10 @@ func StageSequenceBlocksCfg(
 	yieldSize uint16,
 	infoTreeUpdater *l1infotree.Updater,
 	doneHook DoneHook,
-	headerChan chan *types.Header,
-	txInfoChan chan *state.TxInfo,
+
+	// For X Layer, kafka
+	kafkaHeaderChan chan *types.Header,
+	kafkaTxInfoChan chan *state.TxInfo,
 ) SequenceBlockCfg {
 
 	return SequenceBlockCfg{
@@ -163,8 +164,8 @@ func StageSequenceBlocksCfg(
 		dbsmt: dbsmt,
 
 		// For X Layer, kafka
-		headerChan: headerChan,
-		txInfoChan: txInfoChan,
+		kafkaHeaderChan: kafkaHeaderChan,
+		kafkaTxInfoChan: kafkaTxInfoChan,
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add error trigger channels to ensure better atomicity in state/non-state message updates from sequencer to RPCs
- TODO: add error triggers to re-sync/reset state cache layer with latest height from DB 