### PR TITLE
Add realtime support for some RPCs

### DIFF
--- a/zk/realtime/cache/stateless_cache.go
+++ b/zk/realtime/cache/stateless_cache.go
@@ -33,6 +33,18 @@ func (cache *StatelessCache) GetHeader(blockNum uint64) (*ethTypes.Header, int64
 	return cache.blockInfoMap.Get(blockNum)
 }
 
+func (cache *StatelessCache) GetHeaderByHash(blockHash libcommon.Hash) (*ethTypes.Header, int64, libcommon.Hash, bool) {
+	blockNum, exists := cache.blockInfoMap.GetBlockNumberByHash(blockHash)
+	if !exists {
+		return nil, 0, libcommon.Hash{}, false
+	}
+	return cache.blockInfoMap.Get(blockNum)
+}
+
+func (cache *StatelessCache) GetBlockNumberByHash(blockHash libcommon.Hash) (uint64, bool) {
+	return cache.blockInfoMap.GetBlockNumberByHash(blockHash)
+}
+
 func (cache *StatelessCache) GetTxInfo(txHash libcommon.Hash) (ethTypes.Transaction, *ethTypes.Receipt, uint64, []*zktypes.InnerTx, bool) {
 	return cache.txInfoMap.GetTx(txHash)
 }
