### PR TITLE
ignore fork changes for rollup types relating to PP (#1965)

### DIFF
--- a/erigon-lib/kv/tables.go
+++ b/erigon-lib/kv/tables.go
@@ -549,6 +549,10 @@ const (
 	//Diagnostics tables
 	DiagSystemInfo = "DiagSystemInfo"
 	DiagSyncStages = "DiagSyncStages"
+	// Hermez SMT v2
+	TableSmtIntermediateHashes = "HermezSmtIntermediateHashes"
+
+	PP_ROLLUP_TYPES = "pp_rollup_types" // rollup type id -> true
 )
 
 // Keys
@@ -789,6 +793,7 @@ var ChaindataTablesInitial = []string{
 	WITNESS_CACHE,
 	BAD_TX_HASHES,
 	CONFIRMED_L1_INFO_TREE_UPDATE,
+	PP_ROLLUP_TYPES,
 }
 
 const (

--- a/zk/hermez_db/db.go
+++ b/zk/hermez_db/db.go
@@ -55,6 +55,7 @@ const BATCH_ENDS = "batch_ends"                                         // batch
 const WITNESS_CACHE = "witness_cache"                                   // block number -> witness for 1 block
 const BAD_TX_HASHES = "bad_tx_hashes"                                   // tx hash -> integer counter
 const CONFIRMED_L1_INFO_TREE_UPDATE = "confirmed_l1_info_tree_update"   // 1 - > confirmed l1 info tree index information (fork 12 only)
+const PP_ROLLUP_TYPES = "pp_rollup_types"                               // rollup type id -> true
 
 var HermezDbTables = []string{
 	L1VERIFICATIONS,
@@ -2073,4 +2074,16 @@ func (db *HermezDbReader) GetConfirmedL1InfoTreeUpdate() (index, l1BlockNumber u
 		return 0, 0, nil
 	}
 	return BytesToUint64(v[:8]), BytesToUint64(v[8:]), nil
+}
+
+func (db *HermezDb) WritePPRollupType(rollupType uint64) error {
+	return db.tx.Put(PP_ROLLUP_TYPES, Uint64ToBytes(rollupType), []byte{1})
+}
+
+func (db *HermezDbReader) IsPPRollupType(rollupType uint64) (bool, error) {
+	v, err := db.tx.GetOne(PP_ROLLUP_TYPES, Uint64ToBytes(rollupType))
+	if err != nil {
+		return false, err
+	}
+	return len(v) > 0, nil
 }

--- a/zk/stages/stage_l1_sequencer_sync_test.go
+++ b/zk/stages/stage_l1_sequencer_sync_test.go
@@ -94,7 +94,7 @@ func TestSpawnL1SequencerSyncStage(t *testing.T) {
 	const (
 		forkIdBytesStartPosition = 64
 		forkIdBytesEndPosition   = 96
-		rollupDataSize           = 100
+		rollupDataSize           = 128
 
 		injectedBatchLogTransactionStartByte = 128
 		injectedBatchLastGerStartByte        = 32


### PR DESCRIPTION
* ignore fork changes for rollup types relating to PP

* fixing tests now we handle fep -> pp migration