### PR TITLE
Add realtime API for estimateGas function

### DIFF
--- a/zk/realtime/realtimeapi/api.go
+++ b/zk/realtime/realtimeapi/api.go
@@ -1,15 +1,21 @@
 package realtimeapi
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 
+	"errors"
+
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/hexutil"
+	"github.com/ledgerwatch/erigon/core"
 	"github.com/ledgerwatch/erigon/core/types"
+	"github.com/ledgerwatch/erigon/params"
 	"github.com/ledgerwatch/erigon/rpc"
 	"github.com/ledgerwatch/erigon/turbo/adapter/ethapi"
 	"github.com/ledgerwatch/erigon/turbo/jsonrpc"
+	"github.com/ledgerwatch/erigon/turbo/transactions"
 	realtimeCache "github.com/ledgerwatch/erigon/zk/realtime/cache"
 	"github.com/ledgerwatch/erigon/zk/realtime/subscription"
 )
@@ -84,6 +90,188 @@ func (api *RealtimeAPIImpl) getBlockNumber(blockNr rpc.BlockNumber) (uint64, boo
 		}
 		return blockNumber, blockNumber == confirmHeight, nil
 	}
+}
+
+// EstimateGas implements eth_estimateGas using realtime cache for more accurate gas estimation.
+// Returns an estimate of how much gas is necessary to allow the transaction to complete.
+func (api *RealtimeAPIImpl) EstimateGas(ctx context.Context, argsOrNil *ethapi.CallArgs, blockNrOrHash *rpc.BlockNumberOrHash) (hexutil.Uint64, error) {
+	if api.cacheDB == nil || !api.cacheDB.ReadyFlag.Load() {
+		return api.APIImpl.EstimateGas(ctx, argsOrNil, blockNrOrHash)
+	}
+
+	// Parse arguments
+	var args ethapi.CallArgs
+	if argsOrNil != nil {
+		args = *argsOrNil
+	}
+
+	// Use zero address if sender unspecified
+	if args.From == nil {
+		args.From = new(libcommon.Address)
+	}
+
+	// Default to pending block for realtime estimation
+	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+	if blockNrOrHash != nil {
+		bNrOrHash = *blockNrOrHash
+	}
+
+	// Only support pending block for realtime gas estimation
+	if bNrOrHash.BlockNumber == nil || *bNrOrHash.BlockNumber != rpc.PendingBlockNumber {
+		return api.APIImpl.EstimateGas(ctx, argsOrNil, blockNrOrHash)
+	}
+
+	// Begin database transaction
+	tx, err := api.APIImpl.GetDB().BeginRo(ctx)
+	if err != nil {
+		return api.APIImpl.EstimateGas(ctx, &args, nil)
+	}
+	defer tx.Rollback()
+
+	chainConfig, err := api.APIImpl.GetChainConfig(ctx, tx)
+	if err != nil {
+		return api.APIImpl.EstimateGas(ctx, &args, nil)
+	}
+
+	// Get the latest pending block from realtime cache
+	blockNumber, _, err := api.getBlockNumber(rpc.PendingBlockNumber)
+	if err != nil {
+		return api.APIImpl.EstimateGas(ctx, &args, nil)
+	}
+
+	header, _, _, ok := api.cacheDB.Stateless.GetHeader(blockNumber)
+	if !ok {
+		return api.APIImpl.EstimateGas(ctx, &args, nil)
+	}
+
+	// Binary search for gas estimation
+	var (
+		lo     = params.TxGas - 1
+		hi     uint64
+		gasCap uint64
+	)
+
+	// Determine the highest gas limit
+	if args.Gas != nil && uint64(*args.Gas) >= params.TxGas {
+		hi = uint64(*args.Gas)
+	} else {
+		hi = header.GasLimit
+	}
+
+	var feeCap *big.Int
+	if args.GasPrice != nil && (args.MaxFeePerGas != nil || args.MaxPriorityFeePerGas != nil) {
+		return 0, errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
+	} else if args.GasPrice != nil {
+		feeCap = args.GasPrice.ToInt()
+	} else if args.MaxFeePerGas != nil {
+		feeCap = args.MaxFeePerGas.ToInt()
+	} else {
+		feeCap = libcommon.Big0
+	}
+
+	// Check balance using realtime state cache
+	if feeCap.Sign() != 0 {
+		account, err := api.cacheDB.State.ReadAccountData(*args.From)
+		if err != nil {
+			return api.APIImpl.EstimateGas(ctx, &args, nil)
+		}
+
+		var balance *big.Int
+		if account != nil {
+			balance = account.Balance.ToBig()
+		} else {
+			balance = big.NewInt(0)
+		}
+
+		available := balance
+		if args.Value != nil {
+			if args.Value.ToInt().Cmp(available) >= 0 {
+				return 0, errors.New("insufficient funds for transfer")
+			}
+			available.Sub(available, args.Value.ToInt())
+		}
+		allowance := new(big.Int).Div(available, feeCap)
+
+		if allowance.IsUint64() && hi > allowance.Uint64() {
+			hi = allowance.Uint64()
+		}
+	}
+
+	// Cap gas limit with API gas cap
+	if hi > api.APIImpl.GasCap {
+		hi = api.APIImpl.GasCap
+	}
+	gasCap = hi
+
+	engine := api.APIImpl.GetEngine()
+	bn := rpc.BlockNumber(blockNumber)
+	rpcBlockNr := rpc.BlockNumberOrHash{BlockNumber: &bn}
+
+	// Create a helper to check if a gas allowance results in an executable transaction
+	executable := func(gas uint64) (bool, *core.ExecutionResult, error) {
+		// Create temporary args with the new gas limit
+		tempArgs := args
+		gasVal := hexutil.Uint64(gas)
+		tempArgs.Gas = &gasVal
+
+		// Use the simpler DoCall function that doesn't require ZK database data
+		result, err := transactions.DoCall(
+			ctx,
+			engine,
+			tempArgs,
+			tx,
+			rpcBlockNr,
+			header,
+			nil, // no overrides
+			gas,
+			chainConfig,
+			api.cacheDB.State,     // Use realtime state cache
+			api.cacheDB.Stateless, // Use realtime cache as header reader
+			api.APIImpl.GetEvmCallTimeout(),
+		)
+		if err != nil {
+			if errors.Is(err, core.ErrIntrinsicGas) {
+				// Special case, raise gas limit
+				return true, nil, nil
+			}
+			return true, nil, err
+		}
+
+		return result.Failed(), result, nil
+	}
+
+	// Execute binary search to find optimal gas limit
+	for lo+1 < hi {
+		mid := (hi + lo) / 2
+		failed, _, err := executable(mid)
+		if err != nil {
+			return api.APIImpl.EstimateGas(ctx, &args, nil)
+		}
+		if failed {
+			lo = mid
+		} else {
+			hi = mid
+		}
+	}
+
+	// Reject the transaction if it still fails at the highest allowance
+	if hi == gasCap {
+		failed, result, err := executable(hi)
+		if err != nil {
+			return api.APIImpl.EstimateGas(ctx, &args, nil)
+		}
+		if failed {
+			if result != nil && result.Err != nil && result.Err.Error() != "out of gas" {
+				if len(result.Revert()) > 0 {
+					return 0, ethapi.NewRevertError(result)
+				}
+				return 0, result.Err
+			}
+			return 0, fmt.Errorf("gas required exceeds allowance (%d)", gasCap)
+		}
+	}
+
+	return hexutil.Uint64(hi), nil
 }
 
 // newRPCTransaction_realtime returns a transaction that will serialize to the RPC

