### PR TITLE
RPC: Add realtime RPC support for stateless and stateful APIs

### DIFF
--- a/core/state/plain_state_reader_xlayer.go
+++ b/core/state/plain_state_reader_xlayer.go
@@ -53,10 +53,6 @@ func (cache *PlainStateCache) ApplyChangeset(changeset *zktypes.Changeset) error
 
 	// Apply code changes
 	for address, code := range changeset.CodeChanges {
-		if _, ok := changeset.DeletedAccounts[address]; ok {
-			continue
-		}
-
 		account, ok := addressChanges[address]
 		if !ok {
 			return fmt.Errorf("apply code changes failed: no codehash received")
@@ -66,10 +62,6 @@ func (cache *PlainStateCache) ApplyChangeset(changeset *zktypes.Changeset) error
 
 	// Apply storage changes
 	for address, storage := range changeset.StorageChanges {
-		if _, ok := changeset.DeletedAccounts[address]; ok {
-			continue
-		}
-
 		account, err := cache.getOrCreateAccount(address, addressChanges)
 		if err != nil {
 			return fmt.Errorf("apply storage changes failed: %v", err)
@@ -79,6 +71,12 @@ func (cache *PlainStateCache) ApplyChangeset(changeset *zktypes.Changeset) error
 			compositeKey := dbutils.PlainGenerateCompositeStorageKey(address.Bytes(), account.Incarnation, key.Bytes())
 			cache.storageCache[string(compositeKey)] = value
 		}
+	}
+
+	// Apply deleted accounts changes
+	for address := range changeset.DeletedAccounts {
+		// Non-existent / deleted accounts are set to nil
+		addressChanges[address] = nil
 	}
 
 	// Apply account changes
@@ -132,6 +130,8 @@ func (cache *PlainStateCache) ApplyChangesetToAccountData(changeset *zktypes.Cha
 
 	// Apply incarnation changes
 	for address, incarnation := range changeset.IncarnationChanges {
+		cache.incarnationCache[address] = incarnation
+
 		if _, ok := changeset.DeletedAccounts[address]; ok {
 			continue
 		}
@@ -142,12 +142,6 @@ func (cache *PlainStateCache) ApplyChangesetToAccountData(changeset *zktypes.Cha
 		}
 		account.PrevIncarnation = incarnation - 1
 		account.Incarnation = incarnation
-	}
-
-	// Apply deleted accounts changes
-	for address := range changeset.DeletedAccounts {
-		// Non-existent / deleted accounts are set to nil
-		addressChanges[address] = nil
 	}
 
 	return nil
@@ -239,7 +233,7 @@ func (cache *PlainStateCache) getOrCreateAccount(address libcommon.Address, addr
 
 		if account == nil {
 			// Non-existent account, create new account
-			account, err = cache.createAccount(address)
+			account, err = cache.createAccount()
 			if err != nil {
 				return nil, err
 			}
@@ -250,7 +244,7 @@ func (cache *PlainStateCache) getOrCreateAccount(address libcommon.Address, addr
 	return account, nil
 }
 
-func (cache *PlainStateCache) createAccount(address libcommon.Address) (*accounts.Account, error) {
+func (cache *PlainStateCache) createAccount() (*accounts.Account, error) {
 	return &accounts.Account{
 		Initialised: true,
 		Nonce:       0,

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -254,9 +254,8 @@ type Ethereum struct {
 	// For X Layer, kafka
 	txKafkaProducer *kafka.KafkaProducer
 	txKafkaConsumer *kafka.KafkaConsumer
-	txInfoMap       *zktypes.TxInfoMap
-	headerMap       *zktypes.HeaderMap
 	stateCache      *state.PlainStateCache
+	statelessCache  *zktypes.StatelessCache
 	headerChan      chan *types.Header
 	txInfoChan      chan *state.TxInfo
 }
@@ -1294,9 +1293,8 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 					return nil, err
 				}
 				backend.txKafkaConsumer = kafkaConsumer
-				backend.txInfoMap = zktypes.NewTxInfoMap()
-				backend.headerMap = zktypes.NewHeaderMap()
 				backend.stateCache = nil
+				backend.statelessCache = zktypes.NewStatelessCache()
 			}
 
 			backend.syncStages = stages2.NewDefaultZkStages(
@@ -1315,8 +1313,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 				streamClient,
 				dataStreamServer,
 				l1InfoTreeUpdater,
-				backend.txInfoMap,
-				backend.headerMap,
+				backend.statelessCache,
 			)
 
 			backend.syncUnwindOrder = zkStages.ZkUnwindOrder
@@ -1437,7 +1434,7 @@ func (s *Ethereum) Init(stack *node.Node, config *ethconfig.Config, chainConfig 
 
 	var gpCache *jsonrpc.GasPriceCache
 	// For X Layer, split db
-	s.apiList, gpCache = jsonrpc.APIList(chainKv, s.smtDB, ethRpcClient, txPoolRpcClient, s.txPool2, miningRpcClient, ff, stateCache, blockReader, s.agg, &httpRpcCfg, s.engine, config, s.l1Syncer, s.logger, dataStreamServer, s.gasTracker, s.stagedSync.GetCache(), s.txInfoMap, s.headerMap, s.stateCache)
+	s.apiList, gpCache = jsonrpc.APIList(chainKv, s.smtDB, ethRpcClient, txPoolRpcClient, s.txPool2, miningRpcClient, ff, stateCache, blockReader, s.agg, &httpRpcCfg, s.engine, config, s.l1Syncer, s.logger, dataStreamServer, s.gasTracker, s.stagedSync.GetCache(), s.stateCache, s.statelessCache)
 
 	// For X Layer
 	if s.txPool2 != nil && gpCache != nil {
@@ -2007,7 +2004,7 @@ func (s *Ethereum) Start() error {
 
 		go stages2.StageLoop(s.sentryCtx, s.chainDB, s.stagedSync, s.sentriesClient.Hd, s.waitForStageLoopStop, s.config.Sync.LoopThrottle, s.logger, s.blockReader, hook, s.config.ForcePartialCommit)
 
-		go stages2.ListenTxKafkaConsumer(s.sentryCtx, s.txKafkaConsumer, s.config.Zk.XLayer, s.logger, s.txInfoMap, s.headerMap, s.stateCache)
+		go stages2.ListenTxKafkaConsumer(s.sentryCtx, s.txKafkaConsumer, s.config.Zk.XLayer, s.logger, s.stateCache, s.statelessCache)
 
 		go stages2.ListenTxKafkaProducer(s.sentryCtx, s.txKafkaProducer, s.config.Zk.XLayer, s.logger, s.headerChan, s.txInfoChan)
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1437,7 +1437,7 @@ func (s *Ethereum) Init(stack *node.Node, config *ethconfig.Config, chainConfig 
 
 	var gpCache *jsonrpc.GasPriceCache
 	// For X Layer, split db
-	s.apiList, gpCache = jsonrpc.APIList(chainKv, s.smtDB, ethRpcClient, txPoolRpcClient, s.txPool2, miningRpcClient, ff, stateCache, blockReader, s.agg, &httpRpcCfg, s.engine, config, s.l1Syncer, s.logger, dataStreamServer, s.gasTracker, s.stagedSync.GetCache(), s.txInfoMap, s.headerMap)
+	s.apiList, gpCache = jsonrpc.APIList(chainKv, s.smtDB, ethRpcClient, txPoolRpcClient, s.txPool2, miningRpcClient, ff, stateCache, blockReader, s.agg, &httpRpcCfg, s.engine, config, s.l1Syncer, s.logger, dataStreamServer, s.gasTracker, s.stagedSync.GetCache(), s.txInfoMap, s.headerMap, s.stateCache)
 
 	// For X Layer
 	if s.txPool2 != nil && gpCache != nil {

--- a/eth/stagedsync/stage_execute_zkevm.go
+++ b/eth/stagedsync/stage_execute_zkevm.go
@@ -36,7 +36,7 @@ import (
 	"github.com/ledgerwatch/erigon/zk/utils"
 )
 
-func SpawnExecuteBlocksStageZk(s *StageState, u Unwinder, tx kv.RwTx, toBlock uint64, ctx context.Context, cfg ExecuteBlockCfg, initialCycle bool, txInfoMap *zktypes.TxInfoMap, headerMap *zktypes.HeaderMap) (err error) {
+func SpawnExecuteBlocksStageZk(s *StageState, u Unwinder, tx kv.RwTx, toBlock uint64, ctx context.Context, cfg ExecuteBlockCfg, initialCycle bool, statelessCache *zktypes.StatelessCache) (err error) {
 	if cfg.historyV3 {
 		if err = ExecBlockV3(s, u, wrap.TxContainer{Tx: tx}, toBlock, ctx, cfg, initialCycle, log.New()); err != nil {
 			return fmt.Errorf("ExecBlockV3: %w", err)
@@ -216,10 +216,7 @@ Loop:
 
 		// For X Layer, delete receipts from the map
 		if cfg.zk.XLayer.Kafka.Enable {
-			for _, tx := range block.Transactions() {
-				txInfoMap.Delete(tx.Hash())
-			}
-			headerMap.Delete(block.NumberU64())
+			statelessCache.DeleteBlock(blockNum, block)
 		}
 	}
 

--- a/eth/stagedsync/stage_execute_zkevm.go
+++ b/eth/stagedsync/stage_execute_zkevm.go
@@ -214,7 +214,7 @@ Loop:
 			return fmt.Errorf("postExecuteCommitValues: %w", err)
 		}
 
-		// For X Layer, delete receipts from the map
+		// For X Layer, delete block data from the stateless cache
 		if cfg.zk.XLayer.Kafka.Enable {
 			statelessCache.DeleteBlock(blockNum, block)
 		}

--- a/turbo/jsonrpc/daemon.go
+++ b/turbo/jsonrpc/daemon.go
@@ -34,9 +34,8 @@ func APIList(db kv.RoDB, dbsmt kv.RoDB, eth rpchelper.ApiBackend, txPool txpool.
 	gasTracker *RecurringL1GasPriceTracker,
 	// For X Layer
 	cache *smt.SmtCache,
-	txInfoMap *zktypes.TxInfoMap,
-	headerMap *zktypes.HeaderMap,
-	pStateCache state.StateReader,
+	kStateCache state.StateReader,
+	kStatelessCache *zktypes.StatelessCache,
 ) (list []rpc.API, gpCache *GasPriceCache) {
 	// non-sequencer nodes should forward on requests to the sequencer
 	rpcUrl := ""
@@ -81,7 +80,7 @@ func APIList(db kv.RoDB, dbsmt kv.RoDB, eth rpchelper.ApiBackend, txPool txpool.
 	// For X Layer, split db and ac
 	zkEvmImpl := NewZkEvmAPI(ethImpl, db, dbsmt, cfg.ReturnDataLimit, ethCfg, l1Syncer, rpcUrl, dataStreamServer, cache)
 	// For X Layer, realtime response
-	realtimeImpl := NewRealtimeAPI(ethImpl, txInfoMap, headerMap, pStateCache)
+	realtimeImpl := NewRealtimeAPI(ethImpl, kStateCache, kStatelessCache)
 
 	if cfg.GraphQLEnabled {
 		list = append(list, rpc.API{

--- a/turbo/jsonrpc/daemon.go
+++ b/turbo/jsonrpc/daemon.go
@@ -1,6 +1,7 @@
 package jsonrpc
 
 import (
+	"github.com/ledgerwatch/erigon/core/state"
 	"github.com/ledgerwatch/erigon/zk/smt"
 	"github.com/ledgerwatch/log/v3"
 
@@ -31,9 +32,11 @@ func APIList(db kv.RoDB, dbsmt kv.RoDB, eth rpchelper.ApiBackend, txPool txpool.
 	blockReader services.FullBlockReader, agg *libstate.Aggregator, cfg *httpcfg.HttpCfg, engine consensus.EngineReader,
 	ethCfg *ethconfig.Config, l1Syncer *syncer.L1Syncer, logger log.Logger, dataStreamServer server.DataStreamServer,
 	gasTracker *RecurringL1GasPriceTracker,
+	// For X Layer
 	cache *smt.SmtCache,
 	txInfoMap *zktypes.TxInfoMap,
 	headerMap *zktypes.HeaderMap,
+	pStateCache state.StateReader,
 ) (list []rpc.API, gpCache *GasPriceCache) {
 	// non-sequencer nodes should forward on requests to the sequencer
 	rpcUrl := ""
@@ -78,7 +81,7 @@ func APIList(db kv.RoDB, dbsmt kv.RoDB, eth rpchelper.ApiBackend, txPool txpool.
 	// For X Layer, split db and ac
 	zkEvmImpl := NewZkEvmAPI(ethImpl, db, dbsmt, cfg.ReturnDataLimit, ethCfg, l1Syncer, rpcUrl, dataStreamServer, cache)
 	// For X Layer, realtime response
-	realtimeImpl := NewRealtimeAPI(ethImpl, txInfoMap, headerMap)
+	realtimeImpl := NewRealtimeAPI(ethImpl, txInfoMap, headerMap, pStateCache)
 
 	if cfg.GraphQLEnabled {
 		list = append(list, rpc.API{

--- a/turbo/jsonrpc/realtime_accounts_xlayer.go
+++ b/turbo/jsonrpc/realtime_accounts_xlayer.go
@@ -1,0 +1,1 @@
+package jsonrpc

--- a/turbo/jsonrpc/realtime_accounts_xlayer.go
+++ b/turbo/jsonrpc/realtime_accounts_xlayer.go
@@ -1,1 +1,53 @@
 package jsonrpc
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/common/hexutil"
+	"github.com/ledgerwatch/erigon-lib/common/hexutility"
+	"github.com/ledgerwatch/erigon/common"
+)
+
+func (api *RealtimeAPIImpl) GetBalance(ctx context.Context, address libcommon.Address) (*hexutil.Big, error) {
+	acc, err := api.stateCache.ReadAccountData(address)
+	if err != nil {
+		return nil, fmt.Errorf("cant get a balance for account %x: %w", address.String(), err)
+	}
+	if acc == nil {
+		// Special case - non-existent account is assumed to have zero balance
+		return (*hexutil.Big)(big.NewInt(0)), nil
+	}
+
+	return (*hexutil.Big)(acc.Balance.ToBig()), nil
+}
+
+func (api *RealtimeAPIImpl) GetCode(ctx context.Context, address libcommon.Address) (hexutility.Bytes, error) {
+	acc, err := api.stateCache.ReadAccountData(address)
+	if acc == nil || err != nil {
+		return hexutility.Bytes(""), nil
+	}
+	res, _ := api.stateCache.ReadAccountCode(address, acc.Incarnation, acc.CodeHash)
+	if res == nil {
+		return hexutility.Bytes(""), nil
+	}
+	return res, nil
+}
+
+func (api *RealtimeAPIImpl) GetStorageAt(ctx context.Context, address libcommon.Address, index string) (string, error) {
+	var empty []byte
+
+	acc, err := api.stateCache.ReadAccountData(address)
+	if acc == nil || err != nil {
+		return hexutility.Encode(common.LeftPadBytes(empty, 32)), err
+	}
+
+	location := libcommon.HexToHash(index)
+	res, err := api.stateCache.ReadAccountStorage(address, acc.Incarnation, &location)
+	if err != nil {
+		res = empty
+	}
+	return hexutility.Encode(common.LeftPadBytes(res, 32)), err
+}

--- a/turbo/jsonrpc/realtime_api_xlayer.go
+++ b/turbo/jsonrpc/realtime_api_xlayer.go
@@ -3,13 +3,19 @@ package jsonrpc
 import (
 	"context"
 	"fmt"
+	"math/big"
 
 	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/hexutil"
 	"github.com/ledgerwatch/erigon-lib/common/hexutility"
 	"github.com/ledgerwatch/erigon/core/state"
+	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/rpc"
 	zktypes "github.com/ledgerwatch/erigon/zk/types"
+)
+
+var (
+	mockBlockHash = common.BytesToHash([]byte{1})
 )
 
 // RealtimeAPI is a collection of functions that are exposed in rpc only
@@ -83,4 +89,13 @@ func (api *RealtimeAPIImpl) getBlockNumber(blockNr rpc.BlockNumber) (uint64, boo
 		}
 		return blockNumber, blockNumber == currentBlockNumber, nil
 	}
+}
+
+// newRPCTransaction_realtime returns a transaction that will serialize to the RPC
+// representation, with the given location metadata set (if available).
+// Note that realtime API do not support blockHash.
+func newRPCTransaction_realtime(tx types.Transaction, blockNumber uint64, index uint64, baseFee *big.Int) *RPCTransaction {
+	result := NewRPCTransaction(tx, mockBlockHash, blockNumber, index, baseFee)
+	result.BlockHash = &common.Hash{}
+	return result
 }

--- a/turbo/jsonrpc/realtime_api_xlayer.go
+++ b/turbo/jsonrpc/realtime_api_xlayer.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ledgerwatch/erigon-lib/common"
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/hexutil"
 	"github.com/ledgerwatch/erigon-lib/common/hexutility"
 	"github.com/ledgerwatch/erigon/core/state"
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	mockBlockHash = common.BytesToHash([]byte{1})
+	mockBlockHash = libcommon.BytesToHash([]byte{1})
 )
 
 // RealtimeAPI is a collection of functions that are exposed in rpc only
@@ -25,18 +25,18 @@ type RealtimeAPI interface {
 	GetBlockTransactionCountByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*hexutil.Uint, error)
 
 	// Transaction related (see ./realtime_txs_xlayer.go)
-	GetTransactionByHash(ctx context.Context, hash common.Hash, includeExtraInfo *bool) (interface{}, error)
-	GetRawTransactionByHash(ctx context.Context, hash common.Hash) (hexutility.Bytes, error)
+	GetTransactionByHash(ctx context.Context, hash libcommon.Hash, includeExtraInfo *bool) (interface{}, error)
+	GetRawTransactionByHash(ctx context.Context, hash libcommon.Hash) (hexutility.Bytes, error)
 
 	// Receipt related (see ./realtime_receipts_xlayer.go)
-	GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error)
-	GetInternalTransactions(ctx context.Context, hash common.Hash) ([]*zktypes.InnerTx, error)
+	GetTransactionReceipt(ctx context.Context, hash libcommon.Hash) (map[string]interface{}, error)
+	GetInternalTransactions(ctx context.Context, hash libcommon.Hash) ([]*zktypes.InnerTx, error)
 
-	// // Account related (see ./realtime_accounts_xlayer.go)
-	// GetBalance(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (*hexutil.Big, error)
-	// GetTransactionCount(ctx context.Context, address common.Address, blockNrOrHash *rpc.BlockNumberOrHash) (*hexutil.Uint64, error)
-	// GetStorageAt(ctx context.Context, address common.Address, index string, blockNrOrHash rpc.BlockNumberOrHash) (string, error)
-	// GetCode(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (hexutility.Bytes, error)
+	// Account related (see ./realtime_accounts_xlayer.go)
+	GetBalance(ctx context.Context, address libcommon.Address, blockNrOrHash rpc.BlockNumberOrHash) (*hexutil.Big, error)
+	GetTransactionCount(ctx context.Context, address libcommon.Address, blockNrOrHash *rpc.BlockNumberOrHash) (*hexutil.Uint64, error)
+	GetStorageAt(ctx context.Context, address libcommon.Address, index string, blockNrOrHash rpc.BlockNumberOrHash) (string, error)
+	GetCode(ctx context.Context, address libcommon.Address, blockNrOrHash rpc.BlockNumberOrHash) (hexutility.Bytes, error)
 
 	// // Sending related (see ./realtime_call_xlayer.go)
 	// Call(ctx context.Context, args ethapi2.CallArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *ethapi2.StateOverrides) (hexutility.Bytes, error)
@@ -96,6 +96,6 @@ func (api *RealtimeAPIImpl) getBlockNumber(blockNr rpc.BlockNumber) (uint64, boo
 // Note that realtime API do not support blockHash.
 func newRPCTransaction_realtime(tx types.Transaction, blockNumber uint64, index uint64, baseFee *big.Int) *RPCTransaction {
 	result := NewRPCTransaction(tx, mockBlockHash, blockNumber, index, baseFee)
-	result.BlockHash = &common.Hash{}
+	result.BlockHash = &libcommon.Hash{}
 	return result
 }

--- a/turbo/jsonrpc/realtime_api_xlayer.go
+++ b/turbo/jsonrpc/realtime_api_xlayer.go
@@ -2,17 +2,20 @@ package jsonrpc
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/common/hexutil"
 	"github.com/ledgerwatch/erigon/core/state"
+	"github.com/ledgerwatch/erigon/rpc"
 	zktypes "github.com/ledgerwatch/erigon/zk/types"
 )
 
 // RealtimeAPI is a collection of functions that are exposed in rpc only
 type RealtimeAPI interface {
 	// // Block related (see ./realtime_blocks_xlayer.go)
-	// BlockNumber(ctx context.Context) (hexutil.Uint64, error)
-	// GetBlockTransactionCountByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*hexutil.Uint, error)
+	BlockNumber(ctx context.Context) (hexutil.Uint64, error)
+	GetBlockTransactionCountByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*hexutil.Uint, error)
 
 	// // Transaction related (see ./realtime_txs_xlayer.go)
 	// GetTransactionByHash(ctx context.Context, hash common.Hash, includeExtraInfo *bool) (interface{}, error)
@@ -50,5 +53,33 @@ func NewRealtimeAPI(
 		ethApi:         base,
 		stateCache:     stateCache,
 		statelessCache: statelessCache,
+	}
+}
+
+func (api *RealtimeAPIImpl) GetBlockNumber(blockNr rpc.BlockNumber) (uint64, bool, error) {
+	currentBlockNumber := api.statelessCache.GetHeight()
+	if currentBlockNumber == 0 {
+		return 0, false, fmt.Errorf("no block number found in stateless cache")
+	}
+
+	switch blockNr {
+	case rpc.LatestBlockNumber:
+		return currentBlockNumber, true, nil
+	case rpc.EarliestBlockNumber:
+		return 0, false, nil
+	case rpc.FinalizedBlockNumber:
+		return currentBlockNumber, true, nil
+	case rpc.SafeBlockNumber:
+		return currentBlockNumber, true, nil
+	case rpc.PendingBlockNumber:
+		return currentBlockNumber, true, nil
+	case rpc.LatestExecutedBlockNumber:
+		return currentBlockNumber, true, nil
+	default:
+		blockNumber := uint64(blockNr.Int64())
+		if blockNumber > currentBlockNumber {
+			return 0, false, fmt.Errorf("block with number %d not found", blockNumber)
+		}
+		return blockNumber, blockNumber == currentBlockNumber, nil
 	}
 }

--- a/turbo/jsonrpc/realtime_api_xlayer.go
+++ b/turbo/jsonrpc/realtime_api_xlayer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ledgerwatch/erigon/core/state"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/rpc"
+	ethapi2 "github.com/ledgerwatch/erigon/turbo/adapter/ethapi"
 	zktypes "github.com/ledgerwatch/erigon/zk/types"
 )
 
@@ -39,7 +40,7 @@ type RealtimeAPI interface {
 	GetCode(ctx context.Context, address libcommon.Address, blockNrOrHash rpc.BlockNumberOrHash) (hexutility.Bytes, error)
 
 	// // Sending related (see ./realtime_call_xlayer.go)
-	// Call(ctx context.Context, args ethapi2.CallArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *ethapi2.StateOverrides) (hexutility.Bytes, error)
+	Call(ctx context.Context, args ethapi2.CallArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *ethapi2.StateOverrides) (hexutility.Bytes, error)
 }
 
 // RealtimeAPIImpl is implementation of the RealtimeAPI interface

--- a/turbo/jsonrpc/realtime_api_xlayer.go
+++ b/turbo/jsonrpc/realtime_api_xlayer.go
@@ -4,13 +4,36 @@ import (
 	"context"
 
 	"github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/common/hexutil"
+	"github.com/ledgerwatch/erigon-lib/common/hexutility"
+	"github.com/ledgerwatch/erigon/core/state"
+	"github.com/ledgerwatch/erigon/rpc"
+	ethapi2 "github.com/ledgerwatch/erigon/turbo/adapter/ethapi"
 	zktypes "github.com/ledgerwatch/erigon/zk/types"
 )
 
 // RealtimeAPI is a collection of functions that are exposed in rpc only
 type RealtimeAPI interface {
+	// Block related (see ./realtime_blocks_xlayer.go)
+	BlockNumber(ctx context.Context) (hexutil.Uint64, error)
+	GetBlockTransactionCountByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*hexutil.Uint, error)
+
+	// Transaction related (see ./realtime_txs_xlayer.go)
+	GetTransactionByHash(ctx context.Context, hash common.Hash, includeExtraInfo *bool) (interface{}, error)
+	GetRawTransactionByHash(ctx context.Context, hash common.Hash) (hexutility.Bytes, error)
+
+	// Receipt related (see ./realtime_receipts_xlayer.go)
 	GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error)
 	GetInternalTransactions(ctx context.Context, hash common.Hash) ([]*zktypes.InnerTx, error)
+
+	// Account related (see ./realtime_accounts_xlayer.go)
+	GetBalance(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (*hexutil.Big, error)
+	GetTransactionCount(ctx context.Context, address common.Address, blockNrOrHash *rpc.BlockNumberOrHash) (*hexutil.Uint64, error)
+	GetStorageAt(ctx context.Context, address common.Address, index string, blockNrOrHash rpc.BlockNumberOrHash) (string, error)
+	GetCode(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (hexutility.Bytes, error)
+
+	// Sending related (see ./realtime_call_xlayer.go)
+	Call(ctx context.Context, args ethapi2.CallArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *ethapi2.StateOverrides) (hexutility.Bytes, error)
 }
 
 // RealtimeAPIImpl is implementation of the RealtimeAPI interface
@@ -27,6 +50,7 @@ func NewRealtimeAPI(
 	base *APIImpl,
 	txInfoMap *zktypes.TxInfoMap,
 	headerMap *zktypes.HeaderMap,
+	stateCache state.StateReader,
 ) *RealtimeAPIImpl {
 
 	return &RealtimeAPIImpl{
@@ -34,37 +58,4 @@ func NewRealtimeAPI(
 		txInfoMap: txInfoMap,
 		headerMap: headerMap,
 	}
-}
-
-func (api *RealtimeAPIImpl) GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
-	txn, receipt, _, ok := api.txInfoMap.Get(hash)
-	if !ok {
-		return api.ethApi.GetTransactionReceipt(ctx, hash)
-	}
-	header, ok := api.headerMap.Get(receipt.BlockNumber.Uint64())
-	if !ok {
-		return api.ethApi.GetTransactionReceipt(ctx, hash)
-	}
-
-	tx, err := api.ethApi.db.BeginRo(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-
-	cc, err := api.ethApi.chainConfig(ctx, tx)
-	if err != nil {
-		return nil, err
-	}
-
-	return marshalReceipt(receipt, txn, cc, header, txn.Hash(), true), nil
-}
-
-func (api *RealtimeAPIImpl) GetInternalTransactions(ctx context.Context, hash common.Hash) ([]*zktypes.InnerTx, error) {
-	_, _, innerTxs, ok := api.txInfoMap.Get(hash)
-	if !ok {
-		return api.ethApi.GetInternalTransactions(ctx, hash)
-	}
-
-	return innerTxs, nil
 }

--- a/turbo/jsonrpc/realtime_api_xlayer.go
+++ b/turbo/jsonrpc/realtime_api_xlayer.go
@@ -34,13 +34,12 @@ type RealtimeAPI interface {
 	GetInternalTransactions(ctx context.Context, hash libcommon.Hash) ([]*zktypes.InnerTx, error)
 
 	// Account related (see ./realtime_accounts_xlayer.go)
-	GetBalance(ctx context.Context, address libcommon.Address, blockNrOrHash rpc.BlockNumberOrHash) (*hexutil.Big, error)
-	GetTransactionCount(ctx context.Context, address libcommon.Address, blockNrOrHash *rpc.BlockNumberOrHash) (*hexutil.Uint64, error)
-	GetStorageAt(ctx context.Context, address libcommon.Address, index string, blockNrOrHash rpc.BlockNumberOrHash) (string, error)
-	GetCode(ctx context.Context, address libcommon.Address, blockNrOrHash rpc.BlockNumberOrHash) (hexutility.Bytes, error)
+	GetBalance(ctx context.Context, address libcommon.Address) (*hexutil.Big, error)
+	GetCode(ctx context.Context, address libcommon.Address) (hexutility.Bytes, error)
+	GetStorageAt(ctx context.Context, address libcommon.Address, index string) (string, error)
 
 	// // Sending related (see ./realtime_call_xlayer.go)
-	Call(ctx context.Context, args ethapi2.CallArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *ethapi2.StateOverrides) (hexutility.Bytes, error)
+	Call(ctx context.Context, args ethapi2.CallArgs, overrides *ethapi2.StateOverrides) (hexutility.Bytes, error)
 }
 
 // RealtimeAPIImpl is implementation of the RealtimeAPI interface

--- a/turbo/jsonrpc/realtime_api_xlayer.go
+++ b/turbo/jsonrpc/realtime_api_xlayer.go
@@ -4,58 +4,51 @@ import (
 	"context"
 
 	"github.com/ledgerwatch/erigon-lib/common"
-	"github.com/ledgerwatch/erigon-lib/common/hexutil"
-	"github.com/ledgerwatch/erigon-lib/common/hexutility"
 	"github.com/ledgerwatch/erigon/core/state"
-	"github.com/ledgerwatch/erigon/rpc"
-	ethapi2 "github.com/ledgerwatch/erigon/turbo/adapter/ethapi"
 	zktypes "github.com/ledgerwatch/erigon/zk/types"
 )
 
 // RealtimeAPI is a collection of functions that are exposed in rpc only
 type RealtimeAPI interface {
-	// Block related (see ./realtime_blocks_xlayer.go)
-	BlockNumber(ctx context.Context) (hexutil.Uint64, error)
-	GetBlockTransactionCountByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*hexutil.Uint, error)
+	// // Block related (see ./realtime_blocks_xlayer.go)
+	// BlockNumber(ctx context.Context) (hexutil.Uint64, error)
+	// GetBlockTransactionCountByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*hexutil.Uint, error)
 
-	// Transaction related (see ./realtime_txs_xlayer.go)
-	GetTransactionByHash(ctx context.Context, hash common.Hash, includeExtraInfo *bool) (interface{}, error)
-	GetRawTransactionByHash(ctx context.Context, hash common.Hash) (hexutility.Bytes, error)
+	// // Transaction related (see ./realtime_txs_xlayer.go)
+	// GetTransactionByHash(ctx context.Context, hash common.Hash, includeExtraInfo *bool) (interface{}, error)
+	// GetRawTransactionByHash(ctx context.Context, hash common.Hash) (hexutility.Bytes, error)
 
 	// Receipt related (see ./realtime_receipts_xlayer.go)
 	GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error)
 	GetInternalTransactions(ctx context.Context, hash common.Hash) ([]*zktypes.InnerTx, error)
 
-	// Account related (see ./realtime_accounts_xlayer.go)
-	GetBalance(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (*hexutil.Big, error)
-	GetTransactionCount(ctx context.Context, address common.Address, blockNrOrHash *rpc.BlockNumberOrHash) (*hexutil.Uint64, error)
-	GetStorageAt(ctx context.Context, address common.Address, index string, blockNrOrHash rpc.BlockNumberOrHash) (string, error)
-	GetCode(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (hexutility.Bytes, error)
+	// // Account related (see ./realtime_accounts_xlayer.go)
+	// GetBalance(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (*hexutil.Big, error)
+	// GetTransactionCount(ctx context.Context, address common.Address, blockNrOrHash *rpc.BlockNumberOrHash) (*hexutil.Uint64, error)
+	// GetStorageAt(ctx context.Context, address common.Address, index string, blockNrOrHash rpc.BlockNumberOrHash) (string, error)
+	// GetCode(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (hexutility.Bytes, error)
 
-	// Sending related (see ./realtime_call_xlayer.go)
-	Call(ctx context.Context, args ethapi2.CallArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *ethapi2.StateOverrides) (hexutility.Bytes, error)
+	// // Sending related (see ./realtime_call_xlayer.go)
+	// Call(ctx context.Context, args ethapi2.CallArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *ethapi2.StateOverrides) (hexutility.Bytes, error)
 }
 
 // RealtimeAPIImpl is implementation of the RealtimeAPI interface
 type RealtimeAPIImpl struct {
-	ethApi *APIImpl
-
-	// For X Layer, realtime response
-	txInfoMap *zktypes.TxInfoMap
-	headerMap *zktypes.HeaderMap
+	ethApi         *APIImpl
+	stateCache     state.StateReader
+	statelessCache *zktypes.StatelessCache
 }
 
 // NewRealtimeAPI returns RealtimeAPIImpl instance
 func NewRealtimeAPI(
 	base *APIImpl,
-	txInfoMap *zktypes.TxInfoMap,
-	headerMap *zktypes.HeaderMap,
 	stateCache state.StateReader,
+	statelessCache *zktypes.StatelessCache,
 ) *RealtimeAPIImpl {
 
 	return &RealtimeAPIImpl{
-		ethApi:    base,
-		txInfoMap: txInfoMap,
-		headerMap: headerMap,
+		ethApi:         base,
+		stateCache:     stateCache,
+		statelessCache: statelessCache,
 	}
 }

--- a/turbo/jsonrpc/realtime_api_xlayer.go
+++ b/turbo/jsonrpc/realtime_api_xlayer.go
@@ -38,7 +38,7 @@ type RealtimeAPI interface {
 	GetCode(ctx context.Context, address libcommon.Address) (hexutility.Bytes, error)
 	GetStorageAt(ctx context.Context, address libcommon.Address, index string) (string, error)
 
-	// // Sending related (see ./realtime_call_xlayer.go)
+	// Sending related (see ./realtime_call_xlayer.go)
 	Call(ctx context.Context, args ethapi2.CallArgs, overrides *ethapi2.StateOverrides) (hexutility.Bytes, error)
 }
 

--- a/turbo/jsonrpc/realtime_api_xlayer.go
+++ b/turbo/jsonrpc/realtime_api_xlayer.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/hexutil"
+	"github.com/ledgerwatch/erigon-lib/common/hexutility"
 	"github.com/ledgerwatch/erigon/core/state"
 	"github.com/ledgerwatch/erigon/rpc"
 	zktypes "github.com/ledgerwatch/erigon/zk/types"
@@ -17,9 +18,9 @@ type RealtimeAPI interface {
 	BlockNumber(ctx context.Context) (hexutil.Uint64, error)
 	GetBlockTransactionCountByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*hexutil.Uint, error)
 
-	// // Transaction related (see ./realtime_txs_xlayer.go)
-	// GetTransactionByHash(ctx context.Context, hash common.Hash, includeExtraInfo *bool) (interface{}, error)
-	// GetRawTransactionByHash(ctx context.Context, hash common.Hash) (hexutility.Bytes, error)
+	// Transaction related (see ./realtime_txs_xlayer.go)
+	GetTransactionByHash(ctx context.Context, hash common.Hash, includeExtraInfo *bool) (interface{}, error)
+	GetRawTransactionByHash(ctx context.Context, hash common.Hash) (hexutility.Bytes, error)
 
 	// Receipt related (see ./realtime_receipts_xlayer.go)
 	GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error)
@@ -56,7 +57,7 @@ func NewRealtimeAPI(
 	}
 }
 
-func (api *RealtimeAPIImpl) GetBlockNumber(blockNr rpc.BlockNumber) (uint64, bool, error) {
+func (api *RealtimeAPIImpl) getBlockNumber(blockNr rpc.BlockNumber) (uint64, bool, error) {
 	currentBlockNumber := api.statelessCache.GetHeight()
 	if currentBlockNumber == 0 {
 		return 0, false, fmt.Errorf("no block number found in stateless cache")

--- a/turbo/jsonrpc/realtime_api_xlayer.go
+++ b/turbo/jsonrpc/realtime_api_xlayer.go
@@ -21,7 +21,7 @@ var (
 
 // RealtimeAPI is a collection of functions that are exposed in rpc only
 type RealtimeAPI interface {
-	// // Block related (see ./realtime_blocks_xlayer.go)
+	// Block related (see ./realtime_blocks_xlayer.go)
 	BlockNumber(ctx context.Context) (hexutil.Uint64, error)
 	GetBlockTransactionCountByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*hexutil.Uint, error)
 

--- a/turbo/jsonrpc/realtime_blocks_xlayer.go
+++ b/turbo/jsonrpc/realtime_blocks_xlayer.go
@@ -1,0 +1,1 @@
+package jsonrpc

--- a/turbo/jsonrpc/realtime_blocks_xlayer.go
+++ b/turbo/jsonrpc/realtime_blocks_xlayer.go
@@ -21,7 +21,7 @@ func (api *RealtimeAPIImpl) BlockNumber(ctx context.Context) (hexutil.Uint64, er
 // GetBlockTransactionCountByNumber implements realtime_getBlockTransactionCountByNumber.
 // Returns the number of transactions in a block given the block's block number.
 func (api *RealtimeAPIImpl) GetBlockTransactionCountByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*hexutil.Uint, error) {
-	blockNum, _, err := api.GetBlockNumber(blockNr)
+	blockNum, _, err := api.getBlockNumber(blockNr)
 	if err != nil {
 		return api.ethApi.GetBlockTransactionCountByNumber(ctx, blockNr)
 	}

--- a/turbo/jsonrpc/realtime_blocks_xlayer.go
+++ b/turbo/jsonrpc/realtime_blocks_xlayer.go
@@ -1,1 +1,37 @@
 package jsonrpc
+
+import (
+	"context"
+
+	"github.com/ledgerwatch/erigon-lib/common/hexutil"
+	"github.com/ledgerwatch/erigon/rpc"
+)
+
+// BlockNumber implements realtime_blockNumber.
+// Returns the block number of the most recent pre-confirmed block.
+func (api *RealtimeAPIImpl) BlockNumber(ctx context.Context) (hexutil.Uint64, error) {
+	highestHeight := api.statelessCache.GetHeight()
+	if highestHeight == 0 {
+		return api.ethApi.BlockNumber(ctx)
+	}
+
+	return hexutil.Uint64(highestHeight), nil
+}
+
+// GetBlockTransactionCountByNumber implements realtime_getBlockTransactionCountByNumber.
+// Returns the number of transactions in a block given the block's block number.
+func (api *RealtimeAPIImpl) GetBlockTransactionCountByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*hexutil.Uint, error) {
+	blockNum, _, err := api.GetBlockNumber(blockNr)
+	if err != nil {
+		return api.ethApi.GetBlockTransactionCountByNumber(ctx, blockNr)
+	}
+
+	txs, ok := api.statelessCache.GetBlockTxs(blockNum)
+	if !ok {
+		return api.ethApi.GetBlockTransactionCountByNumber(ctx, blockNr)
+	}
+
+	numOfTx := hexutil.Uint(len(txs))
+
+	return &numOfTx, nil
+}

--- a/turbo/jsonrpc/realtime_call_xlayer.go
+++ b/turbo/jsonrpc/realtime_call_xlayer.go
@@ -1,0 +1,1 @@
+package jsonrpc

--- a/turbo/jsonrpc/realtime_call_xlayer.go
+++ b/turbo/jsonrpc/realtime_call_xlayer.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ledgerwatch/erigon/turbo/transactions"
 )
 
-// Call implements eth_call.
+// Call implements realtime_call.
 // Executes a new message call immediately without creating a transaction on the block chain.
 // Note that realtime API only supports execution on the latest block.
 func (api *RealtimeAPIImpl) Call(ctx context.Context, args ethapi2.CallArgs, overrides *ethapi2.StateOverrides) (hexutility.Bytes, error) {

--- a/turbo/jsonrpc/realtime_call_xlayer.go
+++ b/turbo/jsonrpc/realtime_call_xlayer.go
@@ -14,7 +14,7 @@ import (
 // Call implements eth_call.
 // Executes a new message call immediately without creating a transaction on the block chain.
 // Note that realtime API only supports execution on the latest block.
-func (api *RealtimeAPIImpl) Call(ctx context.Context, args ethapi2.CallArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *ethapi2.StateOverrides) (hexutility.Bytes, error) {
+func (api *RealtimeAPIImpl) Call(ctx context.Context, args ethapi2.CallArgs, overrides *ethapi2.StateOverrides) (hexutility.Bytes, error) {
 	tx, err := api.ethApi.db.BeginRo(ctx)
 	if err != nil {
 		return nil, err
@@ -41,7 +41,9 @@ func (api *RealtimeAPIImpl) Call(ctx context.Context, args ethapi2.CallArgs, blo
 		return nil, fmt.Errorf("header not found for block number %d", blockNumber)
 	}
 
-	result, err := transactions.DoCall(ctx, engine, args, tx, blockNrOrHash, header, overrides, api.ethApi.GasCap, chainConfig, api.stateCache, api.statelessCache, api.ethApi.evmCallTimeout)
+	bn := rpc.BlockNumber(blockNumber)
+	rpcBlockNr := rpc.BlockNumberOrHash{BlockNumber: &bn}
+	result, err := transactions.DoCall(ctx, engine, args, tx, rpcBlockNr, header, overrides, api.ethApi.GasCap, chainConfig, api.stateCache, api.statelessCache, api.ethApi.evmCallTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/turbo/jsonrpc/realtime_call_xlayer.go
+++ b/turbo/jsonrpc/realtime_call_xlayer.go
@@ -1,1 +1,59 @@
 package jsonrpc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ledgerwatch/erigon-lib/common/hexutil"
+	"github.com/ledgerwatch/erigon-lib/common/hexutility"
+	"github.com/ledgerwatch/erigon/rpc"
+	ethapi2 "github.com/ledgerwatch/erigon/turbo/adapter/ethapi"
+	"github.com/ledgerwatch/erigon/turbo/transactions"
+)
+
+// Call implements eth_call.
+// Executes a new message call immediately without creating a transaction on the block chain.
+// Note that realtime API only supports execution on the latest block.
+func (api *RealtimeAPIImpl) Call(ctx context.Context, args ethapi2.CallArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *ethapi2.StateOverrides) (hexutility.Bytes, error) {
+	tx, err := api.ethApi.db.BeginRo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	chainConfig, err := api.ethApi.chainConfig(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	engine := api.ethApi.engine()
+
+	if args.Gas == nil || uint64(*args.Gas) == 0 {
+		args.Gas = (*hexutil.Uint64)(&api.ethApi.GasCap)
+	}
+
+	blockNumber, _, err := api.getBlockNumber(rpc.LatestBlockNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	header, ok := api.statelessCache.GetHeader(blockNumber)
+	if !ok {
+		return nil, fmt.Errorf("header not found for block number %d", blockNumber)
+	}
+
+	result, err := transactions.DoCall(ctx, engine, args, tx, blockNrOrHash, header, overrides, api.ethApi.GasCap, chainConfig, api.stateCache, api.statelessCache, api.ethApi.evmCallTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(result.ReturnData) > api.ethApi.ReturnDataLimit {
+		return nil, fmt.Errorf("call returned result on length %d exceeding --rpc.returndata.limit %d", len(result.ReturnData), api.ethApi.ReturnDataLimit)
+	}
+
+	// If the result contains a revert reason, try to unpack and return it.
+	if len(result.Revert()) > 0 {
+		return nil, ethapi2.NewRevertError(result)
+	}
+
+	return result.Return(), result.Err
+}

--- a/turbo/jsonrpc/realtime_receipts_xlayer.go
+++ b/turbo/jsonrpc/realtime_receipts_xlayer.go
@@ -7,6 +7,8 @@ import (
 	zktypes "github.com/ledgerwatch/erigon/zk/types"
 )
 
+// GetTransactionReceipt implements realtime_getTransactionReceipt.
+// Returns the receipt of a transaction given the transaction's hash.
 func (api *RealtimeAPIImpl) GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
 	txn, receipt, _, _, ok := api.statelessCache.GetTxInfo(hash)
 	if !ok {
@@ -31,6 +33,8 @@ func (api *RealtimeAPIImpl) GetTransactionReceipt(ctx context.Context, hash comm
 	return marshalReceipt(receipt, txn, cc, header, txn.Hash(), true), nil
 }
 
+// GetInternalTransactions implements realtime_getInternalTransactions.
+// Returns the internal transactions of a transaction given the transaction's hash.
 func (api *RealtimeAPIImpl) GetInternalTransactions(ctx context.Context, hash common.Hash) ([]*zktypes.InnerTx, error) {
 	_, _, _, innerTxs, ok := api.statelessCache.GetTxInfo(hash)
 	if !ok {

--- a/turbo/jsonrpc/realtime_receipts_xlayer.go
+++ b/turbo/jsonrpc/realtime_receipts_xlayer.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (api *RealtimeAPIImpl) GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
-	txn, receipt, _, ok := api.statelessCache.GetTxInfo(hash)
+	txn, receipt, _, _, ok := api.statelessCache.GetTxInfo(hash)
 	if !ok {
 		return api.ethApi.GetTransactionReceipt(ctx, hash)
 	}
@@ -32,7 +32,7 @@ func (api *RealtimeAPIImpl) GetTransactionReceipt(ctx context.Context, hash comm
 }
 
 func (api *RealtimeAPIImpl) GetInternalTransactions(ctx context.Context, hash common.Hash) ([]*zktypes.InnerTx, error) {
-	_, _, innerTxs, ok := api.statelessCache.GetTxInfo(hash)
+	_, _, _, innerTxs, ok := api.statelessCache.GetTxInfo(hash)
 	if !ok {
 		return api.ethApi.GetInternalTransactions(ctx, hash)
 	}

--- a/turbo/jsonrpc/realtime_receipts_xlayer.go
+++ b/turbo/jsonrpc/realtime_receipts_xlayer.go
@@ -1,0 +1,41 @@
+package jsonrpc
+
+import (
+	"context"
+
+	"github.com/ledgerwatch/erigon-lib/common"
+	zktypes "github.com/ledgerwatch/erigon/zk/types"
+)
+
+func (api *RealtimeAPIImpl) GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
+	txn, receipt, _, ok := api.txInfoMap.Get(hash)
+	if !ok {
+		return api.ethApi.GetTransactionReceipt(ctx, hash)
+	}
+	header, ok := api.headerMap.Get(receipt.BlockNumber.Uint64())
+	if !ok {
+		return api.ethApi.GetTransactionReceipt(ctx, hash)
+	}
+
+	tx, err := api.ethApi.db.BeginRo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	cc, err := api.ethApi.chainConfig(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+
+	return marshalReceipt(receipt, txn, cc, header, txn.Hash(), true), nil
+}
+
+func (api *RealtimeAPIImpl) GetInternalTransactions(ctx context.Context, hash common.Hash) ([]*zktypes.InnerTx, error) {
+	_, _, innerTxs, ok := api.txInfoMap.Get(hash)
+	if !ok {
+		return api.ethApi.GetInternalTransactions(ctx, hash)
+	}
+
+	return innerTxs, nil
+}

--- a/turbo/jsonrpc/realtime_receipts_xlayer.go
+++ b/turbo/jsonrpc/realtime_receipts_xlayer.go
@@ -8,11 +8,11 @@ import (
 )
 
 func (api *RealtimeAPIImpl) GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
-	txn, receipt, _, ok := api.txInfoMap.Get(hash)
+	txn, receipt, _, ok := api.statelessCache.GetTxInfo(hash)
 	if !ok {
 		return api.ethApi.GetTransactionReceipt(ctx, hash)
 	}
-	header, ok := api.headerMap.Get(receipt.BlockNumber.Uint64())
+	header, ok := api.statelessCache.GetHeader(receipt.BlockNumber.Uint64())
 	if !ok {
 		return api.ethApi.GetTransactionReceipt(ctx, hash)
 	}
@@ -32,7 +32,7 @@ func (api *RealtimeAPIImpl) GetTransactionReceipt(ctx context.Context, hash comm
 }
 
 func (api *RealtimeAPIImpl) GetInternalTransactions(ctx context.Context, hash common.Hash) ([]*zktypes.InnerTx, error) {
-	_, _, innerTxs, ok := api.txInfoMap.Get(hash)
+	_, _, innerTxs, ok := api.statelessCache.GetTxInfo(hash)
 	if !ok {
 		return api.ethApi.GetInternalTransactions(ctx, hash)
 	}

--- a/turbo/jsonrpc/realtime_txs_xlayer.go
+++ b/turbo/jsonrpc/realtime_txs_xlayer.go
@@ -1,0 +1,1 @@
+package jsonrpc

--- a/turbo/jsonrpc/realtime_txs_xlayer.go
+++ b/turbo/jsonrpc/realtime_txs_xlayer.go
@@ -1,1 +1,53 @@
 package jsonrpc
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/common/hexutility"
+)
+
+// GetTransactionByHash implements eth_getTransactionByHash. Returns information about a transaction given the transaction's hash.
+func (api *RealtimeAPIImpl) GetTransactionByHash(ctx context.Context, txnHash common.Hash, includeExtraInfo *bool) (interface{}, error) {
+	txn, _, blockNum, _, ok := api.statelessCache.GetTxInfo(txnHash)
+	if !ok {
+		return api.ethApi.GetTransactionByHash(ctx, txnHash, includeExtraInfo)
+	}
+	txHashes, ok := api.statelessCache.GetBlockTxs(blockNum)
+	if !ok {
+		return api.ethApi.GetTransactionByHash(ctx, txnHash, includeExtraInfo)
+	}
+	header, ok := api.statelessCache.GetHeader(blockNum)
+	if !ok {
+		return api.ethApi.GetTransactionByHash(ctx, txnHash, includeExtraInfo)
+	}
+
+	found := false
+	var txnIndex uint64
+	for i, hash := range txHashes {
+		if hash == txnHash {
+			found = true
+			txnIndex = uint64(i)
+			break
+		}
+	}
+	if !found || txn == nil {
+		return api.ethApi.GetTransactionByHash(ctx, txnHash, includeExtraInfo)
+	}
+
+	return newRPCTransaction_realtime(txn, blockNum, txnIndex, header.BaseFee), nil
+}
+
+// GetRawTransactionByHash returns the bytes of the transaction for the given hash.
+func (api *RealtimeAPIImpl) GetRawTransactionByHash(ctx context.Context, hash common.Hash) (hexutility.Bytes, error) {
+	txn, _, _, _, ok := api.statelessCache.GetTxInfo(hash)
+	if !ok || txn == nil {
+		return api.ethApi.GetRawTransactionByHash(ctx, hash)
+	}
+
+	var buf bytes.Buffer
+	err := txn.MarshalBinary(&buf)
+
+	return buf.Bytes(), err
+}

--- a/turbo/jsonrpc/realtime_txs_xlayer.go
+++ b/turbo/jsonrpc/realtime_txs_xlayer.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/common/hexutility"
 )
 
-// GetTransactionByHash implements eth_getTransactionByHash.
+// GetTransactionByHash implements realtime_getTransactionByHash.
 // Returns information about a transaction given the transaction's hash.
 func (api *RealtimeAPIImpl) GetTransactionByHash(ctx context.Context, txnHash common.Hash, includeExtraInfo *bool) (interface{}, error) {
 	txn, _, blockNum, _, ok := api.statelessCache.GetTxInfo(txnHash)

--- a/turbo/jsonrpc/realtime_txs_xlayer.go
+++ b/turbo/jsonrpc/realtime_txs_xlayer.go
@@ -8,7 +8,8 @@ import (
 	"github.com/ledgerwatch/erigon-lib/common/hexutility"
 )
 
-// GetTransactionByHash implements eth_getTransactionByHash. Returns information about a transaction given the transaction's hash.
+// GetTransactionByHash implements eth_getTransactionByHash.
+// Returns information about a transaction given the transaction's hash.
 func (api *RealtimeAPIImpl) GetTransactionByHash(ctx context.Context, txnHash common.Hash, includeExtraInfo *bool) (interface{}, error) {
 	txn, _, blockNum, _, ok := api.statelessCache.GetTxInfo(txnHash)
 	if !ok {
@@ -39,7 +40,8 @@ func (api *RealtimeAPIImpl) GetTransactionByHash(ctx context.Context, txnHash co
 	return newRPCTransaction_realtime(txn, blockNum, txnIndex, header.BaseFee), nil
 }
 
-// GetRawTransactionByHash returns the bytes of the transaction for the given hash.
+// GetRawTransactionByHash implements realtime_getRawTransactionByHash.
+// Returns the bytes of the transaction for the given hash.
 func (api *RealtimeAPIImpl) GetRawTransactionByHash(ctx context.Context, hash common.Hash) (hexutility.Bytes, error) {
 	txn, _, _, _, ok := api.statelessCache.GetTxInfo(hash)
 	if !ok || txn == nil {

--- a/turbo/stages/stageloop_xlayer.go
+++ b/turbo/stages/stageloop_xlayer.go
@@ -142,7 +142,7 @@ func FlushDataToDB(ctx context.Context, db *mdbx.MdbxKV, logger log.Logger, cach
 	cache.TruncateSmtCacheList(saveData.BlockHeight)
 }
 
-func ListenTxKafkaConsumer(ctx context.Context, txKafkaConsumer *kafka.KafkaConsumer, config ethconfig.XLayerConfig, logger log.Logger, txInfoMap *zktypes.TxInfoMap, headerMap *zktypes.HeaderMap, stateCache *state.PlainStateCache) {
+func ListenTxKafkaConsumer(ctx context.Context, txKafkaConsumer *kafka.KafkaConsumer, config ethconfig.XLayerConfig, logger log.Logger, stateCache *state.PlainStateCache, statelessCache *zktypes.StatelessCache) {
 	if sequencer.IsSequencer() {
 		logger.Info("txKafkaConsumer is disabled on sequencer, skipping")
 		return
@@ -167,7 +167,7 @@ func ListenTxKafkaConsumer(ctx context.Context, txKafkaConsumer *kafka.KafkaCons
 		case <-ctx.Done():
 			return
 		case header := <-headersChan:
-			headerMap.Put(header.Number.Uint64(), &header)
+			statelessCache.PutHeader(header.Number.Uint64(), &header)
 			logger.Info("Received header message", "header", header)
 		case txMsg := <-txMsgsChan:
 			// 1. Process non-state data
@@ -186,7 +186,7 @@ func ListenTxKafkaConsumer(ctx context.Context, txKafkaConsumer *kafka.KafkaCons
 				logger.Error("failed to consume tx innerTxs message from kafka", "error", err)
 				continue
 			}
-			txInfoMap.Put(tx.Hash(), tx, receipt, innerTxs)
+			statelessCache.PutTxInfo(blockNumber, tx.Hash(), tx, receipt, innerTxs)
 
 			// 2. Process state data
 			changeset, err := txMsg.GetChangeset()

--- a/turbo/stages/zk_stages.go
+++ b/turbo/stages/zk_stages.go
@@ -41,8 +41,7 @@ func NewDefaultZkStages(ctx context.Context,
 	datastreamClient zkStages.DatastreamClient,
 	dataStreamServer server.DataStreamServer,
 	infoTreeUpdater *l1infotree.Updater,
-	txInfoMap *zktypes.TxInfoMap,
-	headerMap *zktypes.HeaderMap,
+	statelessCache *zktypes.StatelessCache,
 ) []*stagedsync.Stage {
 	dirs := cfg.Dirs
 	blockWriter := blockio.NewBlockWriter(cfg.HistoryV3)
@@ -91,8 +90,7 @@ func NewDefaultZkStages(ctx context.Context,
 		stagedsync.StageCallTracesCfg(db, cfg.Prune, 0, dirs.Tmp),
 		stagedsync.StageTxLookupCfg(db, cfg.Prune, dirs.Tmp, controlServer.ChainConfig.Bor, blockReader),
 		stagedsync.StageFinishCfg(db, dirs.Tmp, forkValidator),
-		txInfoMap,
-		headerMap,
+		statelessCache,
 		runInTestMode)
 }
 

--- a/zk/stages/stages.go
+++ b/zk/stages/stages.go
@@ -240,8 +240,7 @@ func DefaultZkStages(
 	callTraces stages.CallTracesCfg,
 	txLookup stages.TxLookupCfg,
 	finish stages.FinishCfg,
-	txInfoMap *types.TxInfoMap,
-	headerMap *types.HeaderMap,
+	statelessCache *types.StatelessCache,
 	test bool,
 ) []*stages.Stage {
 	return []*stages.Stage{
@@ -320,7 +319,7 @@ func DefaultZkStages(
 			ID:          stages2.Execution,
 			Description: "Execute blocks w/o hash checks",
 			Forward: func(firstCycle bool, badBlockUnwind bool, s *stages.StageState, u stages.Unwinder, txc wrap.TxContainer, logger log.Logger) error {
-				return stages.SpawnExecuteBlocksStageZk(s, u, txc.Tx, 0, ctx, exec, firstCycle, txInfoMap, headerMap)
+				return stages.SpawnExecuteBlocksStageZk(s, u, txc.Tx, 0, ctx, exec, firstCycle, statelessCache)
 			},
 			Unwind: func(firstCycle bool, u *stages.UnwindState, s *stages.StageState, txc wrap.TxContainer, logger log.Logger) error {
 				return stages.UnwindExecutionStageZk(u, s, txc.Tx, ctx, exec, firstCycle)

--- a/zk/types/stateless_cache.go
+++ b/zk/types/stateless_cache.go
@@ -1,9 +1,12 @@
 package types
 
 import (
+	"context"
+	"fmt"
 	"sync/atomic"
 
-	"github.com/ledgerwatch/erigon-lib/common"
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/kv"
 	ethTypes "github.com/ledgerwatch/erigon/core/types"
 )
 
@@ -30,11 +33,11 @@ func (cache *StatelessCache) GetHeader(blockNum uint64) (*ethTypes.Header, bool)
 	return cache.headerMap.Get(blockNum)
 }
 
-func (cache *StatelessCache) GetTxInfo(txHash common.Hash) (ethTypes.Transaction, *ethTypes.Receipt, uint64, []*InnerTx, bool) {
+func (cache *StatelessCache) GetTxInfo(txHash libcommon.Hash) (ethTypes.Transaction, *ethTypes.Receipt, uint64, []*InnerTx, bool) {
 	return cache.txInfoMap.GetTx(txHash)
 }
 
-func (cache *StatelessCache) GetBlockTxs(blockNum uint64) ([]common.Hash, bool) {
+func (cache *StatelessCache) GetBlockTxs(blockNum uint64) ([]libcommon.Hash, bool) {
 	return cache.txInfoMap.GetBlockTxs(blockNum)
 }
 
@@ -46,7 +49,7 @@ func (cache *StatelessCache) PutHeader(blockNum uint64, header *ethTypes.Header)
 	cache.headerMap.Put(blockNum, header)
 }
 
-func (cache *StatelessCache) PutTxInfo(blockNum uint64, txHash common.Hash, tx ethTypes.Transaction, receipt *ethTypes.Receipt, innerTxs []*InnerTx) {
+func (cache *StatelessCache) PutTxInfo(blockNum uint64, txHash libcommon.Hash, tx ethTypes.Transaction, receipt *ethTypes.Receipt, innerTxs []*InnerTx) {
 	if blockNum > cache.highestHeight.Load() {
 		cache.highestHeight.Store(blockNum)
 	}
@@ -60,4 +63,41 @@ func (cache *StatelessCache) DeleteBlock(blockNum uint64, block *ethTypes.Block)
 	for _, tx := range block.Transactions() {
 		cache.txInfoMap.DeleteTxInfo(tx.Hash())
 	}
+}
+
+// -------------- For HeaderReader --------------
+func (cache *StatelessCache) Header(ctx context.Context, tx kv.Getter, hash libcommon.Hash, blockNum uint64) (*ethTypes.Header, error) {
+	header, ok := cache.GetHeader(blockNum)
+	if !ok {
+		return nil, fmt.Errorf("header not found for block number %d", blockNum)
+	}
+	return header, nil
+}
+
+func (cache *StatelessCache) HeaderByNumber(ctx context.Context, tx kv.Getter, blockNum uint64) (*ethTypes.Header, error) {
+	header, ok := cache.GetHeader(blockNum)
+	if !ok {
+		return nil, fmt.Errorf("header not found for block number %d", blockNum)
+	}
+	return header, nil
+}
+
+func (cache *StatelessCache) HeaderByHash(ctx context.Context, tx kv.Getter, hash libcommon.Hash) (*ethTypes.Header, error) {
+	// Unimplemented
+	return nil, nil
+}
+
+func (cache *StatelessCache) ReadAncestor(db kv.Getter, hash libcommon.Hash, number, ancestor uint64, maxNonCanonical *uint64) (libcommon.Hash, uint64) {
+	// Unimplemented
+	return libcommon.Hash{}, 0
+}
+
+func (cache *StatelessCache) HeadersRange(ctx context.Context, walker func(header *ethTypes.Header) error) error {
+	// Unimplemented
+	return nil
+}
+
+func (cache *StatelessCache) Integrity(ctx context.Context) error {
+	// Unimplemented
+	return nil
 }

--- a/zk/types/stateless_cache.go
+++ b/zk/types/stateless_cache.go
@@ -1,0 +1,62 @@
+package types
+
+import (
+	"sync/atomic"
+
+	"github.com/ledgerwatch/erigon-lib/common"
+	ethTypes "github.com/ledgerwatch/erigon/core/types"
+)
+
+type StatelessCache struct {
+	highestHeight atomic.Uint64
+	headerMap     *HeaderMap
+	txInfoMap     *TxInfoMap
+}
+
+func NewStatelessCache() *StatelessCache {
+	return &StatelessCache{
+		headerMap: NewHeaderMap(),
+		txInfoMap: NewTxInfoMap(),
+	}
+}
+
+// -------------- Read operations --------------
+func (cache *StatelessCache) GetHeight() uint64 {
+	return cache.highestHeight.Load()
+}
+
+func (cache *StatelessCache) GetHeader(blockNum uint64) (*ethTypes.Header, bool) {
+	return cache.headerMap.Get(blockNum)
+}
+
+func (cache *StatelessCache) GetTxInfo(txHash common.Hash) (ethTypes.Transaction, *ethTypes.Receipt, []*InnerTx, bool) {
+	return cache.txInfoMap.GetTx(txHash)
+}
+
+func (cache *StatelessCache) GetBlockTxs(blockNum uint64) []common.Hash {
+	return cache.txInfoMap.GetBlockTxs(blockNum)
+}
+
+func (cache *StatelessCache) PutHeader(blockNum uint64, header *ethTypes.Header) {
+	if blockNum > cache.highestHeight.Load() {
+		cache.highestHeight.Store(blockNum)
+	}
+	cache.headerMap.Put(blockNum, header)
+}
+
+// -------------- Write operations --------------
+func (cache *StatelessCache) PutTxInfo(blockNum uint64, txHash common.Hash, tx ethTypes.Transaction, receipt *ethTypes.Receipt, innerTxs []*InnerTx) {
+	if blockNum > cache.highestHeight.Load() {
+		cache.highestHeight.Store(blockNum)
+	}
+	cache.txInfoMap.Put(blockNum, txHash, tx, receipt, innerTxs)
+}
+
+func (cache *StatelessCache) DeleteBlock(blockNum uint64, block *ethTypes.Block) {
+	cache.headerMap.Delete(blockNum)
+	cache.txInfoMap.DeleteBlockTxs(blockNum)
+
+	for _, tx := range block.Transactions() {
+		cache.txInfoMap.DeleteTxInfo(tx.Hash())
+	}
+}

--- a/zk/types/stateless_cache.go
+++ b/zk/types/stateless_cache.go
@@ -15,8 +15,9 @@ type StatelessCache struct {
 
 func NewStatelessCache() *StatelessCache {
 	return &StatelessCache{
-		headerMap: NewHeaderMap(),
-		txInfoMap: NewTxInfoMap(),
+		highestHeight: atomic.Uint64{},
+		headerMap:     NewHeaderMap(),
+		txInfoMap:     NewTxInfoMap(),
 	}
 }
 
@@ -33,7 +34,7 @@ func (cache *StatelessCache) GetTxInfo(txHash common.Hash) (ethTypes.Transaction
 	return cache.txInfoMap.GetTx(txHash)
 }
 
-func (cache *StatelessCache) GetBlockTxs(blockNum uint64) []common.Hash {
+func (cache *StatelessCache) GetBlockTxs(blockNum uint64) ([]common.Hash, bool) {
 	return cache.txInfoMap.GetBlockTxs(blockNum)
 }
 

--- a/zk/types/stateless_cache.go
+++ b/zk/types/stateless_cache.go
@@ -30,7 +30,7 @@ func (cache *StatelessCache) GetHeader(blockNum uint64) (*ethTypes.Header, bool)
 	return cache.headerMap.Get(blockNum)
 }
 
-func (cache *StatelessCache) GetTxInfo(txHash common.Hash) (ethTypes.Transaction, *ethTypes.Receipt, []*InnerTx, bool) {
+func (cache *StatelessCache) GetTxInfo(txHash common.Hash) (ethTypes.Transaction, *ethTypes.Receipt, uint64, []*InnerTx, bool) {
 	return cache.txInfoMap.GetTx(txHash)
 }
 
@@ -38,6 +38,7 @@ func (cache *StatelessCache) GetBlockTxs(blockNum uint64) ([]common.Hash, bool) 
 	return cache.txInfoMap.GetBlockTxs(blockNum)
 }
 
+// -------------- Write operations --------------
 func (cache *StatelessCache) PutHeader(blockNum uint64, header *ethTypes.Header) {
 	if blockNum > cache.highestHeight.Load() {
 		cache.highestHeight.Store(blockNum)
@@ -45,7 +46,6 @@ func (cache *StatelessCache) PutHeader(blockNum uint64, header *ethTypes.Header)
 	cache.headerMap.Put(blockNum, header)
 }
 
-// -------------- Write operations --------------
 func (cache *StatelessCache) PutTxInfo(blockNum uint64, txHash common.Hash, tx ethTypes.Transaction, receipt *ethTypes.Receipt, innerTxs []*InnerTx) {
 	if blockNum > cache.highestHeight.Load() {
 		cache.highestHeight.Store(blockNum)

--- a/zk/types/txinfo_map.go
+++ b/zk/types/txinfo_map.go
@@ -54,11 +54,11 @@ func (rm *TxInfoMap) DeleteTxInfo(txHash common.Hash) {
 	delete(rm.txInfos, txHash)
 }
 
-func (rm *TxInfoMap) GetTx(txHash common.Hash) (ethTypes.Transaction, *ethTypes.Receipt, []*InnerTx, bool) {
+func (rm *TxInfoMap) GetTx(txHash common.Hash) (ethTypes.Transaction, *ethTypes.Receipt, uint64, []*InnerTx, bool) {
 	rm.mu.RLock()
 	defer rm.mu.RUnlock()
 	txInfo, exists := rm.txInfos[txHash]
-	return txInfo.Tx, txInfo.Receipt, txInfo.InnerTxs, exists
+	return txInfo.Tx, txInfo.Receipt, txInfo.BlockNumber, txInfo.InnerTxs, exists
 }
 
 func (rm *TxInfoMap) GetBlockTxs(blockNumber uint64) ([]common.Hash, bool) {

--- a/zk/types/txinfo_map.go
+++ b/zk/types/txinfo_map.go
@@ -61,12 +61,9 @@ func (rm *TxInfoMap) GetTx(txHash common.Hash) (ethTypes.Transaction, *ethTypes.
 	return txInfo.Tx, txInfo.Receipt, txInfo.InnerTxs, exists
 }
 
-func (rm *TxInfoMap) GetBlockTxs(blockNumber uint64) []common.Hash {
+func (rm *TxInfoMap) GetBlockTxs(blockNumber uint64) ([]common.Hash, bool) {
 	rm.mu.RLock()
 	defer rm.mu.RUnlock()
 	hashes, exists := rm.blockTxs[blockNumber]
-	if !exists {
-		return nil
-	}
-	return hashes
+	return hashes, exists
 }

--- a/zk/types/txinfo_map.go
+++ b/zk/types/txinfo_map.go
@@ -16,35 +16,57 @@ type TxInfo struct {
 }
 
 type TxInfoMap struct {
-	txInfos map[common.Hash]TxInfo
-	mu      sync.RWMutex
+	txInfos  map[common.Hash]TxInfo
+	blockTxs map[uint64][]common.Hash
+	mu       sync.RWMutex
 }
 
 func NewTxInfoMap() *TxInfoMap {
 	return &TxInfoMap{
-		txInfos: make(map[common.Hash]TxInfo),
+		txInfos:  make(map[common.Hash]TxInfo),
+		blockTxs: make(map[uint64][]common.Hash),
 	}
 }
 
-func (rm *TxInfoMap) Get(txHash common.Hash) (ethTypes.Transaction, *ethTypes.Receipt, []*InnerTx, bool) {
+func (rm *TxInfoMap) Put(blockNumber uint64, txHash common.Hash, tx ethTypes.Transaction, receipt *ethTypes.Receipt, innerTxs []*InnerTx) {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+	txInfo := TxInfo{
+		BlockNumber: blockNumber,
+		Tx:          tx,
+		Receipt:     receipt,
+		InnerTxs:    innerTxs,
+	}
+
+	rm.txInfos[txHash] = txInfo
+	rm.blockTxs[blockNumber] = append(rm.blockTxs[blockNumber], txHash)
+}
+
+func (rm *TxInfoMap) DeleteBlockTxs(blockNumber uint64) {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+	delete(rm.blockTxs, blockNumber)
+}
+
+func (rm *TxInfoMap) DeleteTxInfo(txHash common.Hash) {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+	delete(rm.txInfos, txHash)
+}
+
+func (rm *TxInfoMap) GetTx(txHash common.Hash) (ethTypes.Transaction, *ethTypes.Receipt, []*InnerTx, bool) {
 	rm.mu.RLock()
 	defer rm.mu.RUnlock()
 	txInfo, exists := rm.txInfos[txHash]
 	return txInfo.Tx, txInfo.Receipt, txInfo.InnerTxs, exists
 }
 
-func (rm *TxInfoMap) Put(txHash common.Hash, tx ethTypes.Transaction, receipt *ethTypes.Receipt, innerTxs []*InnerTx) {
-	rm.mu.Lock()
-	defer rm.mu.Unlock()
-	rm.txInfos[txHash] = TxInfo{
-		Tx:       tx,
-		Receipt:  receipt,
-		InnerTxs: innerTxs,
+func (rm *TxInfoMap) GetBlockTxs(blockNumber uint64) []common.Hash {
+	rm.mu.RLock()
+	defer rm.mu.RUnlock()
+	hashes, exists := rm.blockTxs[blockNumber]
+	if !exists {
+		return nil
 	}
-}
-
-func (rm *TxInfoMap) Delete(txHash common.Hash) {
-	rm.mu.Lock()
-	defer rm.mu.Unlock()
-	delete(rm.txInfos, txHash)
+	return hashes
 }

--- a/zk/types/txinfo_map_test.go
+++ b/zk/types/txinfo_map_test.go
@@ -14,6 +14,7 @@ import (
 func TestTxInfoMap(t *testing.T) {
 	tm := NewTxInfoMap()
 
+	blockNumber := uint64(5)
 	txHash := common.HexToHash("0x123")
 	value := uint256.NewInt(0)
 	gasPrice := uint256.NewInt(0)
@@ -63,36 +64,41 @@ func TestTxInfoMap(t *testing.T) {
 	}
 
 	t.Run("Put and Get", func(t *testing.T) {
-		tm.Put(txHash, tx, receipt, innerTxs)
-		gotTx, gotReceipt, gotInnerTxs, exists := tm.Get(txHash)
+		tm.Put(blockNumber, txHash, tx, receipt, innerTxs)
+		gotTx, gotReceipt, _, gotInnerTxs, exists := tm.GetTx(txHash)
 		assert.True(t, exists)
 		assert.Equal(t, tx, gotTx)
 		assert.Equal(t, receipt, gotReceipt)
 		assert.Equal(t, innerTxs, gotInnerTxs)
+		txHashes, ok := tm.GetBlockTxs(blockNumber)
+		assert.True(t, ok)
+		assert.Equal(t, txHashes, []common.Hash{txHash})
 	})
 
 	t.Run("Get non-existent", func(t *testing.T) {
 		nonExistentHash := common.HexToHash("0x456")
-		_, _, _, exists := tm.Get(nonExistentHash)
+		_, _, _, _, exists := tm.GetTx(nonExistentHash)
 		assert.False(t, exists)
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		tm.Delete(txHash)
-		_, _, _, exists := tm.Get(txHash)
+		tm.DeleteTxInfo(txHash)
+		_, _, _, _, exists := tm.GetTx(txHash)
 		assert.False(t, exists)
 	})
 
+	blockNumber = 10
 	t.Run("Concurrent operations", func(t *testing.T) {
 		const goroutines = 10
 		var wg sync.WaitGroup
+		hashes := make([]common.Hash, 0, goroutines)
 
 		for i := 0; i < goroutines; i++ {
 			wg.Add(1)
-			go func(i int) {
+			hash := common.HexToHash(string(rune(i + 100)))
+			go func(i int, hash common.Hash) {
 				defer wg.Done()
 
-				hash := common.HexToHash(string(rune(i + 100)))
 				value := uint256.NewInt(uint64(i))
 				gasPrice := uint256.NewInt(uint64(i))
 				tx := ethTypes.NewTransaction(uint64(i), common.Address{}, value, uint64(i), gasPrice, nil)
@@ -138,28 +144,41 @@ func TestTxInfoMap(t *testing.T) {
 					},
 				}
 
-				tm.Put(hash, tx, receipt, innerTxs)
+				tm.Put(blockNumber, hash, tx, receipt, innerTxs)
 
-				gotTx, gotReceipt, gotInnerTxs, exists := tm.Get(hash)
+				gotTx, gotReceipt, _, gotInnerTxs, exists := tm.GetTx(hash)
 				assert.True(t, exists)
 				assert.NotNil(t, gotTx)
 				assert.NotNil(t, gotReceipt)
 				assert.Equal(t, uint64(i), gotReceipt.Status)
 				assert.Equal(t, innerTxs, gotInnerTxs)
 
-				tm.Delete(hash)
+				tm.DeleteTxInfo(hash)
 
-				_, _, _, exists = tm.Get(hash)
+				_, _, _, _, exists = tm.GetTx(hash)
 				assert.False(t, exists)
-			}(i)
+			}(i, hash)
+			hashes = append(hashes, hash)
 		}
 
 		wg.Wait()
 
 		for i := 0; i < goroutines; i++ {
 			hash := common.HexToHash(string(rune(i + 100)))
-			_, _, _, exists := tm.Get(hash)
+			_, _, _, _, exists := tm.GetTx(hash)
 			assert.False(t, exists)
 		}
+
+		// Check if all hashes are in the block
+		txHashes, ok := tm.GetBlockTxs(blockNumber)
+		assert.True(t, ok)
+		assert.Equal(t, len(txHashes), len(hashes))
+		for _, hash := range hashes {
+			assert.Contains(t, txHashes, hash)
+		}
+
+		tm.DeleteBlockTxs(blockNumber)
+		_, ok = tm.GetBlockTxs(blockNumber)
+		assert.False(t, ok)
 	})
 }


### PR DESCRIPTION
## Summary

Add realtime stateless APIs for block and txs:
1. realtime_blockNumber (eth_blockNumber mapping)
2. realtime_getBlockTransactionCountByNumber (eth_getBlockTransactionCountByNumber mapping)
3. realtime_getTransactionByHash (eth_getTransactionByHash mapping)
4. realtime_getRawTransactionByHash (eth_getRawTransactionByHash mapping)

Add realtime stateful APIs for account and calls:
1. realtime_getBalance (eth_getBalance mapping)
2. realtime_getStorageAt (eth_getStorageAt mapping)
3. realtime_getCode (eth_getCode mapping)
4. realtime_call (eth_call mapping)