### PR TITLE
RT: Add support for realtime state management for pending and finalized states

### DIFF
--- a/zk/realtime/cache/pending_state_cache.go
+++ b/zk/realtime/cache/pending_state_cache.go
@@ -1,0 +1,241 @@
+package cache
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+
+	libcommon "github.com/ledgerwatch/erigon-lib/common"
+	"github.com/ledgerwatch/erigon-lib/kv/dbutils"
+	"github.com/ledgerwatch/erigon/core/types/accounts"
+	"github.com/ledgerwatch/erigon/turbo/trie"
+	realtimeTypes "github.com/ledgerwatch/erigon/zk/realtime/types"
+	"github.com/ledgerwatch/erigon/zkevm/log"
+)
+
+// GlobalStateCache implements the plain state reader with a changeset cache layer.
+// The pending cache holds the pending chainstate - it holds the global state cache,
+// with a changeset cache layer that stores in-memory the pending state changes.
+type PendingStateCache struct {
+	globalCache *GlobalStateCache
+	cacheLock   sync.RWMutex
+	cache       *stateCache
+}
+
+func NewPendingStateCache(globalCache *GlobalStateCache, size int) *PendingStateCache {
+	return &PendingStateCache{
+		globalCache: globalCache,
+		cache:       newStateCache(size),
+	}
+}
+
+func (cache *PendingStateCache) ApplyChangeset(changeset *realtimeTypes.Changeset, blockNumber uint64, txIndex uint) error {
+	cache.cacheLock.Lock()
+	defer cache.cacheLock.Unlock()
+
+	// Handle account data changes
+	addressChanges := make(map[libcommon.Address]*accounts.Account)
+	cache.applyChangesetToAccountData(changeset, addressChanges)
+
+	// Apply code changes
+	for codeHash, code := range changeset.CodeChanges {
+		cache.cache.codeCache[codeHash] = code
+	}
+
+	// Apply storage changes
+	for address, storage := range changeset.StorageChanges {
+		account, err := cache.getOrCreateAccount(address, addressChanges)
+		if err != nil {
+			return fmt.Errorf("apply storage changes failed: %v", err)
+		}
+
+		for key, value := range storage {
+			compositeKey := dbutils.PlainGenerateCompositeStorageKey(address.Bytes(), account.Incarnation, key.Bytes())
+			cache.cache.storageCache[string(compositeKey)] = value
+		}
+	}
+
+	// Apply incarnation map changes
+	for address, incarnation := range changeset.IncarnationMapChanges {
+		cache.cache.incarnationMapCache[address] = incarnation
+	}
+
+	// Apply deleted accounts changes
+	for address := range changeset.DeletedAccounts {
+		// Non-existent / deleted accounts are set to nil
+		addressChanges[address] = nil
+	}
+
+	// Apply account changes
+	for address, account := range addressChanges {
+		delete(cache.cache.accountCache, address)
+		cache.cache.accountCache[address] = account
+		log.Debug("[Realtime] ApplyChangeset: ", address)
+	}
+
+	log.Debug(fmt.Sprintf("[Realtime] Apply changeset from tx with height: %d, txIndex: %d\n", blockNumber, txIndex))
+
+	return nil
+}
+
+func (cache *PendingStateCache) applyChangesetToAccountData(changeset *realtimeTypes.Changeset, addressChanges map[libcommon.Address]*accounts.Account) (err error) {
+	// Apply balance changes
+	for address, balance := range changeset.BalanceChanges {
+		if _, ok := changeset.DeletedAccounts[address]; ok {
+			continue
+		}
+
+		account, err := cache.getOrCreateAccount(address, addressChanges)
+		if err != nil {
+			return fmt.Errorf("apply balance changes failed: %v", err)
+		}
+		account.Balance.Set(balance)
+	}
+
+	// Apply nonce changes
+	for address, nonce := range changeset.NonceChanges {
+		if _, ok := changeset.DeletedAccounts[address]; ok {
+			continue
+		}
+
+		account, err := cache.getOrCreateAccount(address, addressChanges)
+		if err != nil {
+			return fmt.Errorf("apply nonce changes failed: %v", err)
+		}
+		account.Nonce = nonce
+	}
+
+	// Apply code hash changes
+	for address, codeHash := range changeset.CodeHashChanges {
+		if _, ok := changeset.DeletedAccounts[address]; ok {
+			continue
+		}
+
+		account, err := cache.getOrCreateAccount(address, addressChanges)
+		if err != nil {
+			return fmt.Errorf("apply code hash changes failed: %v", err)
+		}
+		account.CodeHash = codeHash
+	}
+
+	// Apply incarnation changes
+	for address, incarnation := range changeset.IncarnationChanges {
+		if _, ok := changeset.DeletedAccounts[address]; ok {
+			continue
+		}
+
+		account, err := cache.getOrCreateAccount(address, addressChanges)
+		if err != nil {
+			return fmt.Errorf("apply incarnation changes failed: %v", err)
+		}
+		account.Incarnation = incarnation
+	}
+
+	return nil
+}
+
+func (cache *PendingStateCache) getOrCreateAccount(address libcommon.Address, addressChanges map[libcommon.Address]*accounts.Account) (*accounts.Account, error) {
+	account, ok := addressChanges[address]
+	if !ok {
+		var err error
+		account, err = cache.unsafeReadAccountData(address)
+		if err != nil {
+			return nil, err
+		}
+
+		if account == nil {
+			// Non-existent account, create new account
+			account, err = cache.createAccount()
+			if err != nil {
+				return nil, err
+			}
+		}
+		addressChanges[address] = account
+	}
+
+	return account, nil
+}
+
+func (cache *PendingStateCache) unsafeReadAccountData(address libcommon.Address) (*accounts.Account, error) {
+	acc, ok := cache.cache.accountCache[address]
+	if ok {
+		return acc, nil
+	}
+
+	// Cache miss, read from global cache
+	return cache.globalCache.ReadAccountData(address)
+}
+
+func (cache *PendingStateCache) createAccount() (*accounts.Account, error) {
+	return &accounts.Account{
+		Initialised: true,
+		Root:        libcommon.BytesToHash(trie.EmptyRoot[:]),
+		CodeHash:    libcommon.BytesToHash(emptyCodeHash),
+	}, nil
+}
+
+// -------------- StateReader implementation --------------
+func (cache *PendingStateCache) ReadAccountData(address libcommon.Address) (*accounts.Account, error) {
+	cache.cacheLock.RLock()
+	acc, ok := cache.cache.accountCache[address]
+	if ok {
+		accCopy := accounts.DeepCopyAccount(acc)
+		cache.cacheLock.RUnlock()
+		return accCopy, nil
+	}
+	cache.cacheLock.RUnlock()
+
+	// Cache miss, read from global cache
+	return cache.globalCache.ReadAccountData(address)
+}
+
+func (cache *PendingStateCache) ReadAccountStorage(address libcommon.Address, incarnation uint64, key *libcommon.Hash) ([]byte, error) {
+	compositeKey := dbutils.PlainGenerateCompositeStorageKey(address.Bytes(), incarnation, key.Bytes())
+
+	cache.cacheLock.RLock()
+	storage, ok := cache.cache.storageCache[string(compositeKey)]
+	if ok {
+		storageCopy := libcommon.Copy(storage.Bytes())
+		cache.cacheLock.RUnlock()
+		return storageCopy, nil
+	}
+	cache.cacheLock.RUnlock()
+
+	// Cache miss, read from global cache
+	return cache.globalCache.ReadAccountStorage(address, incarnation, key)
+}
+
+func (cache *PendingStateCache) ReadAccountCode(address libcommon.Address, incarnation uint64, codeHash libcommon.Hash) ([]byte, error) {
+	if bytes.Equal(codeHash.Bytes(), emptyCodeHash) {
+		return nil, nil
+	}
+
+	cache.cacheLock.RLock()
+	code, ok := cache.cache.codeCache[codeHash]
+	if ok {
+		codeCopy := libcommon.Copy(code)
+		cache.cacheLock.RUnlock()
+		return codeCopy, nil
+	}
+	cache.cacheLock.RUnlock()
+
+	// Cache miss, read from global cache
+	return cache.globalCache.ReadAccountCode(address, incarnation, codeHash)
+}
+
+func (cache *PendingStateCache) ReadAccountCodeSize(address libcommon.Address, incarnation uint64, codeHash libcommon.Hash) (int, error) {
+	code, err := cache.ReadAccountCode(address, incarnation, codeHash)
+	return len(code), err
+}
+
+func (cache *PendingStateCache) ReadAccountIncarnation(address libcommon.Address) (uint64, error) {
+	cache.cacheLock.RLock()
+	incarnation, ok := cache.cache.incarnationMapCache[address]
+	cache.cacheLock.RUnlock()
+	if ok {
+		return incarnation, nil
+	}
+
+	// Cache miss, read from global cache
+	return cache.globalCache.ReadAccountIncarnation(address)
+}