--- a/zk/realtime/rtclient/client.go
+++ b/zk/realtime/rtclient/client.go
@@ -9,6 +9,7 @@ import (
 
 	ethereum "github.com/ledgerwatch/erigon"
 	"github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/common/hexutil"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/ethclient"
 	rpcTypes "github.com/ledgerwatch/erigon/zk/rpcdaemon"
@@ -87,16 +88,9 @@ func (rc *RealtimeClient) RealtimeCall(from, to common.Address, gas string, gasP
 	return result, nil
 }
 
-// RealtimeEstimateGas estimates the gas cost of a transaction in real-time
-func (rc *RealtimeClient) RealtimeEstimateGas(ctx context.Context, from, to common.Address, value string, data string) (uint64, error) {
-	txParams := map[string]any{
-		"from":  from,
-		"to":    to,
-		"value": value,
-		"data":  data,
-	}
-
-	response, err := client.JSONRPCCall(rc.url, "eth_estimateGas", txParams, PendingTag)
+// RealtimeEstimateGas estimates gas for a transaction using realtime cache
+func (rc *RealtimeClient) RealtimeEstimateGas(args map[string]interface{}) (uint64, error) {
+	response, err := client.JSONRPCCall(rc.url, "eth_estimateGas", args)
 	if err != nil {
 		return 0, err
 	}
@@ -104,13 +98,19 @@ func (rc *RealtimeClient) RealtimeEstimateGas(ctx context.Context, from, to comm
 		return 0, fmt.Errorf("%d - %s", response.Error.Code, response.Error.Message)
 	}
 
-	var result uint64
+	var result string
 	err = json.Unmarshal(response.Result, &result)
 	if err != nil {
 		return 0, err
 	}
 
-	return result, nil
+	// Convert hex string to uint64
+	gasEstimate, err := hexutil.DecodeUint64(result)
+	if err != nil {
+		return 0, err
+	}
+
+	return gasEstimate, nil
 }
 
 // RealtimeGetBalance returns the balance of an account in real-time

--- a/zk/realtime/test/smoke_test.go
+++ b/zk/realtime/test/smoke_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/holiman/uint256"
 	"github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/common/hexutil"
 	"github.com/ledgerwatch/erigon-lib/kv"
 	"github.com/ledgerwatch/erigon-lib/kv/mdbx"
 	"github.com/ledgerwatch/erigon/accounts/abi"
@@ -271,6 +272,37 @@ func TestRealtimeRPC(t *testing.T) {
 		} else {
 			log.Info("RealtimeEnabled: Realtime feature is disabled or cache is not ready")
 		}
+	})
+
+	t.Run("RealtimeEstimateGas", func(t *testing.T) {
+		// Test standard eth_estimateGas with a simple transfer
+		transferArgs := map[string]interface{}{
+			"from":  fromAddress,
+			"to":    testAddress,
+			"value": (*hexutil.Big)(big.NewInt(1)),
+		}
+
+		gasEstimate, err := client.RealtimeEstimateGas(transferArgs)
+		require.NoError(t, err)
+		require.Greater(t, gasEstimate, uint64(0), "Gas estimate should be greater than 0")
+		require.LessOrEqual(t, gasEstimate, uint64(1000000), "Gas estimate should be reasonable")
+		log.Info(fmt.Sprintf("Standard eth_estimateGas for transfer: %d gas", gasEstimate))
+
+		// Test gas estimation for a contract call (ERC20 transfer)
+		transferData, err := erc20ABI.Pack("transfer", erc20Address, big.NewInt(1))
+		require.NoError(t, err)
+
+		contractCallArgs := map[string]interface{}{
+			"from": fromAddress,
+			"to":   erc20Address,
+			"data": (*hexutil.Bytes)(&transferData),
+		}
+
+		gasEstimateCall, err := client.RealtimeEstimateGas(contractCallArgs)
+		require.NoError(t, err)
+		require.Greater(t, gasEstimateCall, gasEstimate, "Contract call should require more gas than simple transfer")
+		require.LessOrEqual(t, gasEstimateCall, uint64(1000000), "Contract call gas estimate should be reasonable")
+		log.Info(fmt.Sprintf("Standard eth_estimateGas for ERC20 transfer: %d gas", gasEstimateCall))
 	})
 }
 func TestRealtimeStateIsConsistent(t *testing.T) {


### PR DESCRIPTION
Add realtime API for estimateGas function
- Use realtime state for calculation of gas
- Only accepts pending blocks as it simulates a transaction against the latest state of the chain
- Follows geth's implementation of eth_estimateGas where binary search is used to narrow down the search space since running the `doCall` function to simulate the transaction is computationally expensive.
