### PR TITLE
Realtime: Fix and clean up realtime subscription

### DIFF
--- a/turbo/jsonrpc/realtime_filters_xlayer.go
+++ b/turbo/jsonrpc/realtime_filters_xlayer.go
@@ -8,20 +8,21 @@ import (
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/eth/filters"
 	"github.com/ledgerwatch/erigon/rpc"
+	realtimeRpc "github.com/ledgerwatch/erigon/zk/realtime/jsonrpc"
 	zktypes "github.com/ledgerwatch/erigon/zk/types"
 	"github.com/ledgerwatch/log/v3"
 )
 
-const SubscribeTxMChannelSize = 256
-
-type RPCRealtimeTransaction struct {
-	Tx       types.Transaction
-	Receipt  *types.Receipt
-	InnerTxs []*zktypes.InnerTx
+type RealtimeResult struct {
+	Header   *types.Header      `json:"Header,omitempty"`
+	TxHash   string             `json:"TxHash,omitempty"`
+	TxData   types.Transaction  `json:"TxData,omitempty"`
+	Receipt  *types.Receipt     `json:"Receipt,omitempty"`
+	InnerTxs []*zktypes.InnerTx `json:"InnerTxs,omitempty"`
 }
 
-// RealtimeTransactions send a notification each time when a transaction was received in real-time.
-func (api *RealtimeAPIImpl) RealtimeTransactions(ctx context.Context, fullTx, includeExtraInfo *bool) (*rpc.Subscription, error) {
+// Realtime send a notification each time when a transaction was received in real-time.
+func (api *RealtimeAPIImpl) Realtime(ctx context.Context, criteria realtimeRpc.StreamCriteria) (*rpc.Subscription, error) {
 	if !api.enableFlag || api.cacheDB == nil {
 		return &rpc.Subscription{}, ErrRealtimeNotEnabled
 	}
@@ -36,48 +37,59 @@ func (api *RealtimeAPIImpl) RealtimeTransactions(ctx context.Context, fullTx, in
 	}
 
 	rpcSub := notifier.CreateSubscription()
-	txChan, id, err := api.subService.SubscribeRealtimeTransactions(SubscribeTxMChannelSize)
+	msgChan, id, err := api.subService.SubscribeRealtime()
 	if err != nil {
 		return &rpc.Subscription{}, err
 	}
 
 	go func() {
 		defer debug.LogPanic()
-		defer api.subService.UnsubscribeRealtimeTransactions(id)
+		defer api.subService.UnsubscribeRealtime(id)
 
 		for {
 			select {
-			case txMsg, ok := <-txChan:
+			case msg, ok := <-msgChan:
 				if !ok {
 					log.Warn("[realtime subscription] realtime txMsg channel closed")
 					return
 				}
 
-				if err := txMsg.Validate(); err != nil {
-					log.Warn("[realtime subscription] error while validating transaction message", "err", err)
-					return
-				}
+				if criteria.NewHeads && msg.BlockMsg != nil {
+					header, _, err := msg.BlockMsg.GetBlockInfo()
+					if err != nil {
+						log.Warn("[realtime subscription] error getting block info", "err", err)
+					}
 
-				_, tx, receipt, innerTxs, err := txMsg.GetAllTxData()
-				if err != nil {
-					log.Warn("[realtime subscription] error getting tx data", "err", err)
-					return
-				}
-
-				if fullTx == nil || !*fullTx {
-					err = notifier.Notify(rpcSub.ID, tx.Hash())
+					result := RealtimeResult{Header: header}
+					err = notifier.Notify(rpcSub.ID, result)
 					if err != nil {
 						log.Warn("[realtime subscription] error while notifying subscription", "err", err)
 					}
-				} else {
-					err = notifier.Notify(rpcSub.ID, RPCRealtimeTransaction{
-						Tx:       tx,
-						Receipt:  receipt,
-						InnerTxs: innerTxs,
-					})
 				}
-				if err != nil {
-					log.Warn("[realtime subscription] error while notifying subscription", "err", err)
+
+				if msg.TxMsg != nil {
+					result := RealtimeResult{}
+					_, tx, receipt, innerTxs, err := msg.TxMsg.GetAllTxData()
+					if err != nil {
+						log.Warn("[realtime subscription] error getting tx data", "err", err)
+					}
+					result.TxHash = tx.Hash().Hex()
+
+					// Add tx data according to stream criteria
+					if criteria.TransactionExtraInfo {
+						result.TxData = tx
+					}
+					if criteria.TransactionReceipt {
+						result.Receipt = receipt
+					}
+					if criteria.TransactionInnerTxs {
+						result.InnerTxs = innerTxs
+					}
+
+					err = notifier.Notify(rpcSub.ID, result)
+					if err != nil {
+						log.Warn("[realtime subscription] error while notifying subscription", "err", err)
+					}
 				}
 			case <-rpcSub.Err():
 				return

--- a/zk/realtime/jsonrpc/criteria.go
+++ b/zk/realtime/jsonrpc/criteria.go
@@ -1,0 +1,8 @@
+package jsonrpc
+
+type StreamCriteria struct {
+	NewHeads             bool
+	TransactionExtraInfo bool
+	TransactionReceipt   bool
+	TransactionInnerTxs  bool
+}

--- a/zk/realtime/jsonrpc/interface.go
+++ b/zk/realtime/jsonrpc/interface.go
@@ -41,6 +41,6 @@ type RealtimeAPI interface {
 
 type RealtimeSubscriptionAPI interface {
 	// Ws subscription related (see ./realtime_filters_xlayer.go)
-	RealtimeTransactions(ctx context.Context, fullTx, includeExtraInfo *bool) (*rpc.Subscription, error)
+	RealtimeTransactions(ctx context.Context, criteria StreamCriteria) (*rpc.Subscription, error)
 	Logs(ctx context.Context, crit filters.FilterCriteria) (*rpc.Subscription, error)
 }

--- a/zk/realtime/stageloop.go
+++ b/zk/realtime/stageloop.go
@@ -118,6 +118,10 @@ func ListenTxKafkaConsumer(
 				continue
 			}
 			kafkaCache.BlockMsgCache.Add(&blockMsg)
+			if subService != nil {
+				// Publish block to subscriptions
+				subService.BroadcastNewMsg(&blockMsg, nil)
+			}
 			logger.Debug("[Realtime] Received block message", "blockNum", header.Number)
 		case txMsg := <-txMsgsChan:
 			if err := txMsg.Validate(); err != nil {
@@ -132,7 +136,7 @@ func ListenTxKafkaConsumer(
 			kafkaCache.TxMsgCache.Add(&txMsg)
 			if subService != nil {
 				// Publish tx to subscriptions
-				subService.BroadcastNewTxMsg(&txMsg)
+				subService.BroadcastNewMsg(nil, &txMsg)
 			}
 			logger.Debug("[Realtime] Received transaction message", "blockNum", txMsg.BlockNumber)
 		case errorTriggerMsg := <-errorMsgsChan:

--- a/zk/realtime/subscription/subscribe.go
+++ b/zk/realtime/subscription/subscribe.go
@@ -12,25 +12,32 @@ import (
 	"github.com/ledgerwatch/log/v3"
 )
 
-// Channel size should be large enough, and limit the number of subscriptions on the node
-const DEFAULT_TX_CHAN_SIZE = 1000
+const (
+	DefaultChannelSize          = 1000
+	DefaultSubscribeChannelSize = 256
 
-// Limit the number of subscriptions on the node
-const MAX_SUBSCRIPTIONS_COUNT = 100
+	// Limit the number of subscriptions on the node
+	MaxSubscriptionsCount = 100
+)
+
+type RealtimeSubMessage struct {
+	BlockMsg *kafkaTypes.BlockMessage
+	TxMsg    *kafkaTypes.TransactionMessage
+}
 
 type RealtimeSubscription struct {
-	txSubs    *SyncMap[SubID, Sub[*kafkaTypes.TransactionMessage]]
-	logsSubs  *SyncMap[SubID, *LogsFilter]
-	newTxChan chan *kafkaTypes.TransactionMessage
-	logger    log.Logger
+	rtSubs     *SyncMap[SubID, Sub[RealtimeSubMessage]]
+	logsSubs   *SyncMap[SubID, *LogsFilter]
+	newMsgChan chan RealtimeSubMessage
+	logger     log.Logger
 }
 
 func NewRealtimeSubscription(ctx context.Context, logger log.Logger) *RealtimeSubscription {
 	return &RealtimeSubscription{
-		txSubs:    NewSyncMap[SubID, Sub[*kafkaTypes.TransactionMessage]](),
-		logsSubs:  NewSyncMap[SubID, *LogsFilter](),
-		newTxChan: make(chan *kafkaTypes.TransactionMessage, DEFAULT_TX_CHAN_SIZE),
-		logger:    logger,
+		rtSubs:     NewSyncMap[SubID, Sub[RealtimeSubMessage]](),
+		logsSubs:   NewSyncMap[SubID, *LogsFilter](),
+		newMsgChan: make(chan RealtimeSubMessage, DefaultChannelSize),
+		logger:     logger,
 	}
 }
 
@@ -41,30 +48,33 @@ func (ff *RealtimeSubscription) Start(ctx context.Context) {
 			select {
 			case <-ctx.Done():
 				return
-			case txMsg := <-ff.newTxChan:
-				wg.Add(2)
+			case msg := <-ff.newMsgChan:
+				wg.Add(1)
 				go func() {
 					defer wg.Done()
-					ff.handleRealtimeTxMsgs(ctx, txMsg)
+					ff.handleRealtimeMsgs(ctx, msg)
 				}()
-				go func() {
-					defer wg.Done()
-					ff.handleRealtimeLogMsgs(ctx, txMsg)
-				}()
+				if msg.TxMsg != nil {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						ff.handleRealtimeLogMsgs(ctx, msg.TxMsg)
+					}()
+				}
 				wg.Wait()
 			}
 		}
 	}()
 }
 
-func (ff *RealtimeSubscription) handleRealtimeTxMsgs(ctx context.Context, txMsg *kafkaTypes.TransactionMessage) {
-	ff.txSubs.Range(func(k SubID, v Sub[*kafkaTypes.TransactionMessage]) error {
+func (ff *RealtimeSubscription) handleRealtimeMsgs(ctx context.Context, msg RealtimeSubMessage) {
+	ff.rtSubs.Range(func(k SubID, v Sub[RealtimeSubMessage]) error {
 		select {
 		case <-ctx.Done():
 			return nil
 		default:
 		}
-		v.Send(txMsg)
+		v.Send(msg)
 		return nil
 	})
 }
@@ -96,35 +106,39 @@ func (ff *RealtimeSubscription) handleRealtimeLogMsgs(ctx context.Context, txMsg
 	}
 }
 
-func (ff *RealtimeSubscription) BroadcastNewTxMsg(txMsg *kafkaTypes.TransactionMessage) {
-	ff.newTxChan <- txMsg
+func (ff *RealtimeSubscription) BroadcastNewMsg(blockMsg *kafkaTypes.BlockMessage, txMsg *kafkaTypes.TransactionMessage) {
+	msg := RealtimeSubMessage{
+		BlockMsg: blockMsg,
+		TxMsg:    txMsg,
+	}
+	ff.newMsgChan <- msg
 }
 
-func (ff *RealtimeSubscription) SubscribeRealtimeTransactions(size int) (<-chan *kafkaTypes.TransactionMessage, SubID, error) {
-	if ff.txSubs.Len() > MAX_SUBSCRIPTIONS_COUNT {
+func (ff *RealtimeSubscription) SubscribeRealtime() (<-chan RealtimeSubMessage, SubID, error) {
+	if ff.rtSubs.Len()+ff.logsSubs.Len() > MaxSubscriptionsCount {
 		return nil, "", fmt.Errorf("max subscriptions count reached")
 	}
 
 	id := SubID(generateSubID())
-	sub := newChanSub[*kafkaTypes.TransactionMessage](size)
-	ff.txSubs.Put(id, sub)
+	sub := newChanSub[RealtimeSubMessage](DefaultSubscribeChannelSize)
+	ff.rtSubs.Put(id, sub)
 	return sub.ch, id, nil
 }
 
-func (ff *RealtimeSubscription) UnsubscribeRealtimeTransactions(id SubID) bool {
-	ch, ok := ff.txSubs.Get(id)
+func (ff *RealtimeSubscription) UnsubscribeRealtime(id SubID) bool {
+	ch, ok := ff.rtSubs.Get(id)
 	if !ok {
 		return false
 	}
 	ch.Close()
-	if _, ok = ff.txSubs.Delete(id); !ok {
+	if _, ok = ff.rtSubs.Delete(id); !ok {
 		return false
 	}
 	return true
 }
 
 func (ff *RealtimeSubscription) SubscribeRealtimeLogs(size int, crit filters.FilterCriteria) (<-chan *types.Log, SubID, error) {
-	if ff.logsSubs.Len() > MAX_SUBSCRIPTIONS_COUNT {
+	if ff.rtSubs.Len()+ff.logsSubs.Len() > MaxSubscriptionsCount {
 		return nil, "", fmt.Errorf("max subscriptions count reached")
 	}
 


### PR DESCRIPTION
## Summary

- Add new headers option for realtime subscriptions
- Add the new realtime StreamCriteria, with the following flags that users can set when using the realtime_subscribe API. Note that new pre-confirmed tx hash will by default be sent to subscribers, while the other criteria flags may be set by the user
  - NewHeads flag to receive new block headers
  - TransactionExtraInfo to receive full transaction data
  - TransactionReceipt to receive transaction receipts
  - TransactionInnerTxs to receive internal transaction logs
- Clean up realtime results json message passed to subscribers