### PR TITLE
Add running 2 rpc nodes in e2e realtime-run

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -5,6 +5,8 @@ DOCKER_BRIDGE_UI := xlayer-bridge-ui
 DOCKER_APPROVE := xlayer-approve
 DOCKER_SEQ := xlayer-seq
 DOCKER_RPC := xlayer-rpc
+DOCKER_RPC_RT := xlayer-rpc-rt
+DOCKER_RPC_NO_RT := xlayer-rpc-no-rt
 DOCKER_L1_NETWORK := xlayer-mock-l1-network
 DOCKER_POOL_DB := xlayer-pool-db
 DOCKER_POOL_MANAGER := xlayer-pool-manager
@@ -28,6 +30,8 @@ RUN_DOCKER_BRIDGE_UI := $(DOCKER_COMPOSE) up -d $(DOCKER_BRIDGE_UI)
 RUN_DOCKER_APPROVE := $(DOCKER_COMPOSE) up -d $(DOCKER_APPROVE)
 RUN_DOCKER_SEQ := $(DOCKER_COMPOSE) up -d $(DOCKER_SEQ)
 RUN_DOCKER_RPC := $(DOCKER_COMPOSE) up -d $(DOCKER_RPC)
+RUN_DOCKER_RPC_RT := $(DOCKER_COMPOSE) up -d $(DOCKER_RPC_RT)
+RUN_DOCKER_RPC_NO_RT := $(DOCKER_COMPOSE) up -d $(DOCKER_RPC_NO_RT)
 RUN_DOCKER_MAINNET_SEQ := $(DOCKER_COMPOSE) up -d $(DOCKER_MAINNET_SEQ)
 RUN_DOCKER_MAINNET_RPC := $(DOCKER_COMPOSE) up -d $(DOCKER_MAINNET_RPC)
 RUN_DOCKER_L1_NETWORK := $(DOCKER_COMPOSE) up -d $(DOCKER_L1_NETWORK)
@@ -107,7 +111,8 @@ realtime-run: stop build-docker
 	$(DOCKER_COMPOSE) up -d xlayer-pool-manager
 
 	sleep 5
-	$(DOCKER_COMPOSE) up -d xlayer-rpc
+	$(DOCKER_COMPOSE) up -d xlayer-rpc-rt
+	$(DOCKER_COMPOSE) up -d xlayer-rpc-no-rt
 
 	sleep 10
 	$(DOCKER_COMPOSE) up -d xlayer-bridge-service
@@ -232,6 +237,13 @@ lint:
 
 .PHONY: test-e2e
 test-e2e: stop all ## Runs group xlayer feature e2e tests checking race conditions
+	sleep 3
+	docker ps -a
+	trap '$(STOP)' EXIT; MallocNanoZone=0 go test -count=1 -failfast -race -v -p 1 -timeout 600s ../ci/e2e-1/...
+	echo "E2E tests passed"
+
+.PHONY: test-realtime-e2e
+test-realtime-e2e: stop realtime-run
 	sleep 3
 	docker ps -a
 	trap '$(STOP)' EXIT; MallocNanoZone=0 go test -count=1 -failfast -race -v -p 1 -timeout 600s ../ci/e2e-1/...

--- a/test/config/test.erigon.rpc.rt.config.yaml
+++ b/test/config/test.erigon.rpc.rt.config.yaml
@@ -85,9 +85,9 @@ zkevm.standalone-smt-db: true  # true: enalbe split smt db, false: not split
 zkevm.enable-trace-log: true
 zkevm.trace-log-path: /home/erigon/data/logs/trace.log
 
-# Disable RT for default RPC node
-realtime.enable-flag: false
-realtime.enable-subscribe-flag: false
+# Enable RT for realtime RPC node
+realtime.enable-flag: true
+realtime.enable-subscribe-flag: true
 realtime.cache-height-threshold: 10
 realtime.kafka-sync-bootstrap-servers: "xlayer-kafka:9092"
 realtime.kafka-sync-tx-topic: xlayer-tx

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -403,6 +403,50 @@ services:
     command: >
       cdk-erigon --http.vhosts=* --http.corsdomain=* --ws --config=/usr/src/app/config.yaml
 
