### PR TITLE
RT: Fix passing confirm block headers to RT RPC nodes

### DIFF
--- a/core/state/intra_block_state_xlayer.go
+++ b/core/state/intra_block_state_xlayer.go
@@ -17,7 +17,7 @@ type TxInfo struct {
 	Entries     Entries
 }
 
-func (sdb *IntraBlockState) GenerateChangesetSinceSnapshotAndSendTxInfo(revid int, txInfoChan chan *TxInfo, tx types.Transaction, receipt *types.Receipt, innerTxs []*zktypes.InnerTx) {
+func (sdb *IntraBlockState) GenerateChangesetSinceSnapshotAndSendTxInfo(revid int, txInfoChan chan TxInfo, tx types.Transaction, receipt *types.Receipt, innerTxs []*zktypes.InnerTx) {
 	// Find the snapshot in the stack of valid snapshots.
 	idx := sort.Search(len(sdb.validRevisions), func(i int) bool {
 		return sdb.validRevisions[i].id >= revid
@@ -36,7 +36,7 @@ func (sdb *IntraBlockState) GenerateChangesetSinceSnapshotAndSendTxInfo(revid in
 	// 	entry.collectChangeset(changeset)
 	// }
 
-	txInfoChan <- &TxInfo{
+	txInfoChan <- TxInfo{
 		BlockNumber: receipt.BlockNumber.Uint64(),
 		Tx:          tx,
 		Receipt:     receipt,

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -137,6 +137,7 @@ import (
 	"github.com/ledgerwatch/erigon/zk/realtime"
 	realtimeCache "github.com/ledgerwatch/erigon/zk/realtime/cache"
 	realtimeKafka "github.com/ledgerwatch/erigon/zk/realtime/kafka"
+	kafkaTypes "github.com/ledgerwatch/erigon/zk/realtime/kafka/types"
 	"github.com/ledgerwatch/erigon/zk/realtime/realtimeapi"
 	realtimeSub "github.com/ledgerwatch/erigon/zk/realtime/subscription"
 	realtimeTypes "github.com/ledgerwatch/erigon/zk/realtime/types"
@@ -260,8 +261,8 @@ type Ethereum struct {
 	kafkaProducer *realtimeKafka.KafkaProducer
 	kafkaConsumer *realtimeKafka.KafkaConsumer
 	realtimeCache *realtimeCache.RealtimeCache
-	blockInfoChan chan *realtimeTypes.BlockInfo
-	txInfoChan    chan *state.TxInfo
+	blockInfoChan chan kafkaTypes.BlockMessage
+	txInfoChan    chan state.TxInfo
 	finishChan    chan realtimeTypes.FinishedEntry
 	realtimeSub   *realtimeSub.RealtimeSubscription
 }
@@ -1242,8 +1243,8 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 				} else {
 					backend.kafkaEnabled = true
 					backend.kafkaProducer = kafkaProducer
-					backend.blockInfoChan = make(chan *realtimeTypes.BlockInfo, realtimeKafka.DefaultKafkaBufferSize)
-					backend.txInfoChan = make(chan *state.TxInfo, realtimeKafka.DefaultKafkaBufferSize)
+					backend.blockInfoChan = make(chan kafkaTypes.BlockMessage, realtimeKafka.DefaultKafkaBufferSize)
+					backend.txInfoChan = make(chan state.TxInfo, realtimeKafka.DefaultKafkaBufferSize)
 
 					// Send error trigger message on sequencer restart
 					if err := backend.kafkaProducer.SendKafkaErrorTrigger(0); err != nil {

--- a/turbo/stages/zk_stages.go
+++ b/turbo/stages/zk_stages.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ledgerwatch/erigon/zk/datastream/server"
 	"github.com/ledgerwatch/erigon/zk/l1infotree"
 	realtimeCache "github.com/ledgerwatch/erigon/zk/realtime/cache"
+	kafkaTypes "github.com/ledgerwatch/erigon/zk/realtime/kafka/types"
 	realtimeTypes "github.com/ledgerwatch/erigon/zk/realtime/types"
 	zkStages "github.com/ledgerwatch/erigon/zk/stages"
 	"github.com/ledgerwatch/erigon/zk/syncer"
@@ -116,8 +117,8 @@ func NewSequencerZkStages(ctx context.Context,
 	txPoolDb kv.RwDB,
 	infoTreeUpdater *l1infotree.Updater,
 	hook *Hook,
-	kafkaBlockInfoChan chan *realtimeTypes.BlockInfo,
-	kafkaTxInfoChan chan *state2.TxInfo,
+	kafkaBlockInfoChan chan kafkaTypes.BlockMessage,
+	kafkaTxInfoChan chan state2.TxInfo,
 ) []*stagedsync.Stage {
 	dirs := cfg.Dirs
 	blockReader := freezeblocks.NewBlockReader(snapshots, nil)

--- a/zk/realtime/cache/realtime_cache.go
+++ b/zk/realtime/cache/realtime_cache.go
@@ -156,7 +156,7 @@ func (cache *RealtimeCache) TryApplyBlockMsg(blockNum uint64, blockMsg *kafkaTyp
 		return err
 	}
 
-	cache.Stateless.PutHeader(blockNum, blockMsg.Header, blockMsg.PrevBlockTxCount, blockMsg.PrevBlockHash)
+	cache.Stateless.PutHeader(blockNum, blockMsg.Header, blockMsg.PrevBlockInfo)
 	return nil
 }
 
@@ -177,7 +177,7 @@ func (cache *RealtimeCache) TryCloseBlockFromBlockMsg(prevblockNum uint64, block
 			return fmt.Errorf("prev block %d is not in pending blocks", prevblockNum)
 		}
 	}
-	prevContext.txCount = blockMsg.PrevBlockTxCount
+	prevContext.txCount = blockMsg.PrevBlockInfo.TxCount
 
 	// Try close pending block
 	cache.tryCloseBlock(prevContext)

--- a/zk/realtime/cache/stateless_cache.go
+++ b/zk/realtime/cache/stateless_cache.go
@@ -33,6 +33,14 @@ func (cache *StatelessCache) GetHeader(blockNum uint64) (*ethTypes.Header, int64
 	return cache.blockInfoMap.Get(blockNum)
 }
 
+func (cache *StatelessCache) GetHeaderByHash(blockHash libcommon.Hash) (*ethTypes.Header, int64, libcommon.Hash, bool) {
+	return cache.blockInfoMap.GetByHash(blockHash)
+}
+
+func (cache *StatelessCache) GetBlockNumberByHash(blockHash libcommon.Hash) (uint64, bool) {
+	return cache.blockInfoMap.GetBlockNumberByHash(blockHash)
+}
+
 func (cache *StatelessCache) GetTxInfo(txHash libcommon.Hash) (ethTypes.Transaction, *ethTypes.Receipt, uint64, []*zktypes.InnerTx, bool) {
 	return cache.txInfoMap.GetTx(txHash)
 }
@@ -42,8 +50,8 @@ func (cache *StatelessCache) GetBlockTxs(blockNum uint64) ([]libcommon.Hash, boo
 }
 
 // -------------- Write operations --------------
-func (cache *StatelessCache) PutHeader(blockNum uint64, header *ethTypes.Header, prevTxCount int64, prevBlockHash libcommon.Hash) {
-	cache.blockInfoMap.PutHeader(blockNum, header, prevTxCount, prevBlockHash)
+func (cache *StatelessCache) PutHeader(blockNum uint64, header *ethTypes.Header, preBlockInfo *realtimeTypes.BlockInfo) {
+	cache.blockInfoMap.PutHeader(blockNum, header, preBlockInfo)
 }
 
 func (cache *StatelessCache) PutTxInfo(blockNum uint64, txHash libcommon.Hash, tx ethTypes.Transaction, receipt *ethTypes.Receipt, innerTxs []*zktypes.InnerTx) {
@@ -73,8 +81,11 @@ func (cache *StatelessCache) HeaderByNumber(ctx context.Context, tx kv.Getter, b
 }
 
 func (cache *StatelessCache) HeaderByHash(ctx context.Context, tx kv.Getter, hash libcommon.Hash) (*ethTypes.Header, error) {
-	// Unimplemented
-	return nil, nil
+	header, _, _, ok := cache.GetHeaderByHash(hash)
+	if !ok {
+		return nil, fmt.Errorf("header not found for block hash %s", hash.Hex())
+	}
+	return header, nil
 }
 
 func (cache *StatelessCache) ReadAncestor(db kv.Getter, hash libcommon.Hash, number, ancestor uint64, maxNonCanonical *uint64) (libcommon.Hash, uint64) {

--- a/zk/realtime/kafka/producer.go
+++ b/zk/realtime/kafka/producer.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/IBM/sarama"
-	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon/core/types"
 	kafkaTypes "github.com/ledgerwatch/erigon/zk/realtime/kafka/types"
 	realtimeTypes "github.com/ledgerwatch/erigon/zk/realtime/types"
@@ -68,12 +67,7 @@ func (client *KafkaProducer) Close() error {
 	return client.producer.Close()
 }
 
-func (client *KafkaProducer) SendKafkaBlockInfo(header *types.Header, prevBlockTxCount int64, prevBlockHash libcommon.Hash) error {
-	msg, err := kafkaTypes.ToKafkaBlockMessage(header, prevBlockTxCount, prevBlockHash)
-	if err != nil {
-		return fmt.Errorf("SendKafkaBlockInfo error: %v", err)
-	}
-
+func (client *KafkaProducer) SendKafkaBlockInfo(msg kafkaTypes.BlockMessage) error {
 	// Marshal message to JSON
 	jsonData, err := msg.MarshalJSON()
 	if err != nil {
@@ -84,7 +78,7 @@ func (client *KafkaProducer) SendKafkaBlockInfo(header *types.Header, prevBlockT
 	kafkaMsg := &sarama.ProducerMessage{
 		Topic: client.config.BlockTopic,
 		Value: sarama.StringEncoder(jsonData),
-		Key:   sarama.StringEncoder(header.Hash().String()),
+		Key:   sarama.StringEncoder(msg.Header.Hash().String()),
 	}
 
 	// Send message

--- a/zk/realtime/kafka/test/kafka_test.go
+++ b/zk/realtime/kafka/test/kafka_test.go
@@ -110,11 +110,26 @@ func TestKafka(t *testing.T) {
 	producer, err := kafka.NewKafkaProducer(cfg)
 	assert.NilError(t, err)
 
-	for i := 0; i < 10; i++ {
+	currBlockHeader := ethTypes.CopyHeader(blockHeader)
+	for i := 1; i <= 10; i++ {
 		err = producer.SendKafkaTransaction(uint64(i), rightvrsTx, rightvrsTxReceipt, rightvrsTxInnerTxs, rightvrsTxChangeset)
 		assert.NilError(t, err)
 
-		err = producer.SendKafkaBlockInfo(blockHeader, int64(i), testHash)
+		var prevBlockHeader *ethTypes.Header
+		if i != 1 {
+			prevBlockHeader = ethTypes.CopyHeader(currBlockHeader)
+		}
+		currBlockHeader.Number = big.NewInt(int64(i))
+		blockMsg := kafkaTypes.BlockMessage{
+			Header: currBlockHeader,
+			PrevBlockInfo: &realtimeTypes.BlockInfo{
+				Header:  prevBlockHeader,
+				TxCount: int64(i),
+				Hash:    testHash,
+			},
+		}
+		assert.NilError(t, err)
+		err = producer.SendKafkaBlockInfo(blockMsg)
 		assert.NilError(t, err)
 
 		err = producer.SendKafkaErrorTrigger(uint64(i))
@@ -122,7 +137,7 @@ func TestKafka(t *testing.T) {
 	}
 
 	accessListTx.SetSender(testFromAddr)
-	for i := 10; i < 20; i++ {
+	for i := 11; i <= 20; i++ {
 		err = producer.SendKafkaTransaction(uint64(i), accessListTx, rightvrsTxReceipt, rightvrsTxInnerTxs, rightvrsTxChangeset)
 
 		assert.NilError(t, err)
@@ -141,7 +156,7 @@ func TestKafka(t *testing.T) {
 	go consumer.ConsumeKafka(ctx, headersChan, txMsgsChan, errorMsgsChan, errorChan)
 
 	// Verify tx messages
-	for i := 0; i < 10; i++ {
+	for i := 1; i <= 10; i++ {
 		select {
 		case err := <-errorChan:
 			t.Fatalf("Received error from consumer: %v", err)
@@ -153,7 +168,7 @@ func TestKafka(t *testing.T) {
 		}
 	}
 
-	for i := 10; i < 20; i++ {
+	for i := 11; i <= 20; i++ {
 		select {
 		case err := <-errorChan:
 			t.Fatalf("Received error from consumer: %v", err)
@@ -167,21 +182,28 @@ func TestKafka(t *testing.T) {
 	}
 
 	// Verify header messages
-	for i := 0; i < 10; i++ {
+	currBlockHeader = ethTypes.CopyHeader(blockHeader)
+	for i := 1; i <= 10; i++ {
 		select {
 		case err := <-errorChan:
 			t.Fatalf("Received error from consumer: %v", err)
 		case rcvHeader := <-headersChan:
-			header, count, prevBlockHash, err := rcvHeader.GetBlockInfo()
+			var prevBlockHeader *ethTypes.Header
+			if i != 1 {
+				prevBlockHeader = ethTypes.CopyHeader(currBlockHeader)
+			}
+			currBlockHeader.Number = big.NewInt(int64(i))
+			header, prevBlockInfo, err := rcvHeader.GetBlockInfo()
 			assert.NilError(t, err)
-			AssertHeader(t, blockHeader, header)
-			assert.Equal(t, count, int64(i))
-			assert.Equal(t, prevBlockHash, testHash)
+			AssertHeader(t, currBlockHeader, header)
+			AssertHeader(t, prevBlockHeader, prevBlockInfo.Header)
+			assert.Equal(t, prevBlockInfo.TxCount, int64(i))
+			assert.Equal(t, prevBlockInfo.Hash, testHash)
 		}
 	}
 
 	// Verify error trigger messages
-	for i := 0; i < 10; i++ {
+	for i := 1; i <= 10; i++ {
 		select {
 		case err := <-errorChan:
 			t.Fatalf("Received error from consumer: %v", err)

--- a/zk/realtime/kafka/test/test_utils.go
+++ b/zk/realtime/kafka/test/test_utils.go
@@ -21,6 +21,12 @@ var (
 )
 
 func AssertHeader(t *testing.T, header *types1.Header, rcvHeader *types1.Header) {
+	if header == nil {
+		if rcvHeader != nil {
+			t.Fatalf("header is nil, but rcvHeader is not nil")
+		}
+		return
+	}
 	assert.Equal(t, header.ParentHash, rcvHeader.ParentHash)
 	assert.Equal(t, header.UncleHash, rcvHeader.UncleHash)
 	assert.Equal(t, header.Coinbase, rcvHeader.Coinbase)

--- a/zk/realtime/kafka/types/block_message.go
+++ b/zk/realtime/kafka/types/block_message.go
@@ -4,48 +4,35 @@ import (
 	"encoding/json"
 	"fmt"
 
-	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	ethTypes "github.com/ledgerwatch/erigon/core/types"
+	realtimeTypes "github.com/ledgerwatch/erigon/zk/realtime/types"
 )
 
 type BlockMessage struct {
-	Header           *ethTypes.Header
-	PrevBlockTxCount int64
-	PrevBlockHash    libcommon.Hash
+	Header        *ethTypes.Header
+	PrevBlockInfo *realtimeTypes.BlockInfo
 }
 
-func ToKafkaBlockMessage(header *ethTypes.Header, prevBlockTxCount int64, prevBlockHash libcommon.Hash) (blockMsg BlockMessage, err error) {
-	blockMsg = BlockMessage{
-		Header:           header,
-		PrevBlockTxCount: prevBlockTxCount,
-		PrevBlockHash:    prevBlockHash,
-	}
-
-	return blockMsg, nil
-}
-
-func (msg BlockMessage) GetBlockInfo() (*ethTypes.Header, int64, libcommon.Hash, error) {
+func (msg BlockMessage) GetBlockInfo() (*ethTypes.Header, *realtimeTypes.BlockInfo, error) {
 	if msg.Header == nil {
-		return nil, 0, libcommon.Hash{}, fmt.Errorf("header is nil")
+		return nil, nil, fmt.Errorf("header is nil")
 	}
 	if msg.Header.Number.Uint64() == 0 {
-		return nil, 0, libcommon.Hash{}, fmt.Errorf("block number is 0")
+		return nil, nil, fmt.Errorf("block number is 0")
 	}
 
-	return msg.Header, msg.PrevBlockTxCount, msg.PrevBlockHash, nil
+	return msg.Header, msg.PrevBlockInfo, nil
 }
 
 func (msg BlockMessage) MarshalJSON() ([]byte, error) {
 	type BlockMessage struct {
-		Header           *ethTypes.Header `json:"header"`
-		PrevBlockTxCount int64            `json:"prevBlockTxCount"`
-		PrevBlockHash    libcommon.Hash   `json:"prevBlockHash"`
+		Header        *ethTypes.Header         `json:"header"`
+		PrevBlockInfo *realtimeTypes.BlockInfo `json:"prevBlockInfo"`
 	}
 
 	var enc BlockMessage
 	enc.Header = msg.Header
-	enc.PrevBlockTxCount = msg.PrevBlockTxCount
-	enc.PrevBlockHash = msg.PrevBlockHash
+	enc.PrevBlockInfo = msg.PrevBlockInfo
 
 	return json.Marshal(&enc)
 }

--- a/zk/realtime/realtimeapi/api_blocks.go
+++ b/zk/realtime/realtimeapi/api_blocks.go
@@ -3,8 +3,12 @@ package realtimeapi
 import (
 	"context"
 
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/hexutil"
+	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/rpc"
+	"github.com/ledgerwatch/erigon/turbo/adapter/ethapi"
+	zktypes "github.com/ledgerwatch/erigon/zk/types"
 )
 
 func (api *RealtimeAPIImpl) BlockNumber(ctx context.Context, tag *RealtimeTag) (hexutil.Uint64, error) {
@@ -45,4 +49,166 @@ func (api *RealtimeAPIImpl) GetBlockTransactionCountByNumber(ctx context.Context
 	}
 	numOfTx := hexutil.Uint(len(txs))
 	return &numOfTx, nil
+}
+
+func (api *RealtimeAPIImpl) GetBlockByNumber(ctx context.Context, blockNr rpc.BlockNumber, fullTx *bool) (map[string]interface{}, error) {
+	if api.cacheDB == nil || !api.cacheDB.ReadyFlag.Load() {
+		return api.APIImpl.GetBlockByNumber(ctx, blockNr, fullTx)
+	}
+
+	if fullTx == nil {
+		fullTx = new(bool)
+	}
+
+	blockNum, _, err := api.getBlockNumber(blockNr)
+	if err != nil {
+		return api.APIImpl.GetBlockByNumber(ctx, blockNr, fullTx)
+	}
+
+	header, _, _, ok := api.cacheDB.Stateless.GetHeader(blockNum)
+	if !ok {
+		return api.APIImpl.GetBlockByNumber(ctx, blockNr, fullTx)
+	}
+
+	txHashes, ok := api.cacheDB.Stateless.GetBlockTxs(blockNum)
+	if !ok {
+		return api.APIImpl.GetBlockByNumber(ctx, blockNr, fullTx)
+	}
+
+	var transactions []types.Transaction
+	for _, txHash := range txHashes {
+		if tx, _, _, _, exists := api.cacheDB.Stateless.GetTxInfo(txHash); exists {
+			transactions = append(transactions, tx)
+		} else {
+			return api.APIImpl.GetBlockByNumber(ctx, blockNr, fullTx)
+		}
+	}
+
+	block := types.NewBlockWithHeader(header).WithBody(transactions, nil)
+
+	additionalFields := map[string]interface{}{
+		"totalDifficulty": (*hexutil.Big)(header.Difficulty),
+	}
+
+	response, err := ethapi.RPCMarshalBlockEx(block, true, *fullTx, nil, libcommon.Hash{}, additionalFields)
+	if err != nil {
+		return api.APIImpl.GetBlockByNumber(ctx, blockNr, fullTx)
+	}
+
+	if blockNr == rpc.PendingBlockNumber {
+		for _, field := range []string{"hash", "nonce", "miner"} {
+			response[field] = nil
+		}
+	}
+
+	return response, nil
+}
+
+func (api *RealtimeAPIImpl) GetBlockByHash(ctx context.Context, numberOrHash rpc.BlockNumberOrHash, fullTx *bool) (map[string]interface{}, error) {
+	if api.cacheDB == nil || !api.cacheDB.ReadyFlag.Load() {
+		return api.APIImpl.GetBlockByHash(ctx, numberOrHash, fullTx)
+	}
+
+	if fullTx == nil {
+		fullTx = new(bool)
+	}
+
+	if numberOrHash.BlockNumber != nil {
+		return api.GetBlockByNumber(ctx, *numberOrHash.BlockNumber, fullTx)
+	}
+
+	if numberOrHash.BlockHash != nil {
+		targetHash := *numberOrHash.BlockHash
+
+		header, _, _, ok := api.cacheDB.Stateless.GetHeaderByHash(targetHash)
+		if !ok {
+			return api.APIImpl.GetBlockByHash(ctx, numberOrHash, fullTx)
+		}
+
+		blockNum, found := api.cacheDB.Stateless.GetBlockNumberByHash(targetHash)
+		if !found {
+			return api.APIImpl.GetBlockByHash(ctx, numberOrHash, fullTx)
+		}
+
+		txHashes, ok := api.cacheDB.Stateless.GetBlockTxs(blockNum)
+		if !ok {
+			return api.APIImpl.GetBlockByHash(ctx, numberOrHash, fullTx)
+		}
+
+		var transactions []types.Transaction
+		for _, txHash := range txHashes {
+			if tx, _, _, _, exists := api.cacheDB.Stateless.GetTxInfo(txHash); exists {
+				transactions = append(transactions, tx)
+			} else {
+				return api.APIImpl.GetBlockByHash(ctx, numberOrHash, fullTx)
+			}
+		}
+
+		block := types.NewBlockWithHeader(header).WithBody(transactions, nil)
+
+		additionalFields := map[string]interface{}{
+			"totalDifficulty": (*hexutil.Big)(header.Difficulty),
+		}
+
+		response, err := ethapi.RPCMarshalBlockEx(block, true, *fullTx, nil, libcommon.Hash{}, additionalFields)
+		if err != nil {
+			return api.APIImpl.GetBlockByHash(ctx, numberOrHash, fullTx)
+		}
+
+		return response, nil
+	}
+
+	return api.APIImpl.GetBlockByHash(ctx, numberOrHash, fullTx)
+}
+
+func (api *RealtimeAPIImpl) GetBlockTransactionCountByHash(ctx context.Context, blockHash libcommon.Hash) (*hexutil.Uint, error) {
+	if api.cacheDB == nil || !api.cacheDB.ReadyFlag.Load() {
+		return api.APIImpl.GetBlockTransactionCountByHash(ctx, blockHash)
+	}
+
+	blockNum, found := api.cacheDB.Stateless.GetBlockNumberByHash(blockHash)
+	if !found {
+		return api.APIImpl.GetBlockTransactionCountByHash(ctx, blockHash)
+	}
+
+	txHashes, ok := api.cacheDB.Stateless.GetBlockTxs(blockNum)
+	if !ok {
+		return api.APIImpl.GetBlockTransactionCountByHash(ctx, blockHash)
+	}
+
+	numOfTx := hexutil.Uint(len(txHashes))
+	return &numOfTx, nil
+}
+
+func (api *RealtimeAPIImpl) GetBlockInternalTransactions(ctx context.Context, blockNr rpc.BlockNumber) (map[libcommon.Hash][]*zktypes.InnerTx, error) {
+	if api.cacheDB == nil || !api.cacheDB.ReadyFlag.Load() {
+		return api.APIImpl.GetBlockInternalTransactions(ctx, blockNr)
+	}
+
+	blockNum, _, err := api.getBlockNumber(blockNr)
+	if err != nil {
+		return api.APIImpl.GetBlockInternalTransactions(ctx, blockNr)
+	}
+
+	_, _, _, ok := api.cacheDB.Stateless.GetHeader(blockNum)
+	if !ok {
+		return api.APIImpl.GetBlockInternalTransactions(ctx, blockNr)
+	}
+
+	txHashes, ok := api.cacheDB.Stateless.GetBlockTxs(blockNum)
+	if !ok {
+		return api.APIImpl.GetBlockInternalTransactions(ctx, blockNr)
+	}
+
+	result := make(map[libcommon.Hash][]*zktypes.InnerTx)
+
+	for _, txHash := range txHashes {
+		_, _, _, innerTxs, exists := api.cacheDB.Stateless.GetTxInfo(txHash)
+		if !exists {
+			return api.APIImpl.GetBlockInternalTransactions(ctx, blockNr)
+		}
+		result[txHash] = innerTxs
+	}
+
+	return result, nil
 }

--- a/zk/realtime/realtimeapi/api_filters.go
+++ b/zk/realtime/realtimeapi/api_filters.go
@@ -49,7 +49,7 @@ func (api *RealtimeAPIImpl) Realtime(ctx context.Context, criteria realtimeSub.S
 				result := RealtimeSubResult{}
 				sendFlag := false
 				if criteria.NewHeads && msg.BlockMsg != nil {
-					header, _, _, err := msg.BlockMsg.GetBlockInfo()
+					header, _, err := msg.BlockMsg.GetBlockInfo()
 					if err != nil {
 						log.Warn("[realtime subscription] error getting block info", "err", err)
 					}

--- a/zk/realtime/realtimeapi/api_node.go
+++ b/zk/realtime/realtimeapi/api_node.go
@@ -1,0 +1,17 @@
+package realtimeapi
+
+import (
+	"context"
+	"fmt"
+)
+
+// Returns the status on whether the RT feature is enabled (when tag provided)
+func (api *RealtimeAPIImpl) RealtimeEnabled(ctx context.Context, tag RealtimeTag) (bool, error) {
+	if api.cacheDB == nil || !api.cacheDB.ReadyFlag.Load() {
+		return false, nil
+	}
+	if tag != Pending {
+		return false, fmt.Errorf("invalid tag, only 'pending' is supported")
+	}
+	return true, nil
+}

--- a/zk/realtime/realtimeapi/types.go
+++ b/zk/realtime/realtimeapi/types.go
@@ -46,3 +46,14 @@ func (t *RealtimeTag) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (t RealtimeTag) MarshalJSON() ([]byte, error) {
+	switch t {
+	case Latest:
+		return []byte(`"latest"`), nil
+	case Pending:
+		return []byte(`"pending"`), nil
+	default:
+		return nil, fmt.Errorf("invalid RealtimeTag value: %d", int64(t))
+	}
+}

--- a/zk/realtime/rtclient/client.go
+++ b/zk/realtime/rtclient/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/ethclient"
+	"github.com/ledgerwatch/erigon/zk/realtime/realtimeapi"
 	rpcTypes "github.com/ledgerwatch/erigon/zk/rpcdaemon"
 	zktypes "github.com/ledgerwatch/erigon/zk/types"
 	"github.com/ledgerwatch/erigon/zkevm/jsonrpc/client"
@@ -371,4 +372,92 @@ func (rc *RealtimeClient) EthGetTokenBalance(
 	}
 
 	return balance, nil
+}
+
+func (rc *RealtimeClient) RealtimeGetBlockByNumber(blockNumber uint64) (map[string]interface{}, error) {
+	// Call eth_getBlockByNumber with fullTx=true to get full transaction details
+	fullTx := true
+	response, err := client.JSONRPCCall(rc.url, "eth_getBlockByNumber", blockNumber, fullTx)
+	if err != nil {
+		return nil, err
+	}
+	if response.Error != nil {
+		return nil, fmt.Errorf("%d - %s", response.Error.Code, response.Error.Message)
+	}
+
+	var result map[string]interface{}
+	err = json.Unmarshal(response.Result, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// RealtimeGetBlockByHash returns the information about a block requested by block hash in real-time
+func (rc *RealtimeClient) RealtimeGetBlockByHash(blockHash common.Hash, fullTx bool) (map[string]interface{}, error) {
+	response, err := client.JSONRPCCall(rc.url, "eth_getBlockByHash", blockHash, fullTx)
+	if err != nil {
+		return nil, err
+	}
+	if response.Error != nil {
+		return nil, fmt.Errorf("%d - %s", response.Error.Code, response.Error.Message)
+	}
+
+	var result map[string]interface{}
+	err = json.Unmarshal(response.Result, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// RealtimeGetBlockTransactionCountByHash returns the number of transactions in a block requested by block hash in real-time
+func (rc *RealtimeClient) RealtimeGetBlockTransactionCountByHash(blockHash common.Hash) (uint64, error) {
+	response, err := client.JSONRPCCall(rc.url, "eth_getBlockTransactionCountByHash", blockHash)
+	if err != nil {
+		return 0, err
+	}
+	if response.Error != nil {
+		return 0, fmt.Errorf("%d - %s", response.Error.Code, response.Error.Message)
+	}
+
+	return transHexToUint64(response.Result)
+}
+
+func (rc *RealtimeClient) RealtimeGetBlockInternalTransactions(blockNumber uint64) (map[common.Hash][]*zktypes.InnerTx, error) {
+	response, err := client.JSONRPCCall(rc.url, "eth_getBlockInternalTransactions", blockNumber)
+	if err != nil {
+		return nil, err
+	}
+	if response.Error != nil {
+		return nil, fmt.Errorf("%d - %s", response.Error.Code, response.Error.Message)
+	}
+
+	var result map[common.Hash][]*zktypes.InnerTx
+	err = json.Unmarshal(response.Result, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (rc *RealtimeClient) RealtimeEnabled(tag realtimeapi.RealtimeTag) (bool, error) {
+	response, err := client.JSONRPCCall(rc.url, "eth_realtimeEnabled", tag)
+	if err != nil {
+		return false, err
+	}
+	if response.Error != nil {
+		return false, fmt.Errorf("%d - %s", response.Error.Code, response.Error.Message)
+	}
+
+	var result bool
+	err = json.Unmarshal(response.Result, &result)
+	if err != nil {
+		return false, err
+	}
+
+	return result, nil
 }

--- a/zk/realtime/stageloop.go
+++ b/zk/realtime/stageloop.go
@@ -29,8 +29,8 @@ var (
 func ListenKafkaProducer(
 	ctx context.Context,
 	kafkaProducer *kafka.KafkaProducer,
-	blockInfoChan chan *realtimeTypes.BlockInfo,
-	txInfoChan chan *state.TxInfo) {
+	blockInfoChan chan kafkaTypes.BlockMessage,
+	txInfoChan chan state.TxInfo) {
 	if !sequencer.IsSequencer() {
 		log.Info("[Realtime] KafkaProducer is disabled on non-sequencer, skipping")
 		return
@@ -45,8 +45,8 @@ func ListenKafkaProducer(
 			return
 		case blockInfo := <-blockInfoChan:
 			currHeight = blockInfo.Header.Number.Uint64()
-			err = kafkaProducer.SendKafkaBlockInfo(blockInfo.Header, blockInfo.TxCount, blockInfo.Hash)
-			log.Debug(fmt.Sprintf("[Realtime] Sent block info message for block number %d with txCount %d", blockInfo.Header.Number, blockInfo.TxCount))
+			err = kafkaProducer.SendKafkaBlockInfo(blockInfo)
+			log.Debug(fmt.Sprintf("[Realtime] Sent block info message for block number %d with prev info %v", blockInfo.Header.Number, blockInfo.PrevBlockInfo))
 		case txInfo := <-txInfoChan:
 			currHeight = txInfo.BlockNumber
 			if currHeight <= 1 {
@@ -112,7 +112,7 @@ func ListenKafkaConsumer(
 			realtimeCache.UpdateExecution(finishEntry)
 			log.Debug("[Realtime] Received finish signal from execution", "finishHeight", finishEntry.Height)
 		case blockMsg := <-blockMsgsChan:
-			header, _, _, err := blockMsg.GetBlockInfo()
+			header, _, err := blockMsg.GetBlockInfo()
 			if err != nil {
 				log.Error(fmt.Sprintf("[Realtime] Failed to consume block message from kafka. error: %v", err))
 				continue

--- a/zk/realtime/test/cache_test.go
+++ b/zk/realtime/test/cache_test.go
@@ -24,15 +24,29 @@ func TestBlockInfoMap(t *testing.T) {
 	}
 	hash := common.HexToHash("0x123")
 	prevTxCount := int64(10)
+	prevHeader := &ethTypes.Header{
+		Number: big.NewInt(int64(blockNum - 1)),
+		Time:   50,
+	}
 
 	t.Run("PutHeader and Get", func(t *testing.T) {
-		bm.PutHeader(blockNum, header, prevTxCount, hash)
+		bm.PutHeader(blockNum, header, &realtimeTypes.BlockInfo{
+			Header:  prevHeader,
+			TxCount: prevTxCount,
+			Hash:    hash,
+		})
+
+		// Check current header
 		cacheHeader, cacheTxCount, cacheHash, exists := bm.Get(blockNum)
 		assert.True(t, exists)
 		assert.Equal(t, header, cacheHeader)
 		assert.Equal(t, cacheHash, common.Hash{})
 		// Init txCount is -1
 		assert.Equal(t, int64(-1), cacheTxCount)
+
+		// Check previous header should not exist
+		_, _, _, exists = bm.Get(blockNum - 1)
+		assert.False(t, exists)
 	})
 
 	t.Run("Get non-existent", func(t *testing.T) {
@@ -57,9 +71,17 @@ func TestBlockInfoMap(t *testing.T) {
 			}
 			prevTxCount := int64(i * 5)
 			prevHash := common.HexToHash(fmt.Sprintf("0x%x", i))
+			prevHeader := &ethTypes.Header{
+				Number: big.NewInt(int64(prevBlockNum)),
+				Time:   uint64(prevBlockNum * 50),
+			}
 
 			// Test PutHeader
-			bm.PutHeader(blockNum, header, prevTxCount, prevHash)
+			bm.PutHeader(blockNum, header, &realtimeTypes.BlockInfo{
+				Header:  prevHeader,
+				TxCount: prevTxCount,
+				Hash:    prevHash,
+			})
 			cacheHeader, cacheTxCount, cacheHash, exists := bm.Get(blockNum)
 			assert.True(t, exists)
 			assert.NotNil(t, cacheHeader)
@@ -70,13 +92,16 @@ func TestBlockInfoMap(t *testing.T) {
 			assert.Equal(t, common.Hash{}, cacheHash)
 
 			// Check previous block txCount
+			cacheHeader, cacheTxCount, cacheHash, exists = bm.Get(prevBlockNum)
 			if i == 0 {
-				continue
+				assert.False(t, exists)
+			} else {
+				assert.True(t, exists)
+				assert.Equal(t, prevHeader, cacheHeader)
+				assert.Equal(t, prevTxCount, cacheTxCount)
+				assert.Equal(t, prevHash, cacheHash)
 			}
-			_, cacheTxCount, cacheHash, exists = bm.Get(prevBlockNum)
-			assert.True(t, exists)
-			assert.Equal(t, cacheTxCount, prevTxCount)
-			assert.Equal(t, cacheHash, prevHash)
+
 		}
 
 		// Test delete

--- a/zk/realtime/test/smoke_test.go
+++ b/zk/realtime/test/smoke_test.go
@@ -28,7 +28,9 @@ import (
 	"github.com/ledgerwatch/erigon/crypto"
 	"github.com/ledgerwatch/erigon/ethclient"
 	"github.com/ledgerwatch/erigon/test/operations"
+	"github.com/ledgerwatch/erigon/zk/realtime/realtimeapi"
 	"github.com/ledgerwatch/erigon/zk/realtime/rtclient"
+	zktypes "github.com/ledgerwatch/erigon/zk/types"
 	"github.com/ledgerwatch/erigon/zkevm/encoding"
 	"github.com/ledgerwatch/erigon/zkevm/log"
 	logger "github.com/ledgerwatch/log/v3"
@@ -160,6 +162,117 @@ func TestRealtimeRPC(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "0x00000000000000000000000000000000000000000052b7d2dcc80cd2e4000000", value, fmt.Sprintf("Balance of %s should be equal to 1000000000000000000000", fromAddress))
 		log.Info(fmt.Sprintf("RealtimeCall result for erc20 contract %s calling method balanceOf %s: %s", erc20Address, fromAddress, value))
+	})
+
+	t.Run("RealtimeGetBlockByNumber", func(t *testing.T) {
+		block, err := client.RealtimeGetBlockByNumber(blockNumber)
+		require.NoError(t, err)
+		require.NotNil(t, block, "Block should not be nil")
+
+		log.Info(fmt.Sprintf("RealtimeGetBlockByNumber result block number: %v, hash: %v, txCount: %v", block["number"], block["hash"], len(block["transactions"].([]interface{}))))
+	})
+
+	t.Run("RealtimeGetBlockByHash", func(t *testing.T) {
+		// Get block by number to obtain the block hash
+		blockByNumber, err := client.RealtimeGetBlockByNumber(blockNumber)
+		require.NoError(t, err)
+		require.NotNil(t, blockByNumber, "Block by number should not be nil")
+
+		// Extract the block hash
+		blockHashStr, ok := blockByNumber["hash"].(string)
+		require.True(t, ok, "Block hash should be a string")
+		require.NotEmpty(t, blockHashStr, "Block hash should not be empty")
+
+		// Test getting the same block by hash
+		blockByHash, err := client.RealtimeGetBlockByHash(common.HexToHash(blockHashStr), true)
+		require.NoError(t, err)
+		require.NotNil(t, blockByHash, "Block by hash should not be nil")
+
+		// Verify that both methods return the same block
+		require.Equal(t, blockByNumber["hash"], blockByHash["hash"], "Block hashes should match")
+		require.Equal(t, blockByNumber["number"], blockByHash["number"], "Block numbers should match")
+
+		log.Info(fmt.Sprintf("RealtimeGetBlockByHash result block number: %v, hash: %v, txCount: %v", blockByHash["number"], blockByHash["hash"], len(blockByHash["transactions"].([]interface{}))))
+	})
+
+	t.Run("RealtimeGetBlockTransactionCountByHash", func(t *testing.T) {
+		numberOfTransactions := 10
+
+		log.Info(fmt.Sprintf("Creating %d transactions for testing...", numberOfTransactions))
+
+		// Create the specified number of transactions and wait for them to be mined
+		txHashes := transTokenBatch(t, context.Background(), client, uint256.NewInt(encoding.Gwei), testAddress.String(), numberOfTransactions)
+		lastTxHash := txHashes[len(txHashes)-1]
+
+		// Get the block information from the last transaction's receipt
+		receipt, err := client.RealtimeGetTransactionReceipt(common.HexToHash(lastTxHash))
+		require.NoError(t, err)
+		require.NotNil(t, receipt, "Transaction receipt should not be nil")
+
+		targetBlockNumber := receipt.BlockNumber.Uint64()
+		targetBlockHash := receipt.BlockHash
+
+		log.Info(fmt.Sprintf("Using block %d (hash: %x) for testing", targetBlockNumber, targetBlockHash))
+
+		// Get the actual transaction count for this block by number
+		actualTxCount, err := client.RealtimeGetBlockTransactionCountByNumber(targetBlockNumber)
+		require.NoError(t, err)
+
+		// Test getting transaction count by hash
+		transactionCount, err := client.RealtimeGetBlockTransactionCountByHash(targetBlockHash)
+		require.NoError(t, err)
+
+		require.Equal(t, actualTxCount, transactionCount, fmt.Sprintf("Transaction count by hash should match count by number (%d)", actualTxCount))
+
+		log.Info(fmt.Sprintf("RealtimeGetBlockTransactionCountByHash result: %d (verified against block content) ✓", transactionCount))
+
+	})
+
+	t.Run("RealtimeGetBlockInternalTransactions", func(t *testing.T) {
+		txHash := transToken(t, ctx, client, uint256.NewInt(encoding.Gwei), testAddress.String())
+
+		var targetBlockNumber uint64
+
+		// Get the block number directly from the transaction receipt
+		receipt, err := client.RealtimeGetTransactionReceipt(common.HexToHash(txHash))
+		require.NoError(t, err)
+
+		targetBlockNumber = receipt.BlockNumber.Uint64()
+
+		// Test getting internal transactions for the block
+		internalTxs, err := client.RealtimeGetBlockInternalTransactions(targetBlockNumber)
+		require.NoError(t, err)
+		require.NotNil(t, internalTxs, "Internal transactions map should not be nil")
+
+		// Count total internal transactions
+		totalInternalTxs := 0
+		for _, innerTxs := range internalTxs {
+			totalInternalTxs += len(innerTxs)
+		}
+
+		require.IsType(t, map[common.Hash][]*zktypes.InnerTx{}, internalTxs, "Should return correct type")
+		log.Info(fmt.Sprintf("RealtimeGetBlockInternalTransactions successfully returned data for block %d", targetBlockNumber))
+	})
+
+	t.Run("RealtimeEnabled", func(t *testing.T) {
+		// Test with valid "pending" tag
+		pendingTag := realtimeapi.Pending
+		isEnabled, err := client.RealtimeEnabled(pendingTag)
+		require.NoError(t, err)
+		require.IsType(t, bool(false), isEnabled, "RealtimeEnabled should return bool")
+
+		// Test with invalid "latest" tag (should return error)
+		latestTag := realtimeapi.Latest
+		_, err = client.RealtimeEnabled(latestTag)
+		require.Error(t, err, "RealtimeEnabled should return error for 'latest' tag")
+		require.Contains(t, err.Error(), "invalid tag, only 'pending' is supported")
+		log.Info(fmt.Sprintf("RealtimeEnabled (latest) correctly returned error: %v", err))
+
+		if isEnabled {
+			log.Info("RealtimeEnabled: Realtime feature is enabled and cache is ready")
+		} else {
+			log.Info("RealtimeEnabled: Realtime feature is disabled or cache is not ready")
+		}
 	})
 }
 func TestRealtimeStateIsConsistent(t *testing.T) {

--- a/zk/realtime/test/utils.go
+++ b/zk/realtime/test/utils.go
@@ -178,6 +178,65 @@ func transToken(t *testing.T, ctx context.Context, client *rtclient.RealtimeClie
 	return transTokenWithFrom(t, ctx, client, operations.DefaultL2AdminPrivateKey, amount, toAddress)
 }
 
+// Creates multiple transactions in a batch and waits for them all to be mined
+func transTokenBatch(t *testing.T, ctx context.Context, client *rtclient.RealtimeClient, amount *uint256.Int, toAddress string, batchSize int) []string {
+	return transTokenBatchWithFrom(t, ctx, client, operations.DefaultL2AdminPrivateKey, amount, toAddress, batchSize)
+}
+
+func transTokenBatchWithFrom(t *testing.T, ctx context.Context, client *rtclient.RealtimeClient, fromPrivateKey string, amount *uint256.Int, toAddress string, batchSize int) []string {
+	var txHashes []string
+	var transactions []types.Transaction
+
+	// Create all transactions first
+	for i := 0; i < batchSize; i++ {
+		chainID, err := client.ChainID(ctx)
+		require.NoError(t, err)
+		auth, err := operations.GetAuth(fromPrivateKey, chainID.Uint64())
+		require.NoError(t, err)
+		nonce, err := client.RealtimeGetTransactionCount(auth.From)
+		require.NoError(t, err)
+		gasPrice, err := client.SuggestGasPrice(ctx)
+		require.NoError(t, err)
+
+		to := common.HexToAddress(toAddress)
+		gas := uint64(21000)
+
+		var tx types.Transaction = &types.LegacyTx{
+			CommonTx: types.CommonTx{
+				Nonce: nonce,
+				To:    &to,
+				Gas:   gas,
+				Value: amount,
+			},
+			GasPrice: uint256.MustFromBig(gasPrice),
+		}
+
+		privateKey, err := crypto.HexToECDSA(strings.TrimPrefix(fromPrivateKey, "0x"))
+		require.NoError(t, err)
+
+		signer := types.MakeSigner(operations.GetTestChainConfig(operations.DefaultL2ChainID), 1, 0)
+		signedTx, err := types.SignTx(tx, *signer, privateKey)
+		require.NoError(t, err)
+
+		err = client.SendTransaction(ctx, signedTx)
+		require.NoError(t, err)
+
+		txHashes = append(txHashes, signedTx.Hash().String())
+		transactions = append(transactions, signedTx)
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Wait for all transactions to be mined
+	for _, tx := range transactions {
+		err := WaitTxToBeMined(ctx, client, tx, DefaultTimeoutTxToBeMined)
+		require.NoError(t, err)
+	}
+
+	log.Info(fmt.Sprintf("All %d transactions have been mined successfully", len(transactions)))
+	return txHashes
+}
+
 func transTokenWithFrom(t *testing.T, ctx context.Context, client *rtclient.RealtimeClient, fromPrivateKey string, amount *uint256.Int, toAddress string) string {
 	chainID, err := client.ChainID(ctx)
 	require.NoError(t, err)

--- a/zk/realtime/types/blockinfo_map.go
+++ b/zk/realtime/types/blockinfo_map.go
@@ -9,19 +9,21 @@ import (
 )
 
 type BlockInfo struct {
-	Header  *ethTypes.Header
-	TxCount int64
-	Hash    libcommon.Hash
+	Header  *ethTypes.Header `json:"header"`
+	TxCount int64            `json:"txCount"`
+	Hash    libcommon.Hash   `json:"hash"`
 }
 
 type BlockInfoMap struct {
 	blockInfos map[uint64]*BlockInfo
+	hashToNum  map[libcommon.Hash]uint64
 	mu         sync.RWMutex
 }
 
 func NewBlockInfoMap(size int) *BlockInfoMap {
 	return &BlockInfoMap{
 		blockInfos: make(map[uint64]*BlockInfo, size),
+		hashToNum:  make(map[libcommon.Hash]uint64, size),
 	}
 }
 
@@ -35,7 +37,31 @@ func (bm *BlockInfoMap) Get(blockNum uint64) (*ethTypes.Header, int64, libcommon
 	return nil, 0, libcommon.Hash{}, exists
 }
 
-func (bm *BlockInfoMap) PutHeader(blockNum uint64, header *ethTypes.Header, prevTxCount int64, prevBlockHash libcommon.Hash) {
+func (bm *BlockInfoMap) GetByHash(blockHash libcommon.Hash) (*ethTypes.Header, int64, libcommon.Hash, bool) {
+	bm.mu.RLock()
+	defer bm.mu.RUnlock()
+
+	blockNum, exists := bm.hashToNum[blockHash]
+	if !exists {
+		return nil, 0, libcommon.Hash{}, false
+	}
+
+	blockInfo, exists := bm.blockInfos[blockNum]
+	if exists {
+		return blockInfo.Header, blockInfo.TxCount, blockInfo.Hash, true
+	}
+	return nil, 0, libcommon.Hash{}, false
+}
+
+func (bm *BlockInfoMap) GetBlockNumberByHash(blockHash libcommon.Hash) (uint64, bool) {
+	bm.mu.RLock()
+	defer bm.mu.RUnlock()
+
+	blockNum, exists := bm.hashToNum[blockHash]
+	return blockNum, exists
+}
+
+func (bm *BlockInfoMap) PutHeader(blockNum uint64, header *ethTypes.Header, prevBlockInfo *BlockInfo) {
 	bm.mu.Lock()
 	defer bm.mu.Unlock()
 	bm.blockInfos[blockNum] = &BlockInfo{
@@ -44,18 +70,26 @@ func (bm *BlockInfoMap) PutHeader(blockNum uint64, header *ethTypes.Header, prev
 		Hash:    libcommon.Hash{},
 	}
 
+	blockHash := header.Hash()
+	bm.hashToNum[blockHash] = blockNum
+
 	// Update previous block header tx count
 	prevBlockNum := blockNum - 1
-	blockInfo, exists := bm.blockInfos[prevBlockNum]
+	_, exists := bm.blockInfos[prevBlockNum]
 	if exists {
-		blockInfo.TxCount = prevTxCount
-		blockInfo.Hash = prevBlockHash
+		// Update previous block info
+		bm.blockInfos[prevBlockNum] = prevBlockInfo
 	}
 }
 
 func (bm *BlockInfoMap) Delete(blockNum uint64) {
 	bm.mu.Lock()
 	defer bm.mu.Unlock()
+	if blockInfo, exists := bm.blockInfos[blockNum]; exists && blockInfo.Header != nil {
+		blockHash := blockInfo.Header.Hash()
+		delete(bm.hashToNum, blockHash)
+	}
+
 	delete(bm.blockInfos, blockNum)
 }
 
@@ -64,6 +98,9 @@ func (bm *BlockInfoMap) Clear() {
 	defer bm.mu.Unlock()
 	for k := range bm.blockInfos {
 		delete(bm.blockInfos, k)
+	}
+	for k := range bm.hashToNum {
+		delete(bm.hashToNum, k)
 	}
 }
 

--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ledgerwatch/erigon/core/rawdb"
 	"github.com/ledgerwatch/erigon/core/state"
 	"github.com/ledgerwatch/erigon/core/types"
+	ethTypes "github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/eth/stagedsync"
 	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
 	"github.com/ledgerwatch/erigon/zk"
@@ -20,6 +21,7 @@ import (
 	"github.com/ledgerwatch/erigon/zk/datastream/server"
 	"github.com/ledgerwatch/erigon/zk/hermez_db"
 	"github.com/ledgerwatch/erigon/zk/metrics"
+	kafkaTypes "github.com/ledgerwatch/erigon/zk/realtime/kafka/types"
 	realtimeTypes "github.com/ledgerwatch/erigon/zk/realtime/types"
 	zktx "github.com/ledgerwatch/erigon/zk/tx"
 	"github.com/ledgerwatch/erigon/zk/txpool"
@@ -30,6 +32,7 @@ import (
 var shouldCheckForExecutionAndDataStreamAlignment = true
 var prevBlockTxCount = int64(0)
 var prevBlockHash = common.Hash{}
+var prevBlockHeader *ethTypes.Header
 
 func SpawnSequencingStage(
 	s *stagedsync.StageState,
@@ -460,10 +463,13 @@ BatchLoop:
 
 		// For X Layer, realtime. Send kafka block header
 		if cfg.zk.XLayer.Realtime.Enable && cfg.kafkaBlockInfoChan != nil {
-			cfg.kafkaBlockInfoChan <- &realtimeTypes.BlockInfo{
-				Header:  header,
-				TxCount: prevBlockTxCount,
-				Hash:    prevBlockHash,
+			cfg.kafkaBlockInfoChan <- kafkaTypes.BlockMessage{
+				Header: header,
+				PrevBlockInfo: &realtimeTypes.BlockInfo{
+					Header:  prevBlockHeader,
+					TxCount: prevBlockTxCount,
+					Hash:    prevBlockHash,
+				},
 			}
 		}
 
@@ -882,6 +888,7 @@ BatchLoop:
 			return err
 		}
 
+		prevBlockHeader = header
 		prevBlockTxCount = int64(len(batchState.blockState.builtBlockElements.transactions))
 		prevBlockHash = block.Hash()
 

--- a/zk/stages/stage_sequence_execute_utils.go
+++ b/zk/stages/stage_sequence_execute_utils.go
@@ -34,7 +34,7 @@ import (
 	"github.com/ledgerwatch/erigon/zk/datastream/server"
 	"github.com/ledgerwatch/erigon/zk/hermez_db"
 	"github.com/ledgerwatch/erigon/zk/l1infotree"
-	realtimeTypes "github.com/ledgerwatch/erigon/zk/realtime/types"
+	kafkaTypes "github.com/ledgerwatch/erigon/zk/realtime/kafka/types"
 	zktx "github.com/ledgerwatch/erigon/zk/tx"
 	"github.com/ledgerwatch/erigon/zk/txpool"
 	zktypes "github.com/ledgerwatch/erigon/zk/types"
@@ -97,8 +97,8 @@ type SequenceBlockCfg struct {
 	doneHook       DoneHook
 
 	// For X Layer, realtime
-	kafkaBlockInfoChan chan *realtimeTypes.BlockInfo
-	kafkaTxInfoChan    chan *state.TxInfo
+	kafkaBlockInfoChan chan kafkaTypes.BlockMessage
+	kafkaTxInfoChan    chan state.TxInfo
 }
 
 func StageSequenceBlocksCfg(
@@ -131,8 +131,8 @@ func StageSequenceBlocksCfg(
 	doneHook DoneHook,
 
 	// For X Layer, realtime
-	kafkaBlockInfoChan chan *realtimeTypes.BlockInfo,
-	kafkaTxInfoChan chan *state.TxInfo,
+	kafkaBlockInfoChan chan kafkaTypes.BlockMessage,
+	kafkaTxInfoChan chan state.TxInfo,
 ) SequenceBlockCfg {
 
 	return SequenceBlockCfg{


### PR DESCRIPTION
## Summary

- Add logic workflow to directly pass confirmed block headers to the RT stateless cache
- Populate and ensure confirm block headers do not have missing fields