@@ -73,8 +85,11 @@ func (cache *StatelessCache) HeaderByNumber(ctx context.Context, tx kv.Getter, b
 }
 
 func (cache *StatelessCache) HeaderByHash(ctx context.Context, tx kv.Getter, hash libcommon.Hash) (*ethTypes.Header, error) {
-	// Unimplemented
-	return nil, nil
+	header, _, _, ok := cache.GetHeaderByHash(hash)
+	if !ok {
+		return nil, fmt.Errorf("header not found for block hash %s", hash.Hex())
+	}
+	return header, nil
 }
 
 func (cache *StatelessCache) ReadAncestor(db kv.Getter, hash libcommon.Hash, number, ancestor uint64, maxNonCanonical *uint64) (libcommon.Hash, uint64) {

--- a/zk/realtime/realtimeapi/api.go
+++ b/zk/realtime/realtimeapi/api.go
@@ -106,7 +106,6 @@ func newRPCTransaction_realtime(tx types.Transaction, txblockhash libcommon.Hash
 func (api *RealtimeAPIImpl) formatBlockResponse(
 	blockNum uint64,
 	fullTx bool,
-	isPending bool,
 ) (map[string]interface{}, error) {
 	header, _, _, ok := api.cacheDB.Stateless.GetHeader(blockNum)
 	if !ok {
@@ -134,13 +133,6 @@ func (api *RealtimeAPIImpl) formatBlockResponse(
 	response, err := ethapi.RPCMarshalBlockEx(block, true, fullTx, nil, libcommon.Hash{}, additionalFields)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal block: %w", err)
-	}
-
-	// Handle pending block special case
-	if isPending {
-		for _, field := range []string{"hash", "nonce", "miner"} {
-			response[field] = nil
-		}
 	}
 
 	return response, nil

--- a/zk/realtime/realtimeapi/api.go
+++ b/zk/realtime/realtimeapi/api.go
@@ -5,8 +5,10 @@ import (
 	"math/big"
 
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/common/hexutil"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/rpc"
+	"github.com/ledgerwatch/erigon/turbo/adapter/ethapi"
 	"github.com/ledgerwatch/erigon/turbo/jsonrpc"
 	realtimeCache "github.com/ledgerwatch/erigon/zk/realtime/cache"
 	"github.com/ledgerwatch/erigon/zk/realtime/subscription"
@@ -96,4 +98,50 @@ func newRPCTransaction_realtime(tx types.Transaction, txblockhash libcommon.Hash
 	result := jsonrpc.NewRPCTransaction(tx, blockhash, blockNumber, index, baseFee)
 	result.BlockHash = &txblockhash
 	return result
+}
+
+// formatBlockResponse creates a formatted block response from cache data
+// This utility function consolidates the block formatting logic used by both
+// GetBlockByNumber and GetBlockByHash methods
+func (api *RealtimeAPIImpl) formatBlockResponse(
+	blockNum uint64,
+	fullTx bool,
+	isPending bool,
+) (map[string]interface{}, error) {
+	header, _, _, ok := api.cacheDB.Stateless.GetHeader(blockNum)
+	if !ok {
+		return nil, fmt.Errorf("header not found for block %d", blockNum)
+	}
+
+	var transactions []types.Transaction
+	txHashes, ok := api.cacheDB.Stateless.GetBlockTxs(blockNum)
+	if ok {
+		for _, txHash := range txHashes {
+			if tx, _, _, _, exists := api.cacheDB.Stateless.GetTxInfo(txHash); exists {
+				transactions = append(transactions, tx)
+			} else {
+				return nil, fmt.Errorf("transaction %s not found in cache", txHash.Hex())
+			}
+		}
+	}
+
+	block := types.NewBlockWithHeader(header).WithBody(transactions, nil)
+
+	additionalFields := map[string]interface{}{
+		"totalDifficulty": (*hexutil.Big)(header.Difficulty),
+	}
+
+	response, err := ethapi.RPCMarshalBlockEx(block, true, fullTx, nil, libcommon.Hash{}, additionalFields)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal block: %w", err)
+	}
+
+	// Handle pending block special case
+	if isPending {
+		for _, field := range []string{"hash", "nonce", "miner"} {
+			response[field] = nil
+		}
+	}
+
+	return response, nil
 }

--- a/zk/realtime/realtimeapi/api.go
+++ b/zk/realtime/realtimeapi/api.go
@@ -103,7 +103,7 @@ func newRPCTransaction_realtime(tx types.Transaction, txblockhash libcommon.Hash
 // formatBlockResponse creates a formatted block response from cache data
 // This utility function consolidates the block formatting logic used by both
 // GetBlockByNumber and GetBlockByHash methods
-func (api *RealtimeAPIImpl) formatBlockResponse(
+func (api *RealtimeAPIImpl) tryGetBlockResponseFromNumber(
 	blockNum uint64,
 	fullTx bool,
 ) (map[string]interface{}, error) {

--- a/zk/realtime/realtimeapi/api_blocks.go
+++ b/zk/realtime/realtimeapi/api_blocks.go
@@ -33,12 +33,6 @@ func (api *RealtimeAPIImpl) GetBlockTransactionCountByNumber(ctx context.Context
 		return api.APIImpl.GetBlockTransactionCountByNumber(ctx, blockNr)
 	}
 
-	if blockNr == rpc.PendingBlockNumber {
-		// Currently x-layer treats pending block as latest block which aligns with Erigon implementation
-		// TODO: Follow OP-stack implementation in the future
-		blockNr = rpc.LatestBlockNumber
-	}
-
 	blockNum, _, err := api.getBlockNumber(blockNr)
 	if err != nil {
 		return api.APIImpl.GetBlockTransactionCountByNumber(ctx, blockNr)
@@ -71,18 +65,15 @@ func (api *RealtimeAPIImpl) GetBlockByNumber(ctx context.Context, blockNr rpc.Bl
 		return api.APIImpl.GetBlockByNumber(ctx, blockNr, fullTx)
 	}
 
-	if blockNr == rpc.PendingBlockNumber {
-		// Currently x-layer treats pending block as latest block which aligns with Erigon implementation
-		// TODO: Follow OP-stack implementation in the future
-		blockNum, _, err = api.getBlockNumber(rpc.LatestBlockNumber)
-		if err != nil {
-			return api.APIImpl.GetBlockByNumber(ctx, blockNr, fullTx)
-		}
-	}
-
-	response, err := api.formatBlockResponse(blockNum, *fullTx, blockNr == rpc.PendingBlockNumber)
+	response, err := api.formatBlockResponse(blockNum, *fullTx)
 	if err != nil {
 		return api.APIImpl.GetBlockByNumber(ctx, blockNr, fullTx)
+	}
+
+	if blockNr == rpc.PendingBlockNumber {
+		for _, field := range []string{"hash", "nonce", "miner"} {
+			response[field] = nil
+		}
 	}
 
 	return response, nil
@@ -110,7 +101,7 @@ func (api *RealtimeAPIImpl) GetBlockByHash(ctx context.Context, numberOrHash rpc
 		return api.APIImpl.GetBlockByHash(ctx, numberOrHash, fullTx)
 	}
 
-	response, err := api.formatBlockResponse(blockNum, *fullTx, false)
+	response, err := api.formatBlockResponse(blockNum, *fullTx)
 	if err != nil {
 		return api.APIImpl.GetBlockByHash(ctx, numberOrHash, fullTx)
 	}
@@ -142,10 +133,6 @@ func (api *RealtimeAPIImpl) GetBlockTransactionCountByHash(ctx context.Context, 
 func (api *RealtimeAPIImpl) GetBlockInternalTransactions(ctx context.Context, blockNr rpc.BlockNumber) (map[libcommon.Hash][]*zktypes.InnerTx, error) {
 	if api.cacheDB == nil || !api.cacheDB.ReadyFlag.Load() {
 		return api.APIImpl.GetBlockInternalTransactions(ctx, blockNr)
-	}
-
-	if blockNr == rpc.PendingBlockNumber {
-		return nil, fmt.Errorf("pending block number not supported")
 	}
 
 	blockNum, _, err := api.getBlockNumber(blockNr)

--- a/zk/realtime/realtimeapi/api_blocks.go
+++ b/zk/realtime/realtimeapi/api_blocks.go
@@ -2,9 +2,15 @@ package realtimeapi
 
 import (
 	"context"
+	"fmt"
 
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/hexutil"
+	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/rpc"
+	"github.com/ledgerwatch/erigon/turbo/adapter/ethapi"
+	zktypes "github.com/ledgerwatch/erigon/zk/types"
+	"github.com/ledgerwatch/log/v3"
 )
 
 func (api *RealtimeAPIImpl) BlockNumber(ctx context.Context, tag *RealtimeTag) (hexutil.Uint64, error) {
@@ -29,6 +35,12 @@ func (api *RealtimeAPIImpl) GetBlockTransactionCountByNumber(ctx context.Context
 		return api.APIImpl.GetBlockTransactionCountByNumber(ctx, blockNr)
 	}
 
+	if blockNr == rpc.PendingBlockNumber {
+		// Currently x-layer treats pending block as latest block which aligns with Erigon implementation
+		// TODO: Follow OP-stack implementation in the future
+		blockNr = rpc.LatestBlockNumber
+	}
+
 	blockNum, _, err := api.getBlockNumber(blockNr)
 	if err != nil {
 		return api.APIImpl.GetBlockTransactionCountByNumber(ctx, blockNr)
@@ -45,4 +57,171 @@ func (api *RealtimeAPIImpl) GetBlockTransactionCountByNumber(ctx context.Context
 	}
 	numOfTx := hexutil.Uint(len(txs))
 	return &numOfTx, nil
+}
+
+func (api *RealtimeAPIImpl) GetBlockByNumber(ctx context.Context, blockNr rpc.BlockNumber, fullTx *bool) (map[string]interface{}, error) {
+	if api.cacheDB == nil || !api.cacheDB.ReadyFlag.Load() {
+		return api.APIImpl.GetBlockByNumber(ctx, blockNr, fullTx)
+	}
+
+	if fullTx == nil {
+		fullTx = new(bool)
+	}
+
+	if blockNr == rpc.PendingBlockNumber {
+		// Currently x-layer treats pending block as latest block which aligns with Erigon implementation
+		// TODO: Follow OP-stack implementation in the future
+		blockNr = rpc.LatestBlockNumber
+	}
+
+	blockNum, _, err := api.getBlockNumber(blockNr)
+	if err != nil {
+		return api.APIImpl.GetBlockByNumber(ctx, blockNr, fullTx)
+	}
+
+	header, _, _, ok := api.cacheDB.Stateless.GetHeader(blockNum)
+	if !ok {
+		return api.APIImpl.GetBlockByNumber(ctx, blockNr, fullTx)
+	}
+
+	txHashes, ok := api.cacheDB.Stateless.GetBlockTxs(blockNum)
+	if !ok {
+		return api.APIImpl.GetBlockByNumber(ctx, blockNr, fullTx)
+	}
+
+	var transactions []types.Transaction
+	for _, txHash := range txHashes {
+		if tx, _, _, _, exists := api.cacheDB.Stateless.GetTxInfo(txHash); exists {
+			transactions = append(transactions, tx)
+		} else {
+			return api.APIImpl.GetBlockByNumber(ctx, blockNr, fullTx)
+		}
+	}
+
+	block := types.NewBlockWithHeader(header).WithBody(transactions, nil)
+
+	additionalFields := map[string]interface{}{
+		"totalDifficulty": (*hexutil.Big)(header.Difficulty),
+	}
+
+	response, err := ethapi.RPCMarshalBlockEx(block, true, *fullTx, nil, libcommon.Hash{}, additionalFields)
+	if err != nil {
+		return api.APIImpl.GetBlockByNumber(ctx, blockNr, fullTx)
+	}
+
+	if blockNr == rpc.PendingBlockNumber {
+		for _, field := range []string{"hash", "nonce", "miner"} {
+			response[field] = nil
+		}
+	}
+
+	return response, nil
+}
+
+func (api *RealtimeAPIImpl) GetBlockByHash(ctx context.Context, numberOrHash rpc.BlockNumberOrHash, fullTx *bool) (map[string]interface{}, error) {
+	if api.cacheDB == nil || !api.cacheDB.ReadyFlag.Load() {
+		return api.APIImpl.GetBlockByHash(ctx, numberOrHash, fullTx)
+	}
+
+	if fullTx == nil {
+		fullTx = new(bool)
+	}
+
+	if numberOrHash.BlockNumber != nil {
+		return api.GetBlockByNumber(ctx, *numberOrHash.BlockNumber, fullTx)
+	}
+
+	if numberOrHash.BlockHash != nil {
+		targetHash := *numberOrHash.BlockHash
+
+		blockNum, found := api.cacheDB.Stateless.GetBlockNumberByHash(targetHash)
+		if !found {
+			return api.APIImpl.GetBlockByHash(ctx, numberOrHash, fullTx)
+		}
+
+		// Get header using the block number we found
+		header, _, _, ok := api.cacheDB.Stateless.GetHeader(blockNum)
+		if !ok {
+			return api.APIImpl.GetBlockByHash(ctx, numberOrHash, fullTx)
+		}
+		log.Debug(fmt.Sprintf("[GetBlockByHash] Header found for block %d", blockNum))
+
+		// Get transactions but don't fallback if missing - just use empty transactions
+		var transactions []types.Transaction
+		txHashes, ok := api.cacheDB.Stateless.GetBlockTxs(blockNum)
+		if ok {
+			for _, txHash := range txHashes {
+				if tx, _, _, _, exists := api.cacheDB.Stateless.GetTxInfo(txHash); exists {
+					transactions = append(transactions, tx)
+				}
+			}
+		}
+
+		block := types.NewBlockWithHeader(header).WithBody(transactions, nil)
+
+		additionalFields := map[string]interface{}{
+			"totalDifficulty": (*hexutil.Big)(header.Difficulty),
+		}
+
+		response, err := ethapi.RPCMarshalBlockEx(block, true, *fullTx, nil, libcommon.Hash{}, additionalFields)
+		if err != nil {
+			return api.APIImpl.GetBlockByHash(ctx, numberOrHash, fullTx)
+		}
+
+		return response, nil
+	}
+
+	return api.APIImpl.GetBlockByHash(ctx, numberOrHash, fullTx)
+}
+
+func (api *RealtimeAPIImpl) GetBlockTransactionCountByHash(ctx context.Context, blockHash libcommon.Hash) (*hexutil.Uint, error) {
+	if api.cacheDB == nil || !api.cacheDB.ReadyFlag.Load() {
+		return api.APIImpl.GetBlockTransactionCountByHash(ctx, blockHash)
+	}
+
+	blockNum, found := api.cacheDB.Stateless.GetBlockNumberByHash(blockHash)
+	if !found {
+		return api.APIImpl.GetBlockTransactionCountByHash(ctx, blockHash)
+	}
+
+	txHashes, ok := api.cacheDB.Stateless.GetBlockTxs(blockNum)
+	if !ok {
+		return api.APIImpl.GetBlockTransactionCountByHash(ctx, blockHash)
+	}
+
+	numOfTx := hexutil.Uint(len(txHashes))
+	return &numOfTx, nil
+}
+
+func (api *RealtimeAPIImpl) GetBlockInternalTransactions(ctx context.Context, blockNr rpc.BlockNumber) (map[libcommon.Hash][]*zktypes.InnerTx, error) {
+	if api.cacheDB == nil || !api.cacheDB.ReadyFlag.Load() {
+		return api.APIImpl.GetBlockInternalTransactions(ctx, blockNr)
+	}
+
+	blockNum, _, err := api.getBlockNumber(blockNr)
+	if err != nil {
+		return api.APIImpl.GetBlockInternalTransactions(ctx, blockNr)
+	}
+
+	_, _, _, ok := api.cacheDB.Stateless.GetHeader(blockNum)
+	if !ok {
+		return api.APIImpl.GetBlockInternalTransactions(ctx, blockNr)
+	}
+
+	txHashes, ok := api.cacheDB.Stateless.GetBlockTxs(blockNum)
+	if !ok {
+		return api.APIImpl.GetBlockInternalTransactions(ctx, blockNr)
+	}
+
+	result := make(map[libcommon.Hash][]*zktypes.InnerTx)
+
+	for _, txHash := range txHashes {
+		_, _, _, innerTxs, exists := api.cacheDB.Stateless.GetTxInfo(txHash)
+		if !exists {
+			return api.APIImpl.GetBlockInternalTransactions(ctx, blockNr)
+		}
+		result[txHash] = innerTxs
+	}
+
+	return result, nil
 }

--- a/zk/realtime/realtimeapi/api_blocks.go
+++ b/zk/realtime/realtimeapi/api_blocks.go
@@ -2,13 +2,11 @@ package realtimeapi
 
 import (
 	"context"
-	"fmt"
 
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/hexutil"
 	"github.com/ledgerwatch/erigon/rpc"
 	zktypes "github.com/ledgerwatch/erigon/zk/types"
-	"github.com/ledgerwatch/log/v3"
 )
 
 func (api *RealtimeAPIImpl) BlockNumber(ctx context.Context, tag *RealtimeTag) (hexutil.Uint64, error) {
@@ -84,7 +82,7 @@ func (api *RealtimeAPIImpl) GetBlockByNumber(ctx context.Context, blockNr rpc.Bl
 		return api.APIImpl.GetBlockByNumber(ctx, blockNr, fullTx)
 	}
 
-	response, err := api.formatBlockResponse(blockNum, *fullTx)
+	response, err := api.tryGetBlockResponseFromNumber(blockNum, *fullTx)
 	if err != nil {
 		return api.APIImpl.GetBlockByNumber(ctx, blockNr, fullTx)
 	}
@@ -120,12 +118,11 @@ func (api *RealtimeAPIImpl) GetBlockByHash(ctx context.Context, numberOrHash rpc
 		return api.APIImpl.GetBlockByHash(ctx, numberOrHash, fullTx)
 	}
 
-	response, err := api.formatBlockResponse(blockNum, *fullTx)
+	response, err := api.tryGetBlockResponseFromNumber(blockNum, *fullTx)
 	if err != nil {
 		return api.APIImpl.GetBlockByHash(ctx, numberOrHash, fullTx)
 	}
 
-	log.Debug(fmt.Sprintf("[GetBlockByHash] Successfully returning block %d with hash %s", blockNum, numberOrHash.BlockHash.Hex()))
 	return response, nil
 
 }

--- a/zk/realtime/realtimeapi/api_blocks.go
+++ b/zk/realtime/realtimeapi/api_blocks.go
@@ -6,9 +6,7 @@ import (
 
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/hexutil"
-	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/rpc"
-	"github.com/ledgerwatch/erigon/turbo/adapter/ethapi"
 	zktypes "github.com/ledgerwatch/erigon/zk/types"
 	"github.com/ledgerwatch/log/v3"
 )
@@ -68,51 +66,23 @@ func (api *RealtimeAPIImpl) GetBlockByNumber(ctx context.Context, blockNr rpc.Bl
 		fullTx = new(bool)
 	}
 
-	if blockNr == rpc.PendingBlockNumber {
-		// Currently x-layer treats pending block as latest block which aligns with Erigon implementation
-		// TODO: Follow OP-stack implementation in the future
-		blockNr = rpc.LatestBlockNumber
-	}
-
 	blockNum, _, err := api.getBlockNumber(blockNr)
 	if err != nil {
 		return api.APIImpl.GetBlockByNumber(ctx, blockNr, fullTx)
 	}
 
-	header, _, _, ok := api.cacheDB.Stateless.GetHeader(blockNum)
-	if !ok {
-		return api.APIImpl.GetBlockByNumber(ctx, blockNr, fullTx)
-	}
-
-	txHashes, ok := api.cacheDB.Stateless.GetBlockTxs(blockNum)
-	if !ok {
-		return api.APIImpl.GetBlockByNumber(ctx, blockNr, fullTx)
-	}
-
-	var transactions []types.Transaction
-	for _, txHash := range txHashes {
-		if tx, _, _, _, exists := api.cacheDB.Stateless.GetTxInfo(txHash); exists {
-			transactions = append(transactions, tx)
-		} else {
+	if blockNr == rpc.PendingBlockNumber {
+		// Currently x-layer treats pending block as latest block which aligns with Erigon implementation
+		// TODO: Follow OP-stack implementation in the future
+		blockNum, _, err = api.getBlockNumber(rpc.LatestBlockNumber)
+		if err != nil {
 			return api.APIImpl.GetBlockByNumber(ctx, blockNr, fullTx)
 		}
 	}
 
-	block := types.NewBlockWithHeader(header).WithBody(transactions, nil)
-
-	additionalFields := map[string]interface{}{
-		"totalDifficulty": (*hexutil.Big)(header.Difficulty),
-	}
-
-	response, err := ethapi.RPCMarshalBlockEx(block, true, *fullTx, nil, libcommon.Hash{}, additionalFields)
+	response, err := api.formatBlockResponse(blockNum, *fullTx, blockNr == rpc.PendingBlockNumber)
 	if err != nil {
 		return api.APIImpl.GetBlockByNumber(ctx, blockNr, fullTx)
-	}
-
-	if blockNr == rpc.PendingBlockNumber {
-		for _, field := range []string{"hash", "nonce", "miner"} {
-			response[field] = nil
-		}
 	}
 
 	return response, nil
@@ -127,51 +97,27 @@ func (api *RealtimeAPIImpl) GetBlockByHash(ctx context.Context, numberOrHash rpc
 		fullTx = new(bool)
 	}
 
-	if numberOrHash.BlockNumber != nil {
+	if numberOrHash.BlockHash == nil {
+		if numberOrHash.BlockNumber == nil {
+			return nil, nil
+
+		}
 		return api.GetBlockByNumber(ctx, *numberOrHash.BlockNumber, fullTx)
 	}
 
-	if numberOrHash.BlockHash != nil {
-		targetHash := *numberOrHash.BlockHash
-
-		blockNum, found := api.cacheDB.Stateless.GetBlockNumberByHash(targetHash)
-		if !found {
-			return api.APIImpl.GetBlockByHash(ctx, numberOrHash, fullTx)
-		}
-
-		// Get header using the block number we found
-		header, _, _, ok := api.cacheDB.Stateless.GetHeader(blockNum)
-		if !ok {
-			return api.APIImpl.GetBlockByHash(ctx, numberOrHash, fullTx)
-		}
-		log.Debug(fmt.Sprintf("[GetBlockByHash] Header found for block %d", blockNum))
-
-		// Get transactions but don't fallback if missing - just use empty transactions
-		var transactions []types.Transaction
-		txHashes, ok := api.cacheDB.Stateless.GetBlockTxs(blockNum)
-		if ok {
-			for _, txHash := range txHashes {
-				if tx, _, _, _, exists := api.cacheDB.Stateless.GetTxInfo(txHash); exists {
-					transactions = append(transactions, tx)
-				}
-			}
-		}
-
-		block := types.NewBlockWithHeader(header).WithBody(transactions, nil)
-
-		additionalFields := map[string]interface{}{
-			"totalDifficulty": (*hexutil.Big)(header.Difficulty),
-		}
-
-		response, err := ethapi.RPCMarshalBlockEx(block, true, *fullTx, nil, libcommon.Hash{}, additionalFields)
-		if err != nil {
-			return api.APIImpl.GetBlockByHash(ctx, numberOrHash, fullTx)
-		}
-
-		return response, nil
+	blockNum, found := api.cacheDB.Stateless.GetBlockNumberByHash(*numberOrHash.BlockHash)
+	if !found {
+		return api.APIImpl.GetBlockByHash(ctx, numberOrHash, fullTx)
 	}
 
-	return api.APIImpl.GetBlockByHash(ctx, numberOrHash, fullTx)
+	response, err := api.formatBlockResponse(blockNum, *fullTx, false)
+	if err != nil {
+		return api.APIImpl.GetBlockByHash(ctx, numberOrHash, fullTx)
+	}
+
+	log.Debug(fmt.Sprintf("[GetBlockByHash] Successfully returning block %d with hash %s", blockNum, numberOrHash.BlockHash.Hex()))
+	return response, nil
+
 }
 
 func (api *RealtimeAPIImpl) GetBlockTransactionCountByHash(ctx context.Context, blockHash libcommon.Hash) (*hexutil.Uint, error) {
@@ -196,6 +142,10 @@ func (api *RealtimeAPIImpl) GetBlockTransactionCountByHash(ctx context.Context, 
 func (api *RealtimeAPIImpl) GetBlockInternalTransactions(ctx context.Context, blockNr rpc.BlockNumber) (map[libcommon.Hash][]*zktypes.InnerTx, error) {
 	if api.cacheDB == nil || !api.cacheDB.ReadyFlag.Load() {
 		return api.APIImpl.GetBlockInternalTransactions(ctx, blockNr)
+	}
+
+	if blockNr == rpc.PendingBlockNumber {
+		return nil, fmt.Errorf("pending block number not supported")
 	}
 
 	blockNum, _, err := api.getBlockNumber(blockNr)

--- a/zk/realtime/realtimeapi/api_node.go
+++ b/zk/realtime/realtimeapi/api_node.go
@@ -1,0 +1,17 @@
+package realtimeapi
+
+import (
+	"context"
+	"fmt"
+)
+
+// Returns the status on whether the RT feature is enabled (when tag provided)
+func (api *RealtimeAPIImpl) RealtimeEnabled(ctx context.Context, tag RealtimeTag) (bool, error) {
+	if api.cacheDB == nil || !api.cacheDB.ReadyFlag.Load() {
+		return false, nil
+	}
+	if tag != Pending {
+		return false, fmt.Errorf("invalid tag, only 'pending' is supported")
+	}
+	return true, nil
+}

--- a/zk/realtime/realtimeapi/api_node.go
+++ b/zk/realtime/realtimeapi/api_node.go
@@ -2,16 +2,9 @@ package realtimeapi
 
 import (
 	"context"
-	"fmt"
 )
 
 // Returns the status on whether the RT feature is enabled (when tag provided)
-func (api *RealtimeAPIImpl) RealtimeEnabled(ctx context.Context, tag RealtimeTag) (bool, error) {
-	if api.cacheDB == nil || !api.cacheDB.ReadyFlag.Load() {
-		return false, nil
-	}
-	if tag != Pending {
-		return false, fmt.Errorf("invalid tag, only 'pending' is supported")
-	}
-	return true, nil
+func (api *RealtimeAPIImpl) RealtimeEnabled(ctx context.Context) (bool, error) {
+	return (api.cacheDB != nil && api.cacheDB.ReadyFlag.Load()), nil
 }

--- a/zk/realtime/realtimeapi/types.go
+++ b/zk/realtime/realtimeapi/types.go
@@ -46,3 +46,14 @@ func (t *RealtimeTag) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (t RealtimeTag) MarshalJSON() ([]byte, error) {
+	switch t {
+	case Latest:
+		return []byte(`"latest"`), nil
+	case Pending:
+		return []byte(`"pending"`), nil
+	default:
+		return nil, fmt.Errorf("invalid RealtimeTag value: %d", int64(t))
+	}
+}

--- a/zk/realtime/rtclient/client.go
+++ b/zk/realtime/rtclient/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/ethclient"
+	"github.com/ledgerwatch/erigon/zk/realtime/realtimeapi"
 	rpcTypes "github.com/ledgerwatch/erigon/zk/rpcdaemon"
 	zktypes "github.com/ledgerwatch/erigon/zk/types"
 	"github.com/ledgerwatch/erigon/zkevm/jsonrpc/client"
@@ -371,4 +372,92 @@ func (rc *RealtimeClient) EthGetTokenBalance(
 	}
 
 	return balance, nil
+}
+
+func (rc *RealtimeClient) RealtimeGetBlockByNumber(blockNumber uint64) (map[string]interface{}, error) {
+	// Call eth_getBlockByNumber with fullTx=true to get full transaction details
+	fullTx := true
+	response, err := client.JSONRPCCall(rc.url, "eth_getBlockByNumber", blockNumber, fullTx)
+	if err != nil {
+		return nil, err
+	}
+	if response.Error != nil {
+		return nil, fmt.Errorf("%d - %s", response.Error.Code, response.Error.Message)
+	}
+
+	var result map[string]interface{}
+	err = json.Unmarshal(response.Result, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// RealtimeGetBlockByHash returns the information about a block requested by block hash in real-time
+func (rc *RealtimeClient) RealtimeGetBlockByHash(blockHash common.Hash, fullTx bool) (map[string]interface{}, error) {
+	response, err := client.JSONRPCCall(rc.url, "eth_getBlockByHash", blockHash, fullTx)
+	if err != nil {
+		return nil, err
+	}
+	if response.Error != nil {
+		return nil, fmt.Errorf("%d - %s", response.Error.Code, response.Error.Message)
+	}
+
+	var result map[string]interface{}
+	err = json.Unmarshal(response.Result, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// RealtimeGetBlockTransactionCountByHash returns the number of transactions in a block requested by block hash in real-time
+func (rc *RealtimeClient) RealtimeGetBlockTransactionCountByHash(blockHash common.Hash) (uint64, error) {
+	response, err := client.JSONRPCCall(rc.url, "eth_getBlockTransactionCountByHash", blockHash)
+	if err != nil {
+		return 0, err
+	}
+	if response.Error != nil {
+		return 0, fmt.Errorf("%d - %s", response.Error.Code, response.Error.Message)
+	}
+
+	return transHexToUint64(response.Result)
+}
+
+func (rc *RealtimeClient) RealtimeGetBlockInternalTransactions(blockNumber uint64) (map[common.Hash][]*zktypes.InnerTx, error) {
+	response, err := client.JSONRPCCall(rc.url, "eth_getBlockInternalTransactions", blockNumber)
+	if err != nil {
+		return nil, err
+	}
+	if response.Error != nil {
+		return nil, fmt.Errorf("%d - %s", response.Error.Code, response.Error.Message)
+	}
+
+	var result map[common.Hash][]*zktypes.InnerTx
+	err = json.Unmarshal(response.Result, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (rc *RealtimeClient) RealtimeEnabled(tag realtimeapi.RealtimeTag) (bool, error) {
+	response, err := client.JSONRPCCall(rc.url, "eth_realtimeEnabled", tag)
+	if err != nil {
+		return false, err
+	}
+	if response.Error != nil {
+		return false, fmt.Errorf("%d - %s", response.Error.Code, response.Error.Message)
+	}
+
+	var result bool
+	err = json.Unmarshal(response.Result, &result)
+	if err != nil {
+		return false, err
+	}
+
+	return result, nil
 }

--- a/zk/realtime/rtclient/client.go
+++ b/zk/realtime/rtclient/client.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/ethclient"
-	"github.com/ledgerwatch/erigon/zk/realtime/realtimeapi"
 	rpcTypes "github.com/ledgerwatch/erigon/zk/rpcdaemon"
 	zktypes "github.com/ledgerwatch/erigon/zk/types"
 	"github.com/ledgerwatch/erigon/zkevm/jsonrpc/client"
@@ -444,8 +443,8 @@ func (rc *RealtimeClient) RealtimeGetBlockInternalTransactions(blockNumber uint6
 	return result, nil
 }
 
-func (rc *RealtimeClient) RealtimeEnabled(tag realtimeapi.RealtimeTag) (bool, error) {
-	response, err := client.JSONRPCCall(rc.url, "eth_realtimeEnabled", tag)
+func (rc *RealtimeClient) RealtimeEnabled() (bool, error) {
+	response, err := client.JSONRPCCall(rc.url, "eth_realtimeEnabled")
 	if err != nil {
 		return false, err
 	}

--- a/zk/realtime/test/smoke_test.go
+++ b/zk/realtime/test/smoke_test.go
@@ -28,7 +28,9 @@ import (
 	"github.com/ledgerwatch/erigon/crypto"
 	"github.com/ledgerwatch/erigon/ethclient"
 	"github.com/ledgerwatch/erigon/test/operations"
+	"github.com/ledgerwatch/erigon/zk/realtime/realtimeapi"
 	"github.com/ledgerwatch/erigon/zk/realtime/rtclient"
+	zktypes "github.com/ledgerwatch/erigon/zk/types"
 	"github.com/ledgerwatch/erigon/zkevm/encoding"
 	"github.com/ledgerwatch/erigon/zkevm/log"
 	logger "github.com/ledgerwatch/log/v3"
@@ -160,6 +162,124 @@ func TestRealtimeRPC(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "0x00000000000000000000000000000000000000000052b7d2dcc80cd2e4000000", value, fmt.Sprintf("Balance of %s should be equal to 1000000000000000000000", fromAddress))
 		log.Info(fmt.Sprintf("RealtimeCall result for erc20 contract %s calling method balanceOf %s: %s", erc20Address, fromAddress, value))
+	})
+
+	t.Run("RealtimeGetBlockByNumber", func(t *testing.T) {
+		latestBlockNumber, err := client.RealtimeBlockNumber()
+		if err != nil {
+			log.Error(fmt.Sprintf("RealtimeGetBlockNumber error: %v", err))
+		}
+		block, err := client.RealtimeGetBlockByNumber(latestBlockNumber)
+		require.NoError(t, err)
+		require.NotNil(t, block, "Block should not be nil")
+		require.NotNil(t, block["hash"], "Block hash should not be nil")
+
+		log.Info(fmt.Sprintf("RealtimeGetBlockByNumber result block number: %v, hash: %v, txCount: %v", block["number"], block["hash"], len(block["transactions"].([]interface{}))))
+	})
+
+	t.Run("RealtimeGetBlockByHash", func(t *testing.T) {
+		latestBlockNumber, err := client.RealtimeBlockNumber()
+		require.NoError(t, err)
+		require.Greater(t, latestBlockNumber, uint64(0), "Latest block number should be greater than 0")
+
+		// Get the block by number
+		log.Info(fmt.Sprintf("Getting finalized block by number: %v", latestBlockNumber))
+		blockByNumber, err := client.RealtimeGetBlockByNumber(latestBlockNumber)
+		require.NoError(t, err)
+		require.NotNil(t, blockByNumber, "Block by number should not be nil")
+
+		// Extract the block hash
+		blockHashStr, ok := blockByNumber["hash"].(string)
+		require.True(t, ok, "Block hash should be a string")
+		require.NotEmpty(t, blockHashStr, "Block hash should not be empty")
+
+		// Test getting the same block by hash
+		blockByHash, err := client.RealtimeGetBlockByHash(common.HexToHash(blockHashStr), true)
+		require.NoError(t, err)
+		require.NotNil(t, blockByHash, "Block should not be nil")
+		require.NotNil(t, blockByHash["hash"], "Block hash should not be nil")
+
+		// Verify that both methods return the same block
+		require.Equal(t, blockByNumber["hash"], blockByHash["hash"], "Block hashes should match")
+		require.Equal(t, blockByNumber["number"], blockByHash["number"], "Block numbers should match")
+
+		log.Info(fmt.Sprintf("RealtimeGetBlockByHash result - finalized block number: %v, hash: %v, txCount: %v", blockByHash["number"], blockByHash["hash"], len(blockByHash["transactions"].([]interface{}))))
+	})
+
+	t.Run("RealtimeGetBlockTransactionCountByHash", func(t *testing.T) {
+		numberOfTransactions := 10
+
+		// Create the specified number of transactions and wait for them to be mined
+		txHashes := transTokenBatch(t, context.Background(), client, uint256.NewInt(encoding.Gwei), testAddress.String(), numberOfTransactions)
+		lastTxHash := txHashes[len(txHashes)-1]
+
+		// Get the block information from the last transaction's receipt
+		receipt, err := client.RealtimeGetTransactionReceipt(common.HexToHash(lastTxHash))
+		require.NoError(t, err)
+		require.NotNil(t, receipt, "Transaction receipt should not be nil")
+
+		targetBlockNumber := receipt.BlockNumber.Uint64()
+		targetBlockHash := receipt.BlockHash
+
+		// Get the actual transaction count for this block by number
+		actualTxCount, err := client.RealtimeGetBlockTransactionCountByNumber(targetBlockNumber)
+		require.NoError(t, err)
+
+		// Test getting transaction count by hash
+		transactionCount, err := client.RealtimeGetBlockTransactionCountByHash(targetBlockHash)
+		require.NoError(t, err)
+
+		require.Equal(t, actualTxCount, transactionCount, fmt.Sprintf("Transaction count by hash should match count by number (%d)", actualTxCount))
+
+		log.Info(fmt.Sprintf("RealtimeGetBlockTransactionCountByHash result: %d (verified against block content) ✓", transactionCount))
+
+	})
+
+	t.Run("RealtimeGetBlockInternalTransactions", func(t *testing.T) {
+		txHash := transToken(t, ctx, client, uint256.NewInt(encoding.Gwei), testAddress.String())
+
+		var targetBlockNumber uint64
+
+		// Get the block number directly from the transaction receipt
+		receipt, err := client.RealtimeGetTransactionReceipt(common.HexToHash(txHash))
+		require.NoError(t, err)
+
+		targetBlockNumber = receipt.BlockNumber.Uint64()
+
+		// Test getting internal transactions for the block
+		internalTxs, err := client.RealtimeGetBlockInternalTransactions(targetBlockNumber)
+		require.NoError(t, err)
+		require.NotNil(t, internalTxs, "Internal transactions map should not be nil")
+
+		// Count total internal transactions
+		totalInternalTxs := 0
+		for _, innerTxs := range internalTxs {
+			totalInternalTxs += len(innerTxs)
+		}
+
+		require.IsType(t, map[common.Hash][]*zktypes.InnerTx{}, internalTxs, "Should return correct type")
+		log.Info(fmt.Sprintf("RealtimeGetBlockInternalTransactions successfully returned data for block %d", targetBlockNumber))
+	})
+
+	t.Run("RealtimeEnabled", func(t *testing.T) {
+		// Test with valid "pending" tag
+		pendingTag := realtimeapi.Pending
+		isEnabled, err := client.RealtimeEnabled(pendingTag)
+		require.NoError(t, err)
+		require.IsType(t, bool(false), isEnabled, "RealtimeEnabled should return bool")
+
+		// Test with invalid "latest" tag (should return error)
+		latestTag := realtimeapi.Latest
+		_, err = client.RealtimeEnabled(latestTag)
+		require.Error(t, err, "RealtimeEnabled should return error for 'latest' tag")
+		require.Contains(t, err.Error(), "invalid tag, only 'pending' is supported")
+		log.Info(fmt.Sprintf("RealtimeEnabled (latest) correctly returned error: %v", err))
+
+		if isEnabled {
+			log.Info("RealtimeEnabled: Realtime feature is enabled and cache is ready")
+		} else {
+			log.Info("RealtimeEnabled: Realtime feature is disabled or cache is not ready")
+		}
 	})
 }
 func TestRealtimeStateIsConsistent(t *testing.T) {

--- a/zk/realtime/test/smoke_test.go
+++ b/zk/realtime/test/smoke_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ledgerwatch/erigon/crypto"
 	"github.com/ledgerwatch/erigon/ethclient"
 	"github.com/ledgerwatch/erigon/test/operations"
-	"github.com/ledgerwatch/erigon/zk/realtime/realtimeapi"
 	"github.com/ledgerwatch/erigon/zk/realtime/rtclient"
 	zktypes "github.com/ledgerwatch/erigon/zk/types"
 	"github.com/ledgerwatch/erigon/zkevm/encoding"
@@ -263,17 +262,9 @@ func TestRealtimeRPC(t *testing.T) {
 
 	t.Run("RealtimeEnabled", func(t *testing.T) {
 		// Test with valid "pending" tag
-		pendingTag := realtimeapi.Pending
-		isEnabled, err := client.RealtimeEnabled(pendingTag)
+		isEnabled, err := client.RealtimeEnabled()
 		require.NoError(t, err)
 		require.IsType(t, bool(false), isEnabled, "RealtimeEnabled should return bool")
-
-		// Test with invalid "latest" tag (should return error)
-		latestTag := realtimeapi.Latest
-		_, err = client.RealtimeEnabled(latestTag)
-		require.Error(t, err, "RealtimeEnabled should return error for 'latest' tag")
-		require.Contains(t, err.Error(), "invalid tag, only 'pending' is supported")
-		log.Info(fmt.Sprintf("RealtimeEnabled (latest) correctly returned error: %v", err))
 
 		if isEnabled {
 			log.Info("RealtimeEnabled: Realtime feature is enabled and cache is ready")

--- a/zk/realtime/test/utils.go
+++ b/zk/realtime/test/utils.go
@@ -178,6 +178,64 @@ func transToken(t *testing.T, ctx context.Context, client *rtclient.RealtimeClie
 	return transTokenWithFrom(t, ctx, client, operations.DefaultL2AdminPrivateKey, amount, toAddress)
 }
 
+// Creates multiple transactions in a batch and waits for them all to be mined
+// If fromPrivateKey is empty, uses the default admin private key
+func transTokenBatch(t *testing.T, ctx context.Context, client *rtclient.RealtimeClient, amount *uint256.Int, toAddress string, batchSize int, fromPrivateKey ...string) []string {
+	privateKey := operations.DefaultL2AdminPrivateKey
+	if len(fromPrivateKey) > 0 && fromPrivateKey[0] != "" {
+		privateKey = fromPrivateKey[0]
+	}
+	var txHashes []string
+	var transactions []types.Transaction
+
+	// Create all transactions first
+	for i := 0; i < batchSize; i++ {
+		chainID, err := client.ChainID(ctx)
+		require.NoError(t, err)
+		auth, err := operations.GetAuth(privateKey, chainID.Uint64())
+		require.NoError(t, err)
+		nonce, err := client.RealtimeGetTransactionCount(auth.From)
+		require.NoError(t, err)
+		gasPrice, err := client.SuggestGasPrice(ctx)
+		require.NoError(t, err)
+
+		to := common.HexToAddress(toAddress)
+		gas := uint64(21000)
+
+		var tx types.Transaction = &types.LegacyTx{
+			CommonTx: types.CommonTx{
+				Nonce: nonce,
+				To:    &to,
+				Gas:   gas,
+				Value: amount,
+			},
+			GasPrice: uint256.MustFromBig(gasPrice),
+		}
+
+		privKey, err := crypto.HexToECDSA(strings.TrimPrefix(privateKey, "0x"))
+		require.NoError(t, err)
+
+		signer := types.MakeSigner(operations.GetTestChainConfig(operations.DefaultL2ChainID), 1, 0)
+		signedTx, err := types.SignTx(tx, *signer, privKey)
+		require.NoError(t, err)
+
+		err = client.SendTransaction(ctx, signedTx)
+		require.NoError(t, err)
+
+		txHashes = append(txHashes, signedTx.Hash().String())
+		transactions = append(transactions, signedTx)
+	}
+
+	// Wait for all transactions to be mined
+	for _, tx := range transactions {
+		err := WaitTxToBeMined(ctx, client, tx, DefaultTimeoutTxToBeMined)
+		require.NoError(t, err)
+	}
+
+	log.Info(fmt.Sprintf("All %d transactions have been mined successfully", len(transactions)))
+	return txHashes
+}
+
 func transTokenWithFrom(t *testing.T, ctx context.Context, client *rtclient.RealtimeClient, fromPrivateKey string, amount *uint256.Int, toAddress string) string {
 	chainID, err := client.ChainID(ctx)
 	require.NoError(t, err)

--- a/zk/realtime/types/blockinfo_map.go
+++ b/zk/realtime/types/blockinfo_map.go
@@ -15,13 +15,15 @@ type BlockInfo struct {
 }
 
 type BlockInfoMap struct {
-	blockInfos map[uint64]*BlockInfo
-	mu         sync.RWMutex
+	blockInfos        map[uint64]*BlockInfo
+	blockHashToHeight map[libcommon.Hash]uint64
+	mu                sync.RWMutex
 }
 
 func NewBlockInfoMap(size int) *BlockInfoMap {
 	return &BlockInfoMap{
-		blockInfos: make(map[uint64]*BlockInfo, size),
+		blockInfos:        make(map[uint64]*BlockInfo, size),
+		blockHashToHeight: make(map[libcommon.Hash]uint64, size),
 	}
 }
 
@@ -33,6 +35,14 @@ func (bm *BlockInfoMap) Get(blockNum uint64) (*ethTypes.Header, int64, libcommon
 		return blockInfo.Header, blockInfo.TxCount, blockInfo.Hash, true
 	}
 	return nil, 0, libcommon.Hash{}, exists
+}
+
+func (bm *BlockInfoMap) GetBlockNumberByHash(blockHash libcommon.Hash) (uint64, bool) {
+	bm.mu.RLock()
+	defer bm.mu.RUnlock()
+
+	blockNum, exists := bm.blockHashToHeight[blockHash]
+	return blockNum, exists
 }
 
 func (bm *BlockInfoMap) PutHeader(blockNum uint64, header *ethTypes.Header, prevBlockInfo *BlockInfo) {
@@ -47,15 +57,21 @@ func (bm *BlockInfoMap) PutHeader(blockNum uint64, header *ethTypes.Header, prev
 	// Update previous block header tx count
 	prevBlockNum := blockNum - 1
 	_, exists := bm.blockInfos[prevBlockNum]
-	if exists {
-		// Update previous block info
+	if exists && prevBlockInfo != nil {
+		// Update previous block info with finalized data
 		bm.blockInfos[prevBlockNum] = prevBlockInfo
+		// Index the finalized previous block hash
+		bm.blockHashToHeight[prevBlockInfo.Hash] = prevBlockNum
 	}
 }
 
 func (bm *BlockInfoMap) Delete(blockNum uint64) {
+	_, _, blockhash, exists := bm.Get(blockNum)
 	bm.mu.Lock()
 	defer bm.mu.Unlock()
+	if exists {
+		delete(bm.blockHashToHeight, blockhash)
+	}
 	delete(bm.blockInfos, blockNum)
 }
 
@@ -64,6 +80,9 @@ func (bm *BlockInfoMap) Clear() {
 	defer bm.mu.Unlock()
 	for k := range bm.blockInfos {
 		delete(bm.blockInfos, k)
+	}
+	for k := range bm.blockHashToHeight {
+		delete(bm.blockHashToHeight, k)
 	}
 }
 

--- a/zk/realtime/types/blockinfo_map.go
+++ b/zk/realtime/types/blockinfo_map.go
@@ -71,8 +71,8 @@ func (bm *BlockInfoMap) Delete(blockNum uint64) {
 	defer bm.mu.Unlock()
 	if exists {
 		delete(bm.blockHashToHeight, blockhash)
+		delete(bm.blockInfos, blockNum)
 	}
-	delete(bm.blockInfos, blockNum)
 }
 
 func (bm *BlockInfoMap) Clear() {


### PR DESCRIPTION
- Add realtime support for the following RPCs:
  1.   eth_getBlockByNumber
  2.  eth_getBlockByHash
  3.  eth_getBlockTransactionCountByHash
  4.  eth_getBlockInternalTransactions
  5.  eth_realtimeSyncing

- Write test cases for the above RPCs
- Add block number to block hash mapping into `blockInfoMap` to query by block hash
- Add in some utils function to query block information using block hash