+  xlayer-rpc-rt:
+    container_name: xlayer-rpc-rt
+    image: cdk-erigon
+    environment:
+      - CDK_ERIGON_SEQUENCER=0
+      - WRITE_MAP=true
+    ports:
+      - 6061:6060
+      - 8124:8545
+      - 8548:8546
+      - 6901:6900
+      - 9091:9095
+    volumes:
+      - ./data/rpc-rt/:/home/erigon/data/
+      - ./config/test.erigon.rpc.rt.config.yaml:/usr/src/app/config.yaml
+      - ./config/first-batch-config.json:/usr/src/app/first-batch-config.json
+      - ./config/dynamic-mynetwork-allocs.json:/usr/src/app/dynamic-mynetwork-allocs.json
+      - ./config/dynamic-mynetwork-chainspec.json:/usr/src/app/dynamic-mynetwork-chainspec.json
+      - ./config/dynamic-mynetwork-conf.json:/usr/src/app/dynamic-mynetwork-conf.json
+    command: >
+      cdk-erigon --http.vhosts=* --http.corsdomain=* --ws --config=/usr/src/app/config.yaml
+
+  xlayer-rpc-no-rt:
+    container_name: xlayer-rpc-no-rt
+    image: cdk-erigon
+    environment:
+      - CDK_ERIGON_SEQUENCER=0
+      - WRITE_MAP=true
+    ports:
+      - 6064:6060
+      - 8128:8545
+      - 8549:8546
+      - 6904:6900
+      - 9098:9095
+    volumes:
+      - ./data/rpc-no-rt/:/home/erigon/data/
+      - ./config/test.erigon.rpc.config.yaml:/usr/src/app/config.yaml
+      - ./config/first-batch-config.json:/usr/src/app/first-batch-config.json
+      - ./config/dynamic-mynetwork-allocs.json:/usr/src/app/dynamic-mynetwork-allocs.json
+      - ./config/dynamic-mynetwork-chainspec.json:/usr/src/app/dynamic-mynetwork-chainspec.json
+      - ./config/dynamic-mynetwork-conf.json:/usr/src/app/dynamic-mynetwork-conf.json
+    command: >
+      cdk-erigon --http.vhosts=* --http.corsdomain=* --ws --config=/usr/src/app/config.yaml
+
   ##############################
   ### polygon zkEVM services ###
   ##############################