--- a/zk/realtime/cache/realtime_cache.go
+++ b/zk/realtime/cache/realtime_cache.go
@@ -23,7 +23,8 @@ const (
 	DefaultStatelessTxCacheSize    = 1000
 
 	// State cache size
-	DefaultStateCacheSize = 1_000_000
+	DefaultGlobalStateCacheSize  = 1_000_000
+	DefaultPendingStateCacheSize = 1_000
 
 	// Sync threshold config
 	PendingBlocksCacheSizeThreshold = 20
@@ -38,6 +39,8 @@ type PendingBlockContext struct {
 	txCount int64
 	// pendingTxs is the queue of pending txs to be processed in the current pending block
 	pendingTxs *realtimeTypes.OrderedList[*kafkaTypes.TransactionMessage]
+	// pendingStateCache is the pending state cache for the current pending block
+	pendingStateCache *PendingStateCache
 }
 
 // String returns a formatted string representation of the PendingBlockContext
@@ -65,7 +68,7 @@ func ComparePendingBlockContext(a, b *PendingBlockContext) int {
 
 type RealtimeCache struct {
 	// Caches
-	State         *StateCache
+	State         *GlobalStateCache
 	Stateless     *StatelessCache
 	CacheDumpPath string
 	ReadyFlag     atomic.Bool
@@ -84,7 +87,7 @@ type RealtimeCache struct {
 }
 
 func NewRealtimeCache(ctx context.Context, db kv.RoDB, cacheDumpPath string) (*RealtimeCache, error) {
-	stateCache, err := NewStateCache(ctx, db, DefaultStateCacheSize)
+	stateCache, err := NewGlobalStateCache(ctx, db, DefaultGlobalStateCacheSize)
 	if err != nil {
 		return nil, err
 	}
@@ -139,6 +142,13 @@ func (cache *RealtimeCache) PutHighestPendingHeight(blockNum uint64) {
 	if blockNum > cache.highestPendingHeight.Load() {
 		cache.highestPendingHeight.Store(blockNum)
 	}
+}
+
+func (cache *RealtimeCache) GetLatestPendingStateCache() *PendingStateCache {
+	if cache.pendingBlocks.Size() == 0 {
+		return nil
+	}
+	return cache.pendingBlocks.Items()[cache.pendingBlocks.Size()-1].pendingStateCache
 }
 
 func (cache *RealtimeCache) TryInitStateCache(executionHeight uint64) error {
@@ -235,7 +245,7 @@ func (cache *RealtimeCache) tryApplyBlockTxMsgs(blockContext *PendingBlockContex
 			return fmt.Errorf("failed to get inner txs. Block number: %d, tx index: %d, error: %v", txMsg.BlockNumber, blockContext.nextTxIndex, err)
 		}
 		cache.Stateless.PutTxInfo(blockContext.blockNum, txMsg.Hash, tx, receipt, innerTxs)
-		cache.State.ApplyChangeset(txMsg.Changeset, txMsg.BlockNumber, txMsg.Receipt.TransactionIndex)
+		blockContext.pendingStateCache.ApplyChangeset(txMsg.Changeset, txMsg.BlockNumber, txMsg.Receipt.TransactionIndex)
 		blockContext.nextTxIndex++
 		processed++
 	}
@@ -270,10 +280,11 @@ func (cache *RealtimeCache) tryCreateNewPendingBlockContext(blockNum uint64) err
 
 	// Create new pending block context
 	newPendingBlockContext := &PendingBlockContext{
-		blockNum:    blockNum,
-		nextTxIndex: 0,
-		pendingTxs:  realtimeTypes.NewOrderedList(DefaultTxMsgSliceSize, CompareTransactionMessages),
-		txCount:     -1,
+		blockNum:          blockNum,
+		nextTxIndex:       0,
+		pendingTxs:        realtimeTypes.NewOrderedList(DefaultTxMsgSliceSize, CompareTransactionMessages),
+		txCount:           -1,
+		pendingStateCache: NewPendingStateCache(cache.State, DefaultPendingStateCacheSize),
 	}
 	cache.pendingBlocks.Add(newPendingBlockContext)
 	cache.pendingBlocks.Sort()
@@ -312,6 +323,7 @@ func (cache *RealtimeCache) tryCloseBlock(pendingBlockContext *PendingBlockConte
 		}
 	}
 	cache.PutHighestConfirmHeight(pendingBlockContext.blockNum)
+	cache.State.FlushState(pendingBlockContext.pendingStateCache.cache)
 	log.Debug(fmt.Sprintf("[Realtime] Closed block %d, pending blocks queue size: %d", pendingBlockContext.blockNum, cache.pendingBlocks.Size()))
 }
 

--- a/zk/realtime/cache/realtime_cache.go
+++ b/zk/realtime/cache/realtime_cache.go
@@ -134,6 +134,13 @@ func (cache *RealtimeCache) UpdateExecution(finishEntry realtimeTypes.FinishedEn
 	}
 }
 
+func (cache *RealtimeCache) GetCurrentPendingHeight() uint64 {
+	if cache.GetHighestPendingHeight() == 0 {
+		return 0
+	}
+	return cache.GetHighestConfirmHeight() + 1
+}
+
 func (cache *RealtimeCache) GetHighestPendingHeight() uint64 {
 	return cache.highestPendingHeight.Load()
 }
@@ -144,11 +151,17 @@ func (cache *RealtimeCache) PutHighestPendingHeight(blockNum uint64) {
 	}
 }
 
