### PR TITLE
CI: Fix broken e2e test

### DIFF
--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -191,7 +191,7 @@ func TestNewAccFreeGas(t *testing.T) {
 		},
 		GasPrice: uint256.MustFromBig(big.NewInt(0)),
 	}
-	privateKey, err := crypto.HexToECDSA(strings.TrimPrefix(operations.DefaultL2NewAcc1PrivateKey, "0x"))
+	privateKey, err := crypto.HexToECDSA(strings.TrimPrefix(operations.DefaultL2NewAcc2PrivateKey, "0x"))
 	require.NoError(t, err)
 	signer := types.MakeSigner(operations.GetTestChainConfig(operations.DefaultL2ChainID), 1, 0)
 	signedTx, err := types.SignTx(tx, *signer, privateKey)

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -178,7 +178,7 @@ func TestNewAccFreeGas(t *testing.T) {
 	var gas uint64 = 21000
 
 	//newAcc transfer failed
-	from := common.HexToAddress(operations.DefaultL2NewAcc1Address)
+	from := common.HexToAddress(operations.DefaultL2NewAcc2Address)
 	to := common.HexToAddress(operations.DefaultL2AdminAddress)
 	nonce, err := client.PendingNonceAt(ctx, from)
 	require.NoError(t, err)
@@ -205,7 +205,7 @@ func TestNewAccFreeGas(t *testing.T) {
 
 	// seq -> newAcc
 	from = common.HexToAddress(operations.DefaultL2AdminAddress)
-	to = common.HexToAddress(operations.DefaultL2NewAcc1Address)
+	to = common.HexToAddress(operations.DefaultL2NewAcc2Address)
 	nonce, err = client.PendingNonceAt(ctx, from)
 	require.NoError(t, err)
 	tx = &types.LegacyTx{
@@ -227,7 +227,7 @@ func TestNewAccFreeGas(t *testing.T) {
 	require.NoError(t, err)
 
 	// newAcc transfer success
-	from = common.HexToAddress(operations.DefaultL2NewAcc1Address)
+	from = common.HexToAddress(operations.DefaultL2NewAcc2Address)
 	to = common.HexToAddress(operations.DefaultL2AdminAddress)
 	nonce, err = client.PendingNonceAt(ctx, from)
 	require.NoError(t, err)
@@ -240,7 +240,7 @@ func TestNewAccFreeGas(t *testing.T) {
 		},
 		GasPrice: uint256.MustFromBig(big.NewInt(0)),
 	}
-	privateKey, err = crypto.HexToECDSA(strings.TrimPrefix(operations.DefaultL2NewAcc1PrivateKey, "0x"))
+	privateKey, err = crypto.HexToECDSA(strings.TrimPrefix(operations.DefaultL2NewAcc2PrivateKey, "0x"))
 	require.NoError(t, err)
 	signedTx, err = types.SignTx(tx, *signer, privateKey)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Use a different address to sign since DefaultL2NewAcc1 address was added into the free gas list on the devnet sequencer in this PR: https://github.com/okx/xlayer-erigon/pull/611/files#diff-6c0c3b96cc692788ee7cc5e3057f503b110c506909d784db9aacda210e94b068L72-R72