--- a/zk/realtime/test/benchmark_test.go
+++ b/zk/realtime/test/benchmark_test.go
@@ -35,9 +35,9 @@ func TestRealtimeBenchmarkNativeTransfer(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ec, err := ethclient.Dial(DefaultL2NetworkURL)
+	ec, err := ethclient.Dial(DefaultL2NetworkRealtimeURL)
 	require.NoError(t, err)
-	client := rtclient.NewRealtimeClient(ec, DefaultL2NetworkURL)
+	client := rtclient.NewRealtimeClient(ec, DefaultL2NetworkRealtimeURL)
 
 	// Default test address for tests that require an address
 	testAddress := common.HexToAddress("0x1234567890123456789012345678901234567890")
@@ -104,9 +104,9 @@ func TestRealtimeBenchmarkERC20Transfer(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ec, err := ethclient.Dial(DefaultL2NetworkURL)
+	ec, err := ethclient.Dial(DefaultL2NetworkRealtimeURL)
 	require.NoError(t, err)
-	client := rtclient.NewRealtimeClient(ec, DefaultL2NetworkURL)
+	client := rtclient.NewRealtimeClient(ec, DefaultL2NetworkRealtimeURL)
 
 	privateKey, err := crypto.HexToECDSA(strings.TrimPrefix(DefaultL2AdminPrivateKey, "0x"))
 	require.NoError(t, err)
@@ -229,9 +229,9 @@ func TestRealtimeBenchmarNewHeadsSubscription(t *testing.T) {
 
 func TestRealtimeBenchmarNewTransactionSubscription(t *testing.T) {
 	ctx := context.Background()
-	ec, err := ethclient.Dial(DefaultL2NetworkURL)
+	ec, err := ethclient.Dial(DefaultL2NetworkRealtimeURL)
 	require.NoError(t, err)
-	client := rtclient.NewRealtimeClient(ec, DefaultL2NetworkURL)
+	client := rtclient.NewRealtimeClient(ec, DefaultL2NetworkRealtimeURL)
 
 	logger := logger.New()
 	wsClient, err := rpc.Dial(DefaultL2NetworkWSURL, logger)

--- a/zk/realtime/test/constants.go
+++ b/zk/realtime/test/constants.go
@@ -3,9 +3,10 @@ package test
 import "time"
 
 const (
-	DefaultL2NetworkURL          = "http://localhost:8124"
-	DefaultL2NetworkWSURL        = "ws://localhost:8548"
-	DefaultL2ChainID      uint64 = 195
+	DefaultL2NetworkRealtimeURL          = "http://localhost:8124"
+	DefaultL2NetworkNoRealtimeURL        = "http://localhost:8128"
+	DefaultL2NetworkWSURL                = "ws://localhost:8548"
+	DefaultL2ChainID              uint64 = 195
 
 	DefaultL2AdminAddress    = "0x8f8E2d6cF621f30e9a11309D6A56A876281Fd534"
 	DefaultL2AdminPrivateKey = "0x815405dddb0e2a99b12af775fd2929e526704e1d1aea6a0b4e74dc33e2f7fcd2"
@@ -13,7 +14,7 @@ const (
 	DefaultTimeoutTxToBeMined = 1 * time.Minute
 
 	DefaultSequncerDBPath = "../../../test/data/seq/chaindata"
-	DefaultStateCachePath = "../../../test/data/rpc/cache"
+	DefaultStateCachePath = "../../../test/data/rpc-rt/cache"
 
 	erc20TransferTopicHex = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
 

--- a/zk/realtime/test/opcode_test.go
+++ b/zk/realtime/test/opcode_test.go
@@ -20,9 +20,9 @@ func TestIterativeCreate2AndDestroy(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ec, err := ethclient.Dial(DefaultL2NetworkURL)
+	ec, err := ethclient.Dial(DefaultL2NetworkRealtimeURL)
 	require.NoError(t, err)
-	client := rtclient.NewRealtimeClient(ec, DefaultL2NetworkURL)
+	client := rtclient.NewRealtimeClient(ec, DefaultL2NetworkRealtimeURL)
 
 	privateKey, err := crypto.HexToECDSA(DefaultL2AdminPrivateKey[2:])
 	require.NoError(t, err)
@@ -54,9 +54,9 @@ func TestMultipleCreate2AndDestroy(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ec, err := ethclient.Dial(DefaultL2NetworkURL)
+	ec, err := ethclient.Dial(DefaultL2NetworkRealtimeURL)
 	require.NoError(t, err)
-	client := rtclient.NewRealtimeClient(ec, DefaultL2NetworkURL)
+	client := rtclient.NewRealtimeClient(ec, DefaultL2NetworkRealtimeURL)
 
 	privateKey, err := crypto.HexToECDSA(DefaultL2AdminPrivateKey[2:])
 	require.NoError(t, err)
@@ -89,9 +89,9 @@ func TestCreate2AndDestroyInSameTx(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ec, err := ethclient.Dial(DefaultL2NetworkURL)
+	ec, err := ethclient.Dial(DefaultL2NetworkRealtimeURL)
 	require.NoError(t, err)
-	client := rtclient.NewRealtimeClient(ec, DefaultL2NetworkURL)
+	client := rtclient.NewRealtimeClient(ec, DefaultL2NetworkRealtimeURL)
 
 	privateKey, err := crypto.HexToECDSA(DefaultL2AdminPrivateKey[2:])
 	require.NoError(t, err)

--- a/zk/realtime/test/smoke_test.go
+++ b/zk/realtime/test/smoke_test.go
@@ -43,9 +43,9 @@ func TestRealtimeRPC(t *testing.T) {
 
 	// Preapre to deploy a ERC20 contract
 	ctx := context.Background()
-	ec, err := ethclient.Dial(DefaultL2NetworkURL)
+	ec, err := ethclient.Dial(DefaultL2NetworkRealtimeURL)
 	require.NoError(t, err)
-	client := rtclient.NewRealtimeClient(ec, DefaultL2NetworkURL)
+	client := rtclient.NewRealtimeClient(ec, DefaultL2NetworkRealtimeURL)
 	blockNumber := setupRealtimeTestEnvironment(t, client)
 
 	privateKey, err := crypto.HexToECDSA(strings.TrimPrefix(DefaultL2AdminPrivateKey, "0x"))
@@ -279,9 +279,9 @@ func TestRealtimeStateIsConsistent(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ec, err := ethclient.Dial(DefaultL2NetworkURL)
+	ec, err := ethclient.Dial(DefaultL2NetworkRealtimeURL)
 	require.NoError(t, err)
-	client := rtclient.NewRealtimeClient(ec, DefaultL2NetworkURL)
+	client := rtclient.NewRealtimeClient(ec, DefaultL2NetworkRealtimeURL)
 
 	privateKey, err := crypto.HexToECDSA(strings.TrimPrefix(DefaultL2AdminPrivateKey, "0x"))
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Fix realtime e2e to run 2 RPC nodes, one RPC node with RT switched on and the other RPC node with RT switched off
- Fixes to ensure all default e2e tests passes (test-e2e and test-data-loss)
- Add e2e comparison tests for eth_* RPCs on both RT enabled and RT disabled nodes to ensure full compatibility on realtime APIs in eth_* namespaces