-func (cache *RealtimeCache) GetLatestPendingStateCache() *PendingStateCache {
+func (cache *RealtimeCache) GetPendingStateCache(blockNum uint64) *PendingStateCache {
 	if cache.pendingBlocks.Size() == 0 {
 		return nil
 	}
-	return cache.pendingBlocks.Items()[cache.pendingBlocks.Size()-1].pendingStateCache
+
+	for _, context := range cache.pendingBlocks.Items() {
+		if context.blockNum == blockNum {
+			return context.pendingStateCache
+		}
+	}
+	return nil
 }
 
 func (cache *RealtimeCache) TryInitStateCache(executionHeight uint64) error {

--- a/zk/realtime/cache/state_cache.go
+++ b/zk/realtime/cache/state_cache.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ledgerwatch/erigon/core/state"
 	"github.com/ledgerwatch/erigon/core/types/accounts"
 	"github.com/ledgerwatch/erigon/crypto"
-	"github.com/ledgerwatch/erigon/turbo/trie"
 	realtimeTypes "github.com/ledgerwatch/erigon/zk/realtime/types"
 	"github.com/ledgerwatch/erigon/zkevm/log"
 )
@@ -26,50 +25,23 @@ var (
 	emptyCodeHash = crypto.Keccak256(nil)
 )
 
-// StateCache implements the plain state reader with a changeset cache layer.
-// The cache holds the chainstate db, with a changeset cache layer that stores
-// in-memory the state changes.
-type StateCache struct {
-	ctx        context.Context
-	db         kv.RoDB
-	initHeight atomic.Uint64
-
-	cacheLock           sync.RWMutex
+type stateCache struct {
 	accountCache        map[libcommon.Address]*accounts.Account
 	storageCache        map[string]*uint256.Int
 	codeCache           map[libcommon.Hash][]byte
 	incarnationMapCache map[libcommon.Address]uint64
 }
 
-func NewStateCache(ctx context.Context, db kv.RoDB, size int) (*StateCache, error) {
-	return &StateCache{
-		ctx:                 ctx,
-		db:                  db,
-		initHeight:          atomic.Uint64{},
+func newStateCache(size int) *stateCache {
+	return &stateCache{
 		accountCache:        make(map[libcommon.Address]*accounts.Account, size),
 		storageCache:        make(map[string]*uint256.Int, size),
 		codeCache:           make(map[libcommon.Hash][]byte, size),
 		incarnationMapCache: make(map[libcommon.Address]uint64, size),
-	}, nil
-}
-
-func (cache *StateCache) TryInitCache(executionHeight uint64) error {
-	cache.cacheLock.Lock()
-	defer cache.cacheLock.Unlock()
-
-	if cache.initHeight.Load() != 0 {
-		return fmt.Errorf("state cache already initialized")
 	}
-	cache.initHeight.Store(executionHeight)
-
-	return nil
 }
 
-func (cache *StateCache) Clear() {
-	cache.cacheLock.Lock()
-	defer cache.cacheLock.Unlock()
-
-	// Clear all caches
+func (cache *stateCache) Clear() {
 	for k := range cache.accountCache {
 		delete(cache.accountCache, k)
 	}
@@ -82,167 +54,94 @@ func (cache *StateCache) Clear() {
 	for k := range cache.incarnationMapCache {
 		delete(cache.incarnationMapCache, k)
 	}
+}
+
+// GlobalStateCache implements the plain state reader with a changeset cache layer.
+// The global cache holds the finalized chainstate - it holds the chainstate db,
+// with a changeset cache layer that stores in-memory the finalized state changes.
+type GlobalStateCache struct {
+	ctx        context.Context
+	db         kv.RoDB
+	initHeight atomic.Uint64
+
+	cacheLock sync.RWMutex
+	cache     *stateCache
+}
+
+func NewGlobalStateCache(ctx context.Context, db kv.RoDB, size int) (*GlobalStateCache, error) {
+	return &GlobalStateCache{
+		ctx:        ctx,
+		db:         db,
+		initHeight: atomic.Uint64{},
+		cache:      newStateCache(size),
+	}, nil
+}
+
+func (cache *GlobalStateCache) TryInitCache(executionHeight uint64) error {
+	cache.cacheLock.Lock()
+	defer cache.cacheLock.Unlock()
+
+	if cache.initHeight.Load() != 0 {
+		return fmt.Errorf("state cache already initialized")
+	}
+	cache.initHeight.Store(executionHeight)
+
+	return nil
+}
+
+func (cache *GlobalStateCache) Clear() {
+	cache.cacheLock.Lock()
+	defer cache.cacheLock.Unlock()
+
+	// Clear all caches
+	cache.cache.Clear()
 	cache.initHeight.Store(0)
 }
 
-func (cache *StateCache) GetInitHeight() uint64 {
+func (cache *GlobalStateCache) GetInitHeight() uint64 {
 	return cache.initHeight.Load()
 }
 
 // -------------- Cache operations --------------
-func (cache *StateCache) ApplyChangeset(changeset *realtimeTypes.Changeset, blockNumber uint64, txIndex uint) error {
+func (cache *GlobalStateCache) FlushState(stateCache *stateCache) error {
 	cache.cacheLock.Lock()
 	defer cache.cacheLock.Unlock()
 
-	// Handle account data changes
-	addressChanges := make(map[libcommon.Address]*accounts.Account)
-	cache.applyChangesetToAccountData(changeset, addressChanges)
+	// Apply account changes
+	for address, account := range stateCache.accountCache {
+		delete(cache.cache.accountCache, address)
+		cache.cache.accountCache[address] = account
+	}
 
 	// Apply code changes
-	for codeHash, code := range changeset.CodeChanges {
-		cache.codeCache[codeHash] = code
+	for codeHash, code := range stateCache.codeCache {
+		delete(cache.cache.codeCache, codeHash)
+		cache.cache.codeCache[codeHash] = code
 	}
 
 	// Apply storage changes
-	for address, storage := range changeset.StorageChanges {
-		account, err := cache.getOrCreateAccount(address, addressChanges)
-		if err != nil {
-			return fmt.Errorf("apply storage changes failed: %v", err)
-		}
-
-		for key, value := range storage {
-			compositeKey := dbutils.PlainGenerateCompositeStorageKey(address.Bytes(), account.Incarnation, key.Bytes())
-			cache.storageCache[string(compositeKey)] = value
-		}
+	for key, value := range stateCache.storageCache {
+		delete(cache.cache.storageCache, key)
+		cache.cache.storageCache[key] = value
 	}
 
 	// Apply incarnation map changes
-	for address, incarnation := range changeset.IncarnationMapChanges {
-		cache.incarnationMapCache[address] = incarnation
-	}
-
-	// Apply deleted accounts changes
-	for address := range changeset.DeletedAccounts {
-		// Non-existent / deleted accounts are set to nil
-		addressChanges[address] = nil
-	}
-
-	// Apply account changes
-	for address, account := range addressChanges {
-		delete(cache.accountCache, address)
-		cache.accountCache[address] = account
-		log.Debug("[Realtime] ApplyChangeset: ", address)
-	}
-
-	log.Debug(fmt.Sprintf("[Realtime] Apply changeset from tx with height: %d, txIndex: %d\n", blockNumber, txIndex))
-
-	return nil
-}
-
-func (cache *StateCache) applyChangesetToAccountData(changeset *realtimeTypes.Changeset, addressChanges map[libcommon.Address]*accounts.Account) (err error) {
-	// Apply balance changes
-	for address, balance := range changeset.BalanceChanges {
-		if _, ok := changeset.DeletedAccounts[address]; ok {
-			continue
-		}
-
-		account, err := cache.getOrCreateAccount(address, addressChanges)
-		if err != nil {
-			return fmt.Errorf("apply balance changes failed: %v", err)
-		}
-		account.Balance.Set(balance)
-	}
-
-	// Apply nonce changes
-	for address, nonce := range changeset.NonceChanges {
-		if _, ok := changeset.DeletedAccounts[address]; ok {
-			continue
-		}
-
-		account, err := cache.getOrCreateAccount(address, addressChanges)
-		if err != nil {
-			return fmt.Errorf("apply nonce changes failed: %v", err)
-		}
-		account.Nonce = nonce
-	}
-
-	// Apply code hash changes
-	for address, codeHash := range changeset.CodeHashChanges {
-		if _, ok := changeset.DeletedAccounts[address]; ok {
-			continue
-		}
-
-		account, err := cache.getOrCreateAccount(address, addressChanges)
-		if err != nil {
-			return fmt.Errorf("apply code hash changes failed: %v", err)
-		}
-		account.CodeHash = codeHash
-	}
-
-	// Apply incarnation changes
-	for address, incarnation := range changeset.IncarnationChanges {
-		if _, ok := changeset.DeletedAccounts[address]; ok {
-			continue
-		}
-
-		account, err := cache.getOrCreateAccount(address, addressChanges)
-		if err != nil {
-			return fmt.Errorf("apply incarnation changes failed: %v", err)
-		}
-		account.Incarnation = incarnation
+	for address, incarnation := range stateCache.incarnationMapCache {
+		delete(cache.cache.incarnationMapCache, address)
+		cache.cache.incarnationMapCache[address] = incarnation
 	}
 
 	return nil
-}
-
-func (cache *StateCache) getOrCreateAccount(address libcommon.Address, addressChanges map[libcommon.Address]*accounts.Account) (*accounts.Account, error) {
-	account, ok := addressChanges[address]
-	if !ok {
-		var err error
-		account, err = cache.unsafeReadAccountData(address)
-		if err != nil {
-			return nil, err
-		}
-
-		if account == nil {
-			// Non-existent account, create new account
-			account, err = cache.createAccount()
-			if err != nil {
-				return nil, err
-			}
-		}
-		addressChanges[address] = account
-	}
-
-	return account, nil
-}
-
-func (cache *StateCache) unsafeReadAccountData(address libcommon.Address) (*accounts.Account, error) {
-	acc, ok := cache.accountCache[address]
-	if ok {
-		return acc, nil
-	}
-
-	// Cache miss, read from chainstate db
-	return cache.GetAccountFromChainDb(address)
-}
-
-func (cache *StateCache) createAccount() (*accounts.Account, error) {
-	return &accounts.Account{
-		Initialised: true,
-		Root:        libcommon.BytesToHash(trie.EmptyRoot[:]),
-		CodeHash:    libcommon.BytesToHash(emptyCodeHash),
-	}, nil
 }
 
 // -------------- StateReader implementation --------------
-func (cache *StateCache) ReadAccountData(address libcommon.Address) (*accounts.Account, error) {
+func (cache *GlobalStateCache) ReadAccountData(address libcommon.Address) (*accounts.Account, error) {
 	if cache.initHeight.Load() == 0 {
 		return nil, ErrNotReady
 	}
 
 	cache.cacheLock.RLock()
-	acc, ok := cache.accountCache[address]
+	acc, ok := cache.cache.accountCache[address]
 	if ok {
 		accCopy := accounts.DeepCopyAccount(acc)
 		cache.cacheLock.RUnlock()
@@ -254,7 +153,7 @@ func (cache *StateCache) ReadAccountData(address libcommon.Address) (*accounts.A
 	return cache.GetAccountFromChainDb(address)
 }
 
-func (cache *StateCache) ReadAccountStorage(address libcommon.Address, incarnation uint64, key *libcommon.Hash) ([]byte, error) {
+func (cache *GlobalStateCache) ReadAccountStorage(address libcommon.Address, incarnation uint64, key *libcommon.Hash) ([]byte, error) {
 	if cache.initHeight.Load() == 0 {
 		return nil, ErrNotReady
 	}
@@ -262,7 +161,7 @@ func (cache *StateCache) ReadAccountStorage(address libcommon.Address, incarnati
 	compositeKey := dbutils.PlainGenerateCompositeStorageKey(address.Bytes(), incarnation, key.Bytes())
 
 	cache.cacheLock.RLock()
-	storage, ok := cache.storageCache[string(compositeKey)]
+	storage, ok := cache.cache.storageCache[string(compositeKey)]
 	if ok {
 		storageCopy := libcommon.Copy(storage.Bytes())
 		cache.cacheLock.RUnlock()
@@ -274,7 +173,7 @@ func (cache *StateCache) ReadAccountStorage(address libcommon.Address, incarnati
 	return cache.GetAccountStorageFromChainDb(address, incarnation, key)
 }
 
-func (cache *StateCache) ReadAccountCode(address libcommon.Address, incarnation uint64, codeHash libcommon.Hash) ([]byte, error) {
+func (cache *GlobalStateCache) ReadAccountCode(address libcommon.Address, incarnation uint64, codeHash libcommon.Hash) ([]byte, error) {
 	if bytes.Equal(codeHash.Bytes(), emptyCodeHash) {
 		return nil, nil
 	}
@@ -284,7 +183,7 @@ func (cache *StateCache) ReadAccountCode(address libcommon.Address, incarnation 
 	}
 
 	cache.cacheLock.RLock()
-	code, ok := cache.codeCache[codeHash]
+	code, ok := cache.cache.codeCache[codeHash]
 	if ok {
 		codeCopy := libcommon.Copy(code)
 		cache.cacheLock.RUnlock()
@@ -296,18 +195,18 @@ func (cache *StateCache) ReadAccountCode(address libcommon.Address, incarnation 
 	return cache.GetAccountCodeFromChainDb(address, incarnation, codeHash)
 }
 
-func (cache *StateCache) ReadAccountCodeSize(address libcommon.Address, incarnation uint64, codeHash libcommon.Hash) (int, error) {
+func (cache *GlobalStateCache) ReadAccountCodeSize(address libcommon.Address, incarnation uint64, codeHash libcommon.Hash) (int, error) {
 	code, err := cache.ReadAccountCode(address, incarnation, codeHash)
 	return len(code), err
 }
 
-func (cache *StateCache) ReadAccountIncarnation(address libcommon.Address) (uint64, error) {
+func (cache *GlobalStateCache) ReadAccountIncarnation(address libcommon.Address) (uint64, error) {
 	if cache.initHeight.Load() == 0 {
 		return 0, ErrNotReady
 	}
 
 	cache.cacheLock.RLock()
-	incarnation, ok := cache.incarnationMapCache[address]
+	incarnation, ok := cache.cache.incarnationMapCache[address]
 	cache.cacheLock.RUnlock()
 	if ok {
 		return incarnation, nil
@@ -318,7 +217,7 @@ func (cache *StateCache) ReadAccountIncarnation(address libcommon.Address) (uint
 }
 
 // -------------- Chainstate db reader operations --------------
-func (cache *StateCache) GetAccountFromChainDb(address libcommon.Address) (*accounts.Account, error) {
+func (cache *GlobalStateCache) GetAccountFromChainDb(address libcommon.Address) (*accounts.Account, error) {
 	tx, err := cache.db.BeginRo(cache.ctx)
 	if err != nil {
 		return nil, err
@@ -329,7 +228,7 @@ func (cache *StateCache) GetAccountFromChainDb(address libcommon.Address) (*acco
 	return reader.ReadAccountData(address)
 }
 
-func (cache *StateCache) GetAccountStorageFromChainDb(address libcommon.Address, incarnation uint64, key *libcommon.Hash) ([]byte, error) {
+func (cache *GlobalStateCache) GetAccountStorageFromChainDb(address libcommon.Address, incarnation uint64, key *libcommon.Hash) ([]byte, error) {
 	tx, err := cache.db.BeginRo(cache.ctx)
 	if err != nil {
 		return nil, err
@@ -340,7 +239,7 @@ func (cache *StateCache) GetAccountStorageFromChainDb(address libcommon.Address,
 	return reader.ReadAccountStorage(address, incarnation, key)
 }
 
-func (cache *StateCache) GetAccountCodeFromChainDb(address libcommon.Address, incarnation uint64, codeHash libcommon.Hash) ([]byte, error) {
+func (cache *GlobalStateCache) GetAccountCodeFromChainDb(address libcommon.Address, incarnation uint64, codeHash libcommon.Hash) ([]byte, error) {
 	tx, err := cache.db.BeginRo(cache.ctx)
 	if err != nil {
 		return nil, err
@@ -351,7 +250,7 @@ func (cache *StateCache) GetAccountCodeFromChainDb(address libcommon.Address, in
 	return reader.ReadAccountCode(address, incarnation, codeHash)
 }
 
-func (cache *StateCache) GetAccountIncarnationFromChainDb(address libcommon.Address) (uint64, error) {
+func (cache *GlobalStateCache) GetAccountIncarnationFromChainDb(address libcommon.Address) (uint64, error) {
 	tx, err := cache.db.BeginRo(cache.ctx)
 	if err != nil {
 		return 0, err
@@ -363,12 +262,12 @@ func (cache *StateCache) GetAccountIncarnationFromChainDb(address libcommon.Addr
 }
 
 // -------------- Debug operations --------------
-func (cache *StateCache) DebugDumpToFile(cacheDumpPath string) error {
+func (cache *GlobalStateCache) DebugDumpToFile(cacheDumpPath string) error {
 	cache.cacheLock.RLock()
 	defer cache.cacheLock.RUnlock()
 
 	accountData := make(map[string]string)
-	for addr, acc := range cache.accountCache {
+	for addr, acc := range cache.cache.accountCache {
 		value := make([]byte, acc.EncodingLengthForStorage())
 		acc.EncodeForStorage(value)
 		accountData[hex.EncodeToString(addr[:])] = hex.EncodeToString(value)
@@ -378,7 +277,7 @@ func (cache *StateCache) DebugDumpToFile(cacheDumpPath string) error {
 	}
 
 	storageData := make(map[string]string)
-	for key, value := range cache.storageCache {
+	for key, value := range cache.cache.storageCache {
 		storageData[hex.EncodeToString([]byte(key))] = hex.EncodeToString(value.Bytes())
 	}
 	if err := realtimeTypes.WriteToJSON(filepath.Join(cacheDumpPath, "storage_cache.json"), storageData); err != nil {
@@ -386,7 +285,7 @@ func (cache *StateCache) DebugDumpToFile(cacheDumpPath string) error {
 	}
 
 	codeData := make(map[string]string)
-	for hash, code := range cache.codeCache {
+	for hash, code := range cache.cache.codeCache {
 		codeData[hex.EncodeToString(hash[:])] = hex.EncodeToString(code)
 	}
 	if err := realtimeTypes.WriteToJSON(filepath.Join(cacheDumpPath, "code_cache.json"), codeData); err != nil {
@@ -394,7 +293,7 @@ func (cache *StateCache) DebugDumpToFile(cacheDumpPath string) error {
 	}
 
 	incarnationData := make(map[string]uint64)
-	for addr, incarnation := range cache.incarnationMapCache {
+	for addr, incarnation := range cache.cache.incarnationMapCache {
 		incarnationData[hex.EncodeToString(addr[:])] = incarnation
 	}
 	if err := realtimeTypes.WriteToJSON(filepath.Join(cacheDumpPath, "incarnation_cache.json"), incarnationData); err != nil {
@@ -406,12 +305,12 @@ func (cache *StateCache) DebugDumpToFile(cacheDumpPath string) error {
 
 // DebugCompare compares the state cache with the chain-state db, and returns the
 // list of account addresses that have differing states.
-func (cache *StateCache) DebugCompare(reader state.StateReader) []string {
+func (cache *GlobalStateCache) DebugCompare(reader state.StateReader) []string {
 	cache.cacheLock.RLock()
 	defer cache.cacheLock.RUnlock()
 
 	mismatches := []string{}
-	for addr, accCache := range cache.accountCache {
+	for addr, accCache := range cache.cache.accountCache {
 		log.Info("[Realtime] Comparing account", "address", addr.String())
 		accDb, err := reader.ReadAccountData(addr)
 		if err != nil {

--- a/zk/realtime/realtimeapi/api.go
+++ b/zk/realtime/realtimeapi/api.go
@@ -88,9 +88,9 @@ func (api *RealtimeAPIImpl) getBlockNumber(blockNr rpc.BlockNumber) (uint64, boo
 }
 
 func (api *RealtimeAPIImpl) getPendingHeightFromCache() (uint64, error) {
-	pendingHeight := api.cacheDB.GetHighestPendingHeight()
+	pendingHeight := api.cacheDB.GetCurrentPendingHeight()
 	if pendingHeight == 0 {
-		return 0, fmt.Errorf("no block number found in stateless cache")
+		return 0, fmt.Errorf("no pending block number found in stateless cache")
 	}
 	return pendingHeight, nil
 }
@@ -98,7 +98,7 @@ func (api *RealtimeAPIImpl) getPendingHeightFromCache() (uint64, error) {
 func (api *RealtimeAPIImpl) getConfirmHeightFromCache() (uint64, error) {
 	confirmHeight := api.cacheDB.GetHighestConfirmHeight()
 	if confirmHeight == 0 {
-		return 0, fmt.Errorf("no block number found in stateless cache")
+		return 0, fmt.Errorf("no confirmed block number found in stateless cache")
 	}
 	return confirmHeight, nil
 }
@@ -120,10 +120,11 @@ func (api *RealtimeAPIImpl) createStateReader(blockNrOrHash *rpc.BlockNumberOrHa
 
 	// Realtime supports pending and latest tags only
 	if *blockNrOrHash.BlockNumber == rpc.PendingBlockNumber || *blockNrOrHash.BlockNumber == rpc.BlockNumber(pendingHeight) {
-		pendingReader := api.cacheDB.GetLatestPendingStateCache()
+		pendingReader := api.cacheDB.GetPendingStateCache(pendingHeight)
 		if pendingReader != nil {
 			reader = pendingReader
 		} else {
+			// Pending block was closed, we use the latest confirmed global state
 			reader = api.cacheDB.State
 		}
 		blockNumber = pendingHeight

--- a/zk/realtime/realtimeapi/api.go
+++ b/zk/realtime/realtimeapi/api.go
@@ -6,6 +6,7 @@ import (
 
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/common/hexutil"
+	"github.com/ledgerwatch/erigon/core/state"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/erigon/rpc"
 	"github.com/ledgerwatch/erigon/turbo/adapter/ethapi"
@@ -54,9 +55,9 @@ func (api *RealtimeAPIImpl) getBlockNumber(blockNr rpc.BlockNumber) (uint64, boo
 		return 0, false, ErrRealtimeNotEnabled
 	}
 
-	confirmHeight := api.cacheDB.GetHighestConfirmHeight()
-	if confirmHeight == 0 {
-		return 0, false, fmt.Errorf("no block number found in stateless cache")
+	confirmHeight, err := api.getConfirmHeightFromCache()
+	if err != nil {
+		return 0, false, err
 	}
 
 	switch blockNr {
@@ -70,9 +71,9 @@ func (api *RealtimeAPIImpl) getBlockNumber(blockNr rpc.BlockNumber) (uint64, boo
 	case rpc.SafeBlockNumber:
 		return confirmHeight, true, nil
 	case rpc.PendingBlockNumber:
-		pendingHeight := api.cacheDB.GetHighestPendingHeight()
-		if pendingHeight == 0 {
-			return 0, false, fmt.Errorf("no block number found in stateless cache")
+		pendingHeight, err := api.getPendingHeightFromCache()
+		if err != nil {
+			return 0, false, err
 		}
 		return pendingHeight, true, nil
 	case rpc.LatestExecutedBlockNumber:
@@ -84,6 +85,53 @@ func (api *RealtimeAPIImpl) getBlockNumber(blockNr rpc.BlockNumber) (uint64, boo
 		}
 		return blockNumber, blockNumber == confirmHeight, nil
 	}
+}
+
+func (api *RealtimeAPIImpl) getPendingHeightFromCache() (uint64, error) {
+	pendingHeight := api.cacheDB.GetHighestPendingHeight()
+	if pendingHeight == 0 {
+		return 0, fmt.Errorf("no block number found in stateless cache")
+	}
+	return pendingHeight, nil
+}
+
+func (api *RealtimeAPIImpl) getConfirmHeightFromCache() (uint64, error) {
+	confirmHeight := api.cacheDB.GetHighestConfirmHeight()
+	if confirmHeight == 0 {
+		return 0, fmt.Errorf("no block number found in stateless cache")
+	}
+	return confirmHeight, nil
+}
+
+func (api *RealtimeAPIImpl) createStateReader(blockNrOrHash *rpc.BlockNumberOrHash) (reader state.StateReader, blockNumber uint64, err error) {
+	if blockNrOrHash.BlockNumber == nil {
+		// todo: add support for latest block hash
+		return nil, 0, fmt.Errorf("failed to create state reader: block number is nil")
+	}
+
+	confirmHeight, err := api.getConfirmHeightFromCache()
+	if err != nil {
+		return nil, 0, err
+	}
+	pendingHeight, err := api.getPendingHeightFromCache()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// Realtime supports pending and latest tags only
+	if *blockNrOrHash.BlockNumber == rpc.PendingBlockNumber || *blockNrOrHash.BlockNumber == rpc.BlockNumber(pendingHeight) {
+		pendingReader := api.cacheDB.GetLatestPendingStateCache()
+		if pendingReader != nil {
+			reader = pendingReader
+		} else {
+			reader = api.cacheDB.State
+		}
+		blockNumber = pendingHeight
+	} else if *blockNrOrHash.BlockNumber == rpc.LatestBlockNumber || *blockNrOrHash.BlockNumber == rpc.BlockNumber(confirmHeight) {
+		reader = api.cacheDB.State
+		blockNumber = confirmHeight
+	}
+	return
 }
 
 // newRPCTransaction_realtime returns a transaction that will serialize to the RPC

--- a/zk/realtime/realtimeapi/api_accounts.go
+++ b/zk/realtime/realtimeapi/api_accounts.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/common/hexutil"
 	"github.com/ledgerwatch/erigon-lib/common/hexutility"
 	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/core/state"
 	"github.com/ledgerwatch/erigon/rpc"
 )
 
@@ -17,9 +18,23 @@ func (api *RealtimeAPIImpl) GetBalance(ctx context.Context, address libcommon.Ad
 		return api.APIImpl.GetBalance(ctx, address, blockNrOrHash)
 	}
 
-	if blockNrOrHash.BlockNumber != nil && *blockNrOrHash.BlockNumber == rpc.PendingBlockNumber {
+	if blockNrOrHash.BlockNumber != nil {
+		// Realtime supports pending and latest tags only
+		var reader state.StateReader
+		if *blockNrOrHash.BlockNumber == rpc.PendingBlockNumber {
+			reader = api.cacheDB.GetLatestPendingStateCache()
+		} else if *blockNrOrHash.BlockNumber == rpc.LatestBlockNumber {
+			reader = api.cacheDB.State
+		} else {
+			return api.APIImpl.GetBalance(ctx, address, blockNrOrHash)
+		}
+
+		if reader == nil {
+			reader = api.cacheDB.State
+		}
+
 		// Realtime supported only for pending tags
-		acc, err := api.cacheDB.State.ReadAccountData(address)
+		acc, err := reader.ReadAccountData(address)
 		if err != nil {
 			return nil, fmt.Errorf("cant get a balance for account %x: %w", address.String(), err)
 		}
@@ -39,15 +54,28 @@ func (api *RealtimeAPIImpl) GetTransactionCount(ctx context.Context, address lib
 		return api.APIImpl.GetTransactionCount(ctx, address, blockNrOrHash)
 	}
 
-	if blockNrOrHash.BlockNumber != nil && *blockNrOrHash.BlockNumber == rpc.PendingBlockNumber {
-		// Realtime supported only for pending tags
+	if blockNrOrHash.BlockNumber != nil {
+		// Realtime supports pending and latest tags only
+		var reader state.StateReader
+		if *blockNrOrHash.BlockNumber == rpc.PendingBlockNumber {
+			reader = api.cacheDB.GetLatestPendingStateCache()
+		} else if *blockNrOrHash.BlockNumber == rpc.LatestBlockNumber {
+			reader = api.cacheDB.State
+		} else {
+			return api.APIImpl.GetTransactionCount(ctx, address, blockNrOrHash)
+		}
+
+		if reader == nil {
+			reader = api.cacheDB.State
+		}
+
 		ethNonce, err := api.APIImpl.GetTransactionCount(ctx, address, blockNrOrHash)
 		if err != nil {
 			ethNonce = nil
 		}
 
 		var cacheNonce *hexutil.Uint64
-		acc, err := api.cacheDB.State.ReadAccountData(address)
+		acc, err := reader.ReadAccountData(address)
 		if err != nil {
 			cacheNonce = nil
 		} else if acc != nil {
@@ -80,13 +108,26 @@ func (api *RealtimeAPIImpl) GetCode(ctx context.Context, address libcommon.Addre
 		return api.APIImpl.GetCode(ctx, address, blockNrOrHash)
 	}
 
-	if blockNrOrHash.BlockNumber != nil && *blockNrOrHash.BlockNumber == rpc.PendingBlockNumber {
-		// Realtime supported only for pending tags
-		acc, err := api.cacheDB.State.ReadAccountData(address)
+	if blockNrOrHash.BlockNumber != nil {
+		// Realtime supports pending and latest tags only
+		var reader state.StateReader
+		if *blockNrOrHash.BlockNumber == rpc.PendingBlockNumber {
+			reader = api.cacheDB.GetLatestPendingStateCache()
+		} else if *blockNrOrHash.BlockNumber == rpc.LatestBlockNumber {
+			reader = api.cacheDB.State
+		} else {
+			return api.APIImpl.GetCode(ctx, address, blockNrOrHash)
+		}
+
+		if reader == nil {
+			reader = api.cacheDB.State
+		}
+
+		acc, err := reader.ReadAccountData(address)
 		if acc == nil || err != nil {
 			return hexutility.Bytes(""), nil
 		}
-		res, _ := api.cacheDB.State.ReadAccountCode(address, acc.Incarnation, acc.CodeHash)
+		res, _ := reader.ReadAccountCode(address, acc.Incarnation, acc.CodeHash)
 		if res == nil {
 			return hexutility.Bytes(""), nil
 		}
@@ -101,17 +142,29 @@ func (api *RealtimeAPIImpl) GetStorageAt(ctx context.Context, address libcommon.
 		return api.APIImpl.GetStorageAt(ctx, address, index, blockNrOrHash)
 	}
 
-	if blockNrOrHash.BlockNumber != nil && *blockNrOrHash.BlockNumber == rpc.PendingBlockNumber {
-		// Realtime supported only for pending tags
-		var empty []byte
+	if blockNrOrHash.BlockNumber != nil {
+		// Realtime supports pending and latest tags only
+		var reader state.StateReader
+		if *blockNrOrHash.BlockNumber == rpc.PendingBlockNumber {
+			reader = api.cacheDB.GetLatestPendingStateCache()
+		} else if *blockNrOrHash.BlockNumber == rpc.LatestBlockNumber {
+			reader = api.cacheDB.State
+		} else {
+			return api.APIImpl.GetStorageAt(ctx, address, index, blockNrOrHash)
+		}
 
-		acc, err := api.cacheDB.State.ReadAccountData(address)
+		if reader == nil {
+			reader = api.cacheDB.State
+		}
+
+		var empty []byte
+		acc, err := reader.ReadAccountData(address)
 		if acc == nil || err != nil {
 			return hexutility.Encode(common.LeftPadBytes(empty, 32)), err
 		}
 
 		location := libcommon.HexToHash(index)
-		res, err := api.cacheDB.State.ReadAccountStorage(address, acc.Incarnation, &location)
+		res, err := reader.ReadAccountStorage(address, acc.Incarnation, &location)
 		if err != nil {
 			res = empty
 		}

--- a/zk/realtime/realtimeapi/api_accounts.go
+++ b/zk/realtime/realtimeapi/api_accounts.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ledgerwatch/erigon-lib/common/hexutil"
 	"github.com/ledgerwatch/erigon-lib/common/hexutility"
 	"github.com/ledgerwatch/erigon/common"
-	"github.com/ledgerwatch/erigon/core/state"
 	"github.com/ledgerwatch/erigon/rpc"
 )
 
@@ -18,35 +17,21 @@ func (api *RealtimeAPIImpl) GetBalance(ctx context.Context, address libcommon.Ad
 		return api.APIImpl.GetBalance(ctx, address, blockNrOrHash)
 	}
 
-	if blockNrOrHash.BlockNumber != nil {
-		// Realtime supports pending and latest tags only
-		var reader state.StateReader
-		if *blockNrOrHash.BlockNumber == rpc.PendingBlockNumber {
-			reader = api.cacheDB.GetLatestPendingStateCache()
-		} else if *blockNrOrHash.BlockNumber == rpc.LatestBlockNumber {
-			reader = api.cacheDB.State
-		} else {
-			return api.APIImpl.GetBalance(ctx, address, blockNrOrHash)
-		}
-
-		if reader == nil {
-			reader = api.cacheDB.State
-		}
-
-		// Realtime supported only for pending tags
-		acc, err := reader.ReadAccountData(address)
-		if err != nil {
-			return nil, fmt.Errorf("cant get a balance for account %x: %w", address.String(), err)
-		}
-		if acc == nil {
-			// Special case - non-existent account is assumed to have zero balance
-			return (*hexutil.Big)(big.NewInt(0)), nil
-		}
-
-		return (*hexutil.Big)(acc.Balance.ToBig()), nil
+	reader, _, err := api.createStateReader(&blockNrOrHash)
+	if err != nil || reader == nil {
+		return api.APIImpl.GetBalance(ctx, address, blockNrOrHash)
 	}
 
-	return api.APIImpl.GetBalance(ctx, address, blockNrOrHash)
+	acc, err := reader.ReadAccountData(address)
+	if err != nil {
+		return nil, fmt.Errorf("cant get a balance for account %x: %w", address.String(), err)
+	}
+	if acc == nil {
+		// Special case - non-existent account is assumed to have zero balance
+		return (*hexutil.Big)(big.NewInt(0)), nil
+	}
+
+	return (*hexutil.Big)(acc.Balance.ToBig()), nil
 }
 
 func (api *RealtimeAPIImpl) GetTransactionCount(ctx context.Context, address libcommon.Address, blockNrOrHash *rpc.BlockNumberOrHash) (*hexutil.Uint64, error) {
@@ -54,53 +39,47 @@ func (api *RealtimeAPIImpl) GetTransactionCount(ctx context.Context, address lib
 		return api.APIImpl.GetTransactionCount(ctx, address, blockNrOrHash)
 	}
 
-	if blockNrOrHash.BlockNumber != nil {
-		// Realtime supports pending and latest tags only
-		var reader state.StateReader
-		if *blockNrOrHash.BlockNumber == rpc.PendingBlockNumber {
-			reader = api.cacheDB.GetLatestPendingStateCache()
-		} else if *blockNrOrHash.BlockNumber == rpc.LatestBlockNumber {
-			reader = api.cacheDB.State
-		} else {
-			return api.APIImpl.GetTransactionCount(ctx, address, blockNrOrHash)
+	if blockNrOrHash == nil {
+		latest := rpc.LatestBlockNumber
+		blockNrOrHash = &rpc.BlockNumberOrHash{
+			BlockNumber: &latest,
 		}
-
-		if reader == nil {
-			reader = api.cacheDB.State
-		}
-
-		ethNonce, err := api.APIImpl.GetTransactionCount(ctx, address, blockNrOrHash)
-		if err != nil {
-			ethNonce = nil
-		}
-
-		var cacheNonce *hexutil.Uint64
-		acc, err := reader.ReadAccountData(address)
-		if err != nil {
-			cacheNonce = nil
-		} else if acc != nil {
-			nonce := hexutil.Uint64(acc.Nonce)
-			cacheNonce = &nonce
-		}
-
-		if ethNonce == nil && cacheNonce == nil {
-			return nil, fmt.Errorf("failed to get transaction count for account %x from both sources", address)
-		}
-
-		if ethNonce == nil {
-			return cacheNonce, nil
-		}
-		if cacheNonce == nil {
-			return ethNonce, nil
-		}
-
-		if *ethNonce > *cacheNonce {
-			return ethNonce, nil
-		}
-		return cacheNonce, nil
 	}
 
-	return api.APIImpl.GetTransactionCount(ctx, address, blockNrOrHash)
+	reader, _, err := api.createStateReader(blockNrOrHash)
+	if err != nil || reader == nil {
+		return api.APIImpl.GetTransactionCount(ctx, address, blockNrOrHash)
+	}
+
+	ethNonce, err := api.APIImpl.GetTransactionCount(ctx, address, blockNrOrHash)
+	if err != nil {
+		ethNonce = nil
+	}
+
+	var cacheNonce *hexutil.Uint64
+	acc, err := reader.ReadAccountData(address)
+	if err != nil {
+		cacheNonce = nil
+	} else if acc != nil {
+		nonce := hexutil.Uint64(acc.Nonce)
+		cacheNonce = &nonce
+	}
+
+	if ethNonce == nil && cacheNonce == nil {
+		return nil, fmt.Errorf("failed to get transaction count for account %x from both sources", address)
+	}
+
+	if ethNonce == nil {
+		return cacheNonce, nil
+	}
+	if cacheNonce == nil {
+		return ethNonce, nil
+	}
+
+	if *ethNonce > *cacheNonce {
+		return ethNonce, nil
+	}
+	return cacheNonce, nil
 }
 
 func (api *RealtimeAPIImpl) GetCode(ctx context.Context, address libcommon.Address, blockNrOrHash rpc.BlockNumberOrHash) (hexutility.Bytes, error) {
@@ -108,33 +87,20 @@ func (api *RealtimeAPIImpl) GetCode(ctx context.Context, address libcommon.Addre
 		return api.APIImpl.GetCode(ctx, address, blockNrOrHash)
 	}
 
-	if blockNrOrHash.BlockNumber != nil {
-		// Realtime supports pending and latest tags only
-		var reader state.StateReader
-		if *blockNrOrHash.BlockNumber == rpc.PendingBlockNumber {
-			reader = api.cacheDB.GetLatestPendingStateCache()
-		} else if *blockNrOrHash.BlockNumber == rpc.LatestBlockNumber {
-			reader = api.cacheDB.State
-		} else {
-			return api.APIImpl.GetCode(ctx, address, blockNrOrHash)
-		}
-
-		if reader == nil {
-			reader = api.cacheDB.State
-		}
-
-		acc, err := reader.ReadAccountData(address)
-		if acc == nil || err != nil {
-			return hexutility.Bytes(""), nil
-		}
-		res, _ := reader.ReadAccountCode(address, acc.Incarnation, acc.CodeHash)
-		if res == nil {
-			return hexutility.Bytes(""), nil
-		}
-		return res, nil
+	reader, _, err := api.createStateReader(&blockNrOrHash)
+	if err != nil || reader == nil {
+		return api.APIImpl.GetCode(ctx, address, blockNrOrHash)
 	}
 
-	return api.APIImpl.GetCode(ctx, address, blockNrOrHash)
+	acc, err := reader.ReadAccountData(address)
+	if acc == nil || err != nil {
+		return hexutility.Bytes(""), nil
+	}
+	res, _ := reader.ReadAccountCode(address, acc.Incarnation, acc.CodeHash)
+	if res == nil {
+		return hexutility.Bytes(""), nil
+	}
+	return res, nil
 }
 
 func (api *RealtimeAPIImpl) GetStorageAt(ctx context.Context, address libcommon.Address, index string, blockNrOrHash rpc.BlockNumberOrHash) (string, error) {
@@ -142,34 +108,21 @@ func (api *RealtimeAPIImpl) GetStorageAt(ctx context.Context, address libcommon.
 		return api.APIImpl.GetStorageAt(ctx, address, index, blockNrOrHash)
 	}
 
-	if blockNrOrHash.BlockNumber != nil {
-		// Realtime supports pending and latest tags only
-		var reader state.StateReader
-		if *blockNrOrHash.BlockNumber == rpc.PendingBlockNumber {
-			reader = api.cacheDB.GetLatestPendingStateCache()
-		} else if *blockNrOrHash.BlockNumber == rpc.LatestBlockNumber {
-			reader = api.cacheDB.State
-		} else {
-			return api.APIImpl.GetStorageAt(ctx, address, index, blockNrOrHash)
-		}
-
-		if reader == nil {
-			reader = api.cacheDB.State
-		}
-
-		var empty []byte
-		acc, err := reader.ReadAccountData(address)
-		if acc == nil || err != nil {
-			return hexutility.Encode(common.LeftPadBytes(empty, 32)), err
-		}
-
-		location := libcommon.HexToHash(index)
-		res, err := reader.ReadAccountStorage(address, acc.Incarnation, &location)
-		if err != nil {
-			res = empty
-		}
-		return hexutility.Encode(common.LeftPadBytes(res, 32)), err
+	reader, _, err := api.createStateReader(&blockNrOrHash)
+	if err != nil || reader == nil {
+		return api.APIImpl.GetStorageAt(ctx, address, index, blockNrOrHash)
 	}
 
-	return api.APIImpl.GetStorageAt(ctx, address, index, blockNrOrHash)
+	var empty []byte
+	acc, err := reader.ReadAccountData(address)
+	if acc == nil || err != nil {
+		return hexutility.Encode(common.LeftPadBytes(empty, 32)), err
+	}
+
+	location := libcommon.HexToHash(index)
+	res, err := reader.ReadAccountStorage(address, acc.Incarnation, &location)
+	if err != nil {
+		res = empty
+	}
+	return hexutility.Encode(common.LeftPadBytes(res, 32)), err
 }

--- a/zk/realtime/realtimeapi/api_call.go
+++ b/zk/realtime/realtimeapi/api_call.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ledgerwatch/erigon-lib/common/hexutil"
 	"github.com/ledgerwatch/erigon-lib/common/hexutility"
+	"github.com/ledgerwatch/erigon/core/state"
 	"github.com/ledgerwatch/erigon/rpc"
 	ethapi2 "github.com/ledgerwatch/erigon/turbo/adapter/ethapi"
 	"github.com/ledgerwatch/erigon/turbo/transactions"
@@ -19,15 +20,37 @@ func (api *RealtimeAPIImpl) Call(ctx context.Context, args ethapi2.CallArgs, blo
 		return api.APIImpl.Call(ctx, args, blockNrOrHash, overrides)
 	}
 
-	if blockNrOrHash.BlockNumber != nil && *blockNrOrHash.BlockNumber == rpc.PendingBlockNumber {
-		// Realtime supported only for pending tags
-		return api.doRealtimeCall(ctx, args, overrides)
+	if blockNrOrHash.BlockNumber != nil {
+		// Realtime supports pending and latest tags only
+		var reader state.StateReader
+		var blockNumber uint64
+		var err error
+		if *blockNrOrHash.BlockNumber == rpc.PendingBlockNumber {
+			blockNumber, _, err = api.getBlockNumber(rpc.PendingBlockNumber)
+			reader = api.cacheDB.GetLatestPendingStateCache()
+			if err != nil {
+				return nil, err
+			}
+		} else if *blockNrOrHash.BlockNumber == rpc.LatestBlockNumber {
+			blockNumber, _, err = api.getBlockNumber(rpc.LatestBlockNumber)
+			reader = api.cacheDB.State
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			return api.APIImpl.Call(ctx, args, blockNrOrHash, overrides)
+		}
+
+		if reader == nil {
+			reader = api.cacheDB.State
+		}
+		return api.doRealtimeCall(ctx, args, overrides, blockNumber, reader)
 	}
 
 	return api.APIImpl.Call(ctx, args, blockNrOrHash, overrides)
 }
 
-func (api *RealtimeAPIImpl) doRealtimeCall(ctx context.Context, args ethapi2.CallArgs, overrides *ethapi2.StateOverrides) (hexutility.Bytes, error) {
+func (api *RealtimeAPIImpl) doRealtimeCall(ctx context.Context, args ethapi2.CallArgs, overrides *ethapi2.StateOverrides, blockNumber uint64, reader state.StateReader) (hexutility.Bytes, error) {
 	tx, err := api.APIImpl.GetDB().BeginRo(ctx)
 	if err != nil {
 		return nil, err
@@ -44,11 +67,6 @@ func (api *RealtimeAPIImpl) doRealtimeCall(ctx context.Context, args ethapi2.Cal
 		args.Gas = (*hexutil.Uint64)(&api.APIImpl.GasCap)
 	}
 
-	blockNumber, _, err := api.getBlockNumber(rpc.PendingBlockNumber)
-	if err != nil {
-		return nil, err
-	}
-
 	header, _, _, ok := api.cacheDB.Stateless.GetHeader(blockNumber)
 	if !ok {
 		return nil, fmt.Errorf("header not found for block number %d", blockNumber)
@@ -56,7 +74,7 @@ func (api *RealtimeAPIImpl) doRealtimeCall(ctx context.Context, args ethapi2.Cal
 
 	bn := rpc.BlockNumber(blockNumber)
 	rpcBlockNr := rpc.BlockNumberOrHash{BlockNumber: &bn}
-	result, err := transactions.DoCall(ctx, engine, args, tx, rpcBlockNr, header, overrides, api.APIImpl.GasCap, chainConfig, api.cacheDB.State, api.cacheDB.Stateless, api.APIImpl.GetEvmCallTimeout())
+	result, err := transactions.DoCall(ctx, engine, args, tx, rpcBlockNr, header, overrides, api.APIImpl.GasCap, chainConfig, reader, api.cacheDB.Stateless, api.APIImpl.GetEvmCallTimeout())
 	if err != nil {
 		return nil, err
 	}

--- a/zk/realtime/realtimeapi/api_call.go
+++ b/zk/realtime/realtimeapi/api_call.go
@@ -20,34 +20,12 @@ func (api *RealtimeAPIImpl) Call(ctx context.Context, args ethapi2.CallArgs, blo
 		return api.APIImpl.Call(ctx, args, blockNrOrHash, overrides)
 	}
 
-	if blockNrOrHash.BlockNumber != nil {
-		// Realtime supports pending and latest tags only
-		var reader state.StateReader
-		var blockNumber uint64
-		var err error
-		if *blockNrOrHash.BlockNumber == rpc.PendingBlockNumber {
-			blockNumber, _, err = api.getBlockNumber(rpc.PendingBlockNumber)
-			reader = api.cacheDB.GetLatestPendingStateCache()
-			if err != nil {
-				return nil, err
-			}
-		} else if *blockNrOrHash.BlockNumber == rpc.LatestBlockNumber {
-			blockNumber, _, err = api.getBlockNumber(rpc.LatestBlockNumber)
-			reader = api.cacheDB.State
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			return api.APIImpl.Call(ctx, args, blockNrOrHash, overrides)
-		}
-
-		if reader == nil {
-			reader = api.cacheDB.State
-		}
-		return api.doRealtimeCall(ctx, args, overrides, blockNumber, reader)
+	reader, blockNumber, err := api.createStateReader(&blockNrOrHash)
+	if err != nil || reader == nil {
+		return api.APIImpl.Call(ctx, args, blockNrOrHash, overrides)
 	}
 
-	return api.APIImpl.Call(ctx, args, blockNrOrHash, overrides)
+	return api.doRealtimeCall(ctx, args, overrides, blockNumber, reader)
 }
 
 func (api *RealtimeAPIImpl) doRealtimeCall(ctx context.Context, args ethapi2.CallArgs, overrides *ethapi2.StateOverrides, blockNumber uint64, reader state.StateReader) (hexutility.Bytes, error) {

--- a/zk/realtime/stageloop.go
+++ b/zk/realtime/stageloop.go
@@ -114,7 +114,7 @@ func ListenKafkaConsumer(
 				log.Debug(fmt.Sprintf("[Realtime] Chain rollback detected, resetting realtime cache. finishHeight: %d", finishEntry.Height))
 			}
 			realtimeCache.UpdateExecution(finishEntry)
-			log.Debug("[Realtime] Received finish signal from execution", "finishHeight", finishEntry.Height)
+			log.Debug(fmt.Sprintf("[Realtime] Received finish signal from execution. finishHeight: %d", finishEntry.Height))
 		case blockMsg := <-blockMsgsChan:
 			if err := blockMsg.Validate(realtimeCache.GetExecutionHeight()); err != nil {
 				log.Error(fmt.Sprintf("[Realtime] Failed to consume block message from kafka. error: %v", err))

--- a/zk/realtime/test/cache_test.go
+++ b/zk/realtime/test/cache_test.go
@@ -45,8 +45,11 @@ func TestBlockInfoMap(t *testing.T) {
 		assert.Equal(t, int64(-1), cacheTxCount)
 
 		// Check previous header should not exist
-		_, _, _, exists = bm.Get(blockNum - 1)
-		assert.False(t, exists)
+		cacheHeader, cacheTxCount, cacheHash, exists = bm.Get(blockNum - 1)
+		assert.True(t, exists)
+		assert.Equal(t, prevHeader, cacheHeader)
+		assert.Equal(t, prevTxCount, cacheTxCount)
+		assert.Equal(t, hash, cacheHash)
 	})
 
 	t.Run("Get non-existent", func(t *testing.T) {
@@ -93,15 +96,10 @@ func TestBlockInfoMap(t *testing.T) {
 
 			// Check previous block txCount
 			cacheHeader, cacheTxCount, cacheHash, exists = bm.Get(prevBlockNum)
-			if i == 0 {
-				assert.False(t, exists)
-			} else {
-				assert.True(t, exists)
-				assert.Equal(t, prevHeader, cacheHeader)
-				assert.Equal(t, prevTxCount, cacheTxCount)
-				assert.Equal(t, prevHash, cacheHash)
-			}
-
+			assert.True(t, exists)
+			assert.Equal(t, prevHeader, cacheHeader)
+			assert.Equal(t, prevTxCount, cacheTxCount)
+			assert.Equal(t, prevHash, cacheHash)
 		}
 
 		// Test delete

--- a/zk/realtime/test/smoke_test.go
+++ b/zk/realtime/test/smoke_test.go
@@ -272,7 +272,47 @@ func TestRealtimeRPC(t *testing.T) {
 			log.Info("RealtimeEnabled: Realtime feature is disabled or cache is not ready")
 		}
 	})
+
+	t.Run("RealtimeLatest", func(t *testing.T) {
+		latestBlockNum, err := client.RealtimeBlockNumber()
+		require.NoError(t, err)
+		require.Greater(t, latestBlockNum, uint64(0), "Latest block number should be greater than 0")
+
+		// Change chain-state
+		fromAddress := common.HexToAddress(DefaultL2AdminAddress)
+		testAddress := common.HexToAddress("0x1234567890123456789012345678901234567890")
+		transferAmount := new(big.Int).Mul(big.NewInt(1), big.NewInt(1e18))
+		nonce, err := client.RealtimeGetTransactionCount(fromAddress)
+		require.NoError(t, err)
+		signedTx := erc20TransferTx(t, ctx, privateKey, client, transferAmount, testAddress, erc20Address, nonce)
+		err = WaitTxToBeMined(ctx, client, signedTx, DefaultTimeoutTxToBeMined)
+		require.NoError(t, err)
+
+		// Test state APIs
+		balance, err := client.RealtimeGetBalance(fromAddress)
+		require.NoError(t, err)
+		require.Greater(t, balance.Uint64(), uint64(0), "Balance should be greater than 0")
+
+		tokenBalance, err := client.RealtimeGetTokenBalance(fromAddress, testAddress, erc20Address)
+		require.NoError(t, err)
+		require.Greater(t, tokenBalance.Uint64(), uint64(0), "Token balance should be greater than 0")
+
+		// Test stateless APIs
+		block, err := client.RealtimeGetBlockByNumber(latestBlockNum)
+		require.NoError(t, err)
+		require.NotNil(t, block, "Block should not be nil")
+		require.NotNil(t, block["hash"], "Block hash should not be nil")
+
+		blockByHash, err := client.RealtimeGetBlockByHash(common.HexToHash(block["hash"].(string)), true)
+		require.NoError(t, err)
+		require.NotNil(t, blockByHash, "Block should not be nil")
+		require.NotNil(t, blockByHash["hash"], "Block hash should not be nil")
+
+		require.Equal(t, block["hash"], blockByHash["hash"], "Block hashes should match")
+		require.Equal(t, block["number"], blockByHash["number"], "Block numbers should match")
+	})
 }
+
 func TestRealtimeStateIsConsistent(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/zk/realtime/types/blockinfo_map.go
+++ b/zk/realtime/types/blockinfo_map.go
@@ -56,8 +56,7 @@ func (bm *BlockInfoMap) PutHeader(blockNum uint64, header *ethTypes.Header, prev
 
 	// Update previous block info
 	prevBlockNum := blockNum - 1
-	_, exists := bm.blockInfos[prevBlockNum]
-	if exists && prevBlockInfo != nil {
+	if prevBlockInfo != nil {
 		bm.blockInfos[prevBlockNum] = prevBlockInfo
 		bm.blockHashToHeight[prevBlockInfo.Hash] = prevBlockNum
 	}


### PR DESCRIPTION
## Summary

- Adds support for state management on the realtime cache for pending and finalized states
- Allow state APIs (account and state APIs) to pass "latest" and "pending" tags
- "pending" tags will use the latest pending cache, which contains the chain-state of the last pending block waiting to be finalized by the sequencer
- "latest" tag will use the latest finalized cache (global cache), which contains the chain-state of the last finalized block by the sequencer