### PR TITLE
Fix forward getblockbynumber

### DIFF
--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ledgerwatch/erigon/turbo/debug"
 	"github.com/ledgerwatch/erigon/turbo/logging"
 	"github.com/ledgerwatch/erigon/turbo/snapshotsync/snap"
+	"github.com/ledgerwatch/erigon/zk/sequencer"
 
 	"github.com/ledgerwatch/erigon-lib/direct"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces"
@@ -585,6 +586,10 @@ func startRegularRpcServer(ctx context.Context, cfg *httpcfg.HttpCfg, rpcAPI []r
 
 	// For X Layer
 	rpc.SetRateLimit(cfg.MethodRateLimit)
+
+	if !sequencer.IsSequencer() {
+		rpchelper.StartFinalizedBatchPoller(ctx, time.Second)
+	}
 
 	allowListForRPC, err := parseAllowListForRPC(cfg.RpcAllowListFilePath)
 	if err != nil {

--- a/turbo/rpchelper/rpc_block_xlayer.go
+++ b/turbo/rpchelper/rpc_block_xlayer.go
@@ -1,6 +1,7 @@
 package rpchelper
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -65,7 +66,18 @@ func getFinalizedBatchNumberWithSequencerUrl(tx kv.Tx, sequencerRpcUrl string) (
 	if sequencer.IsSequencer() {
 		return getFinalizedBatchNumberAsSequencer(tx)
 	} else {
-		return getFinalizedBatchNumberAsRPC(sequencerRpcUrl)
+		if bn := currentFinalizedBatchNumber.Load(); bn != 0 {
+			return bn, nil
+		}
+		if sequencerRpcUrl == "" {
+			return 0, fmt.Errorf("sequencerRpcUrl is not set")
+		}
+		bn, err := getFinalizedBatchNumberAsRPC(sequencerRpcUrl)
+		if err != nil {
+			return 0, err
+		}
+		currentFinalizedBatchNumber.Store(bn)
+		return bn, nil
 	}
 }
 
@@ -130,13 +142,19 @@ func getFinalizedBlockNumberAsRPC(tx kv.Tx, sequencerRpcUrl string) (uint64, err
 
 // querySequencerForFinalizedBlock gets the finalized block number from the current finalized batch number
 func querySequencerForFinalizedBlock(tx kv.Tx, sequencerRpcUrl string) (uint64, error) {
-	// Ensure background query is started
-	startBackgroundQueryOnce.Do(startBackgroundQuery)
-
-	// Get current finalized batch number
+	if sequencerRpcUrl == "" {
+		return 0, fmt.Errorf("sequencerRpcUrl is not set")
+	}
+	// Read current finalized batch number from the poller cache
 	batchNumber := currentFinalizedBatchNumber.Load()
 	if batchNumber == 0 {
-		return 0, fmt.Errorf("no finalized batch number available yet")
+		// Fallback once to avoid empty result before poller kicks in
+		bn, err := getFinalizedBatchNumberAsRPC(sequencerRpcUrl)
+		if err != nil {
+			return 0, fmt.Errorf("no finalized batch number available yet: %w", err)
+		}
+		currentFinalizedBatchNumber.Store(bn)
+		batchNumber = bn
 	}
 
 	// Use hermez database to get the highest block in the finalized batch
@@ -168,25 +186,46 @@ func transHexToUint64(hex json.RawMessage) (uint64, error) {
 	return result1, nil
 }
 
+// StartFinalizedBatchPoller starts a background goroutine that queries the sequencer
+// for finalized batch number on given interval; stops when ctx is done.
+func StartFinalizedBatchPoller(ctx context.Context, interval time.Duration) {
+	if sequencer.IsSequencer() {
+		return
+	}
+	startBackgroundQueryOnce.Do(func() {
+		go startBackgroundQuery(ctx, interval)
+	})
+}
+
 // startBackgroundQuery starts a background goroutine that queries the sequencer
 // for finalized batch number every second
-func startBackgroundQuery() {
-	go func() {
-		ticker := time.NewTicker(1 * time.Second)
-		defer ticker.Stop()
+func startBackgroundQuery(ctx context.Context, interval time.Duration) {
+	if sequencerRpcUrl == "" {
+		log.Warn("finalized batch poller not started: empty sequencer RPC URL")
+		return
+	}
+	// initial fetch
+	if bn, err := getFinalizedBatchNumberAsRPC(sequencerRpcUrl); err != nil {
+		log.Error("failed to get finalized batch number from sequencer (initial)", "err", err)
+	} else {
+		currentFinalizedBatchNumber.Store(bn)
+	}
 
-		for {
-			select {
-			case <-ticker.C:
-				if sequencerRpcUrl == "" {
-					panic("only should be called in rpc")
-				}
-				batchNumber, err := getFinalizedBatchNumberAsRPC(sequencerRpcUrl)
-				if err != nil {
-					log.Error("failed to get finalized batch number from sequencer", "err", err)
-				}
-				currentFinalizedBatchNumber.Store(batchNumber)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("finalized batch poller stopped")
+			return
+		case <-ticker.C:
+			bn, err := getFinalizedBatchNumberAsRPC(sequencerRpcUrl)
+			if err != nil {
+				log.Error("failed to get finalized batch number from sequencer", "err", err)
+				continue
 			}
+			currentFinalizedBatchNumber.Store(bn)
 		}
-	}()
+	}
 }

--- a/turbo/rpchelper/rpc_block_xlayer.go
+++ b/turbo/rpchelper/rpc_block_xlayer.go
@@ -3,9 +3,9 @@ package rpchelper
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -24,11 +24,12 @@ var (
 	//  every function (which is used in multiple places)
 	sequencerRpcUrl string
 
-	// Global variable to store current finalized batch number
-	currentFinalizedBatchNumber atomic.Uint64
+	// Global variable storing a pointer to the current finalized batch number.
+	// A nil pointer indicates the value has not been fetched yet.
+	currentFinalizedBatchNumber atomic.Pointer[uint64]
 
-	// Once to ensure the background goroutine is started only once
-	startBackgroundQueryOnce sync.Once
+	// ErrFinalizedBatchUnavailable is returned when the poller has not yet fetched the finalized batch number.
+	ErrFinalizedBatchUnavailable = errors.New("finalized batch number is not yet available from the poller")
 )
 
 // SetSequencerRpcUrl sets the global sequencer RPC URL
@@ -51,9 +52,7 @@ func GetFinalizedBatchNumber(tx kv.Tx) (uint64, error) {
 	return getFinalizedBatchNumberWithSequencerUrl(tx, GetSequencerRpcUrl())
 }
 
-// GetFinalizedBlockNumberWithSequencerUrl returns the finalized block number
-// If running as sequencer, it read from local database
-// If running as RPC node, it queries the sequencer for the finalized block header
+// GetFinalizedBlockNumberWithSequencerUrl returns the finalized block number.
 func GetFinalizedBlockNumberWithSequencerUrl(tx kv.Tx, sequencerRpcUrl string) (uint64, error) {
 	if sequencer.IsSequencer() {
 		return getFinalizedBlockNumberAsSequencer(tx)
@@ -66,18 +65,8 @@ func getFinalizedBatchNumberWithSequencerUrl(tx kv.Tx, sequencerRpcUrl string) (
 	if sequencer.IsSequencer() {
 		return getFinalizedBatchNumberAsSequencer(tx)
 	} else {
-		if bn := currentFinalizedBatchNumber.Load(); bn != 0 {
-			return bn, nil
-		}
-		if sequencerRpcUrl == "" {
-			return 0, fmt.Errorf("sequencerRpcUrl is not set")
-		}
-		bn, err := getFinalizedBatchNumberAsRPC(sequencerRpcUrl)
-		if err != nil {
-			return 0, err
-		}
-		currentFinalizedBatchNumber.Store(bn)
-		return bn, nil
+		// Only read from the poller's cache. Do not perform a fallback fetch here.
+		return GetCachedFinalizedBatchNumber()
 	}
 }
 
@@ -125,36 +114,24 @@ func getFinalizedBlockNumberAsSequencer(tx kv.Tx) (uint64, error) {
 	return blockNumber, nil
 }
 
-// getFinalizedBlockNumberAsRPC implements the logic for RPC nodes by querying the sequencer
+// getFinalizedBlockNumberAsRPC implements the logic for RPC nodes by using the cached finalized batch number.
 func getFinalizedBlockNumberAsRPC(tx kv.Tx, sequencerRpcUrl string) (uint64, error) {
-	if sequencerRpcUrl == "" {
-		panic("sequencerRpcUrl is not set")
-	}
-
-	// Query the sequencer for the finalized block header
-	blockNumber, err := querySequencerForFinalizedBlock(tx, sequencerRpcUrl)
+	// This function's main responsibility is to convert a batch number to a block number.
+	blockNumber, err := getBlockNumberFromFinalizedBatch(tx)
 	if err != nil {
-		return 0, fmt.Errorf("failed to query sequencer for finalized block: %w", err)
+		return 0, fmt.Errorf("failed to get finalized block: %w", err)
 	}
 
 	return blockNumber, nil
 }
 
-// querySequencerForFinalizedBlock gets the finalized block number from the current finalized batch number
-func querySequencerForFinalizedBlock(tx kv.Tx, sequencerRpcUrl string) (uint64, error) {
-	if sequencerRpcUrl == "" {
-		return 0, fmt.Errorf("sequencerRpcUrl is not set")
-	}
-	// Read current finalized batch number from the poller cache
-	batchNumber := currentFinalizedBatchNumber.Load()
-	if batchNumber == 0 {
-		// Fallback once to avoid empty result before poller kicks in
-		bn, err := getFinalizedBatchNumberAsRPC(sequencerRpcUrl)
-		if err != nil {
-			return 0, fmt.Errorf("no finalized batch number available yet: %w", err)
-		}
-		currentFinalizedBatchNumber.Store(bn)
-		batchNumber = bn
+// getBlockNumberFromFinalizedBatch reads the latest finalized batch number from the cache
+// and uses the local database to find the corresponding highest block number in that batch.
+func getBlockNumberFromFinalizedBatch(tx kv.Tx) (uint64, error) {
+	// Read current finalized batch number from the poller cache.
+	batchNumber, err := GetCachedFinalizedBatchNumber()
+	if err != nil {
+		return 0, err
 	}
 
 	// Use hermez database to get the highest block in the finalized batch
@@ -192,23 +169,23 @@ func StartFinalizedBatchPoller(ctx context.Context, interval time.Duration) {
 	if sequencer.IsSequencer() {
 		return
 	}
-	startBackgroundQueryOnce.Do(func() {
-		go startBackgroundQuery(ctx, interval)
-	})
+
+	go startBackgroundQuery(ctx, interval)
 }
 
-// startBackgroundQuery starts a background goroutine that queries the sequencer
-// for finalized batch number every second
+// startBackgroundQuery runs the poller loop that periodically fetches the
+// finalized batch number from the sequencer and updates the cache.
 func startBackgroundQuery(ctx context.Context, interval time.Duration) {
 	if sequencerRpcUrl == "" {
 		log.Warn("finalized batch poller not started: empty sequencer RPC URL")
 		return
 	}
-	// initial fetch
+	// Initial fetch to warm up the cache and handle early requests.
 	if bn, err := getFinalizedBatchNumberAsRPC(sequencerRpcUrl); err != nil {
-		log.Error("failed to get finalized batch number from sequencer (initial)", "err", err)
+		log.Error("failed to get finalized batch number from sequencer (initial fetch)", "err", err)
 	} else {
-		currentFinalizedBatchNumber.Store(bn)
+		newVal := bn
+		currentFinalizedBatchNumber.Store(&newVal)
 	}
 
 	ticker := time.NewTicker(interval)
@@ -225,7 +202,18 @@ func startBackgroundQuery(ctx context.Context, interval time.Duration) {
 				log.Error("failed to get finalized batch number from sequencer", "err", err)
 				continue
 			}
-			currentFinalizedBatchNumber.Store(bn)
+			newVal := bn
+			currentFinalizedBatchNumber.Store(&newVal)
 		}
 	}
+}
+
+// GetCachedFinalizedBatchNumber is the single source of truth for reading the latest batch number
+// fetched by the poller. It returns an error if the poller hasn't successfully fetched a value yet.
+func GetCachedFinalizedBatchNumber() (uint64, error) {
+	valPtr := currentFinalizedBatchNumber.Load()
+	if valPtr == nil {
+		return 0, ErrFinalizedBatchUnavailable
+	}
+	return *valPtr, nil
 }

--- a/turbo/rpchelper/rpc_block_xlayer.go
+++ b/turbo/rpchelper/rpc_block_xlayer.go
@@ -4,15 +4,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
 
-	"github.com/ledgerwatch/erigon-lib/common/hexutil"
 	"github.com/ledgerwatch/erigon-lib/kv"
 
 	"github.com/ledgerwatch/erigon/eth/stagedsync/stages"
-	"github.com/ledgerwatch/erigon/rpc"
 	"github.com/ledgerwatch/erigon/zk/hermez_db"
 	"github.com/ledgerwatch/erigon/zk/sequencer"
 	"github.com/ledgerwatch/erigon/zkevm/jsonrpc/client"
+	"github.com/ledgerwatch/erigon/zkevm/log"
 )
 
 var (
@@ -20,6 +22,12 @@ var (
 	// use a global variable to avoid passing the sequencer RPC URL to
 	//  every function (which is used in multiple places)
 	sequencerRpcUrl string
+
+	// Global variable to store current finalized batch number
+	currentFinalizedBatchNumber atomic.Uint64
+
+	// Once to ensure the background goroutine is started only once
+	startBackgroundQueryOnce sync.Once
 )
 
 // SetSequencerRpcUrl sets the global sequencer RPC URL
@@ -57,7 +65,7 @@ func getFinalizedBatchNumberWithSequencerUrl(tx kv.Tx, sequencerRpcUrl string) (
 	if sequencer.IsSequencer() {
 		return getFinalizedBatchNumberAsSequencer(tx)
 	} else {
-		return getFinalizedBatchNumberAsRPC(tx, sequencerRpcUrl)
+		return getFinalizedBatchNumberAsRPC(sequencerRpcUrl)
 	}
 }
 
@@ -65,14 +73,14 @@ func getFinalizedBatchNumberAsSequencer(tx kv.Tx) (uint64, error) {
 	return stages.GetStageProgress(tx, stages.AnalysisGroupVerifiedBatchNo)
 }
 
-func getFinalizedBatchNumberAsRPC(tx kv.Tx, sequencerRpcUrl string) (uint64, error) {
+func getFinalizedBatchNumberAsRPC(sequencerRpcUrl string) (uint64, error) {
 	if sequencerRpcUrl == "" {
 		return 0, fmt.Errorf("sequencerRpcUrl is not set")
 	}
 
 	response, err := client.JSONRPCCall(sequencerRpcUrl, "zkevm_finalizedBatchNumber")
 	if err != nil {
-		return 0, fmt.Errorf("failed to call sequencer RPC: %w", err)
+		return 0, fmt.Errorf("failed to call zkevm_finalizedBatchNumber to sequencer.err:%v. sequencerRpcUrl:%s", err, sequencerRpcUrl)
 	}
 	return transHexToUint64(response.Result)
 }
@@ -112,7 +120,7 @@ func getFinalizedBlockNumberAsRPC(tx kv.Tx, sequencerRpcUrl string) (uint64, err
 	}
 
 	// Query the sequencer for the finalized block header
-	blockNumber, err := querySequencerForFinalizedBlock(sequencerRpcUrl)
+	blockNumber, err := querySequencerForFinalizedBlock(tx, sequencerRpcUrl)
 	if err != nil {
 		return 0, fmt.Errorf("failed to query sequencer for finalized block: %w", err)
 	}
@@ -120,34 +128,22 @@ func getFinalizedBlockNumberAsRPC(tx kv.Tx, sequencerRpcUrl string) (uint64, err
 	return blockNumber, nil
 }
 
-// querySequencerForFinalizedBlock sends a request to the sequencer to get the finalized block number
-func querySequencerForFinalizedBlock(sequencerRpcUrl string) (uint64, error) {
-	// Send eth_getBlockByNumber request with "finalized" parameter
-	response, err := client.JSONRPCCall(sequencerRpcUrl, "eth_getBlockByNumber", rpc.FinalizedBlockNumber.String(), false)
+// querySequencerForFinalizedBlock gets the finalized block number from the current finalized batch number
+func querySequencerForFinalizedBlock(tx kv.Tx, sequencerRpcUrl string) (uint64, error) {
+	// Ensure background query is started
+	startBackgroundQueryOnce.Do(startBackgroundQuery)
+
+	// Get current finalized batch number
+	batchNumber := currentFinalizedBatchNumber.Load()
+	if batchNumber == 0 {
+		return 0, fmt.Errorf("no finalized batch number available yet")
+	}
+
+	// Use hermez database to get the highest block in the finalized batch
+	hermezDb := hermez_db.NewHermezDbReader(tx)
+	blockNumber, _, err := hermezDb.GetHighestBlockInBatch(batchNumber)
 	if err != nil {
-		return 0, fmt.Errorf("failed to call sequencer RPC: %w", err)
-	}
-
-	if response.Error != nil {
-		return 0, fmt.Errorf("sequencer RPC error: %s", response.Error.Message)
-	}
-
-	// Parse the response to extract block number
-	var blockHeader map[string]interface{}
-	if err := json.Unmarshal(response.Result, &blockHeader); err != nil {
-		return 0, fmt.Errorf("failed to unmarshal block header: %w", err)
-	}
-
-	// Extract block number from the response
-	blockNumberHex, ok := blockHeader["number"].(string)
-	if !ok {
-		return 0, fmt.Errorf("invalid block number in response")
-	}
-
-	// Convert hex string to uint64
-	blockNumber, err := hexutil.DecodeUint64(blockNumberHex)
-	if err != nil {
-		return 0, fmt.Errorf("failed to decode block number: %w", err)
+		return 0, fmt.Errorf("failed to get highest block in batch %d: %w", batchNumber, err)
 	}
 
 	return blockNumber, nil
@@ -170,4 +166,27 @@ func transHexToUint64(hex json.RawMessage) (uint64, error) {
 	}
 
 	return result1, nil
+}
+
+// startBackgroundQuery starts a background goroutine that queries the sequencer
+// for finalized batch number every second
+func startBackgroundQuery() {
+	go func() {
+		ticker := time.NewTicker(1 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				if sequencerRpcUrl == "" {
+					panic("only should be called in rpc")
+				}
+				batchNumber, err := getFinalizedBatchNumberAsRPC(sequencerRpcUrl)
+				if err != nil {
+					log.Error("failed to get finalized batch number from sequencer", "err", err)
+				}
+				currentFinalizedBatchNumber.Store(batchNumber)
+			}
+		}
+	}()
 }

--- a/turbo/rpchelper/rpc_block_xlayer.go
+++ b/turbo/rpchelper/rpc_block_xlayer.go
@@ -45,49 +45,27 @@ func GetSequencerRpcUrl() string {
 // GetFinalizedBlockNumber returns the finalized block number
 // This is a backward-compatible function that uses the global sequencer RPC URL
 func GetFinalizedBlockNumber(tx kv.Tx) (uint64, error) {
-	return GetFinalizedBlockNumberWithSequencerUrl(tx, GetSequencerRpcUrl())
+	if sequencer.IsSequencer() {
+		return getFinalizedBlockNumberFromLocalDB(tx)
+	} else {
+		return getBlockNumberFromCachedFinalizedBatchNumber(tx)
+	}
 }
 
 func GetFinalizedBatchNumber(tx kv.Tx) (uint64, error) {
-	return getFinalizedBatchNumberWithSequencerUrl(tx, GetSequencerRpcUrl())
-}
-
-// GetFinalizedBlockNumberWithSequencerUrl returns the finalized block number.
-func GetFinalizedBlockNumberWithSequencerUrl(tx kv.Tx, sequencerRpcUrl string) (uint64, error) {
 	if sequencer.IsSequencer() {
-		return getFinalizedBlockNumberAsSequencer(tx)
+		return getFinalizedBatchNumberFromLocalDB(tx)
 	} else {
-		return getFinalizedBlockNumberAsRPC(tx, sequencerRpcUrl)
+		return getCachedFinalizedBatchNumber()
 	}
 }
 
-func getFinalizedBatchNumberWithSequencerUrl(tx kv.Tx, sequencerRpcUrl string) (uint64, error) {
-	if sequencer.IsSequencer() {
-		return getFinalizedBatchNumberAsSequencer(tx)
-	} else {
-		// Only read from the poller's cache. Do not perform a fallback fetch here.
-		return GetCachedFinalizedBatchNumber()
-	}
-}
-
-func getFinalizedBatchNumberAsSequencer(tx kv.Tx) (uint64, error) {
+func getFinalizedBatchNumberFromLocalDB(tx kv.Tx) (uint64, error) {
 	return stages.GetStageProgress(tx, stages.AnalysisGroupVerifiedBatchNo)
 }
 
-func getFinalizedBatchNumberAsRPC(sequencerRpcUrl string) (uint64, error) {
-	if sequencerRpcUrl == "" {
-		return 0, fmt.Errorf("sequencerRpcUrl is not set")
-	}
-
-	response, err := client.JSONRPCCall(sequencerRpcUrl, "zkevm_finalizedBatchNumber")
-	if err != nil {
-		return 0, fmt.Errorf("failed to call zkevm_finalizedBatchNumber to sequencer.err:%v. sequencerRpcUrl:%s", err, sequencerRpcUrl)
-	}
-	return transHexToUint64(response.Result)
-}
-
-// getFinalizedBlockNumberAsSequencer implements the original logic for sequencer nodes
-func getFinalizedBlockNumberAsSequencer(tx kv.Tx) (uint64, error) {
+// getFinalizedBlockNumberFromLocalDB implements the original logic for sequencer nodes
+func getFinalizedBlockNumberFromLocalDB(tx kv.Tx) (uint64, error) {
 	// get highest verified batch
 	highestVerifiedBatchNo, err := stages.GetStageProgress(tx, stages.AnalysisGroupVerifiedBatchNo)
 	if err != nil {
@@ -114,22 +92,11 @@ func getFinalizedBlockNumberAsSequencer(tx kv.Tx) (uint64, error) {
 	return blockNumber, nil
 }
 
-// getFinalizedBlockNumberAsRPC implements the logic for RPC nodes by using the cached finalized batch number.
-func getFinalizedBlockNumberAsRPC(tx kv.Tx, sequencerRpcUrl string) (uint64, error) {
-	// This function's main responsibility is to convert a batch number to a block number.
-	blockNumber, err := getBlockNumberFromFinalizedBatch(tx)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get finalized block: %w", err)
-	}
-
-	return blockNumber, nil
-}
-
-// getBlockNumberFromFinalizedBatch reads the latest finalized batch number from the cache
+// getBlockNumberFromCachedFinalizedBatchNumber reads the latest finalized batch number from the cache
 // and uses the local database to find the corresponding highest block number in that batch.
-func getBlockNumberFromFinalizedBatch(tx kv.Tx) (uint64, error) {
+func getBlockNumberFromCachedFinalizedBatchNumber(tx kv.Tx) (uint64, error) {
 	// Read current finalized batch number from the poller cache.
-	batchNumber, err := GetCachedFinalizedBatchNumber()
+	batchNumber, err := getCachedFinalizedBatchNumber()
 	if err != nil {
 		return 0, err
 	}
@@ -142,6 +109,63 @@ func getBlockNumberFromFinalizedBatch(tx kv.Tx) (uint64, error) {
 	}
 
 	return blockNumber, nil
+}
+
+// StartFinalizedBatchPoller starts a background goroutine that queries the sequencer
+// for finalized batch number on given interval; stops when ctx is done.
+func StartFinalizedBatchPoller(ctx context.Context, interval time.Duration) {
+	if sequencer.IsSequencer() {
+		return
+	}
+
+	go startBackgroundQuery(ctx, interval)
+}
+
+// startBackgroundQuery runs the poller loop that periodically fetches the
+// finalized batch number from the sequencer and updates the cache.
+func startBackgroundQuery(ctx context.Context, interval time.Duration) {
+	if sequencerRpcUrl == "" {
+		log.Warn("finalized batch poller not started: empty sequencer RPC URL")
+		return
+	}
+	// Initial fetch to warm up the cache and handle early requests.
+	if bn, err := getFinalizedBatchNumberFromSequencer(sequencerRpcUrl); err != nil {
+		log.Error("failed to get finalized batch number from sequencer (initial fetch)", "err", err)
+	} else {
+		newVal := bn
+		currentFinalizedBatchNumber.Store(&newVal)
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("finalized batch poller stopped")
+			return
+		case <-ticker.C:
+			bn, err := getFinalizedBatchNumberFromSequencer(sequencerRpcUrl)
+			if err != nil {
+				log.Error("failed to get finalized batch number from sequencer", "err", err)
+				continue
+			}
+			newVal := bn
+			currentFinalizedBatchNumber.Store(&newVal)
+		}
+	}
+}
+
+func getFinalizedBatchNumberFromSequencer(sequencerRpcUrl string) (uint64, error) {
+	if sequencerRpcUrl == "" {
+		return 0, fmt.Errorf("sequencerRpcUrl is not set")
+	}
+
+	response, err := client.JSONRPCCall(sequencerRpcUrl, "zkevm_finalizedBatchNumber")
+	if err != nil {
+		return 0, fmt.Errorf("failed to call zkevm_finalizedBatchNumber to sequencer.err:%v. sequencerRpcUrl:%s", err, sequencerRpcUrl)
+	}
+	return transHexToUint64(response.Result)
 }
 
 func transHexToUint64(hex json.RawMessage) (uint64, error) {
@@ -163,54 +187,9 @@ func transHexToUint64(hex json.RawMessage) (uint64, error) {
 	return result1, nil
 }
 
-// StartFinalizedBatchPoller starts a background goroutine that queries the sequencer
-// for finalized batch number on given interval; stops when ctx is done.
-func StartFinalizedBatchPoller(ctx context.Context, interval time.Duration) {
-	if sequencer.IsSequencer() {
-		return
-	}
-
-	go startBackgroundQuery(ctx, interval)
-}
-
-// startBackgroundQuery runs the poller loop that periodically fetches the
-// finalized batch number from the sequencer and updates the cache.
-func startBackgroundQuery(ctx context.Context, interval time.Duration) {
-	if sequencerRpcUrl == "" {
-		log.Warn("finalized batch poller not started: empty sequencer RPC URL")
-		return
-	}
-	// Initial fetch to warm up the cache and handle early requests.
-	if bn, err := getFinalizedBatchNumberAsRPC(sequencerRpcUrl); err != nil {
-		log.Error("failed to get finalized batch number from sequencer (initial fetch)", "err", err)
-	} else {
-		newVal := bn
-		currentFinalizedBatchNumber.Store(&newVal)
-	}
-
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			log.Info("finalized batch poller stopped")
-			return
-		case <-ticker.C:
-			bn, err := getFinalizedBatchNumberAsRPC(sequencerRpcUrl)
-			if err != nil {
-				log.Error("failed to get finalized batch number from sequencer", "err", err)
-				continue
-			}
-			newVal := bn
-			currentFinalizedBatchNumber.Store(&newVal)
-		}
-	}
-}
-
-// GetCachedFinalizedBatchNumber is the single source of truth for reading the latest batch number
+// getCachedFinalizedBatchNumber is the single source of truth for reading the latest batch number
 // fetched by the poller. It returns an error if the poller hasn't successfully fetched a value yet.
-func GetCachedFinalizedBatchNumber() (uint64, error) {
+func getCachedFinalizedBatchNumber() (uint64, error) {
 	valPtr := currentFinalizedBatchNumber.Load()
 	if valPtr == nil {
 		return 0, ErrFinalizedBatchUnavailable


### PR DESCRIPTION
Fix forward getblockbynumber based on https://github.com/okx/xlayer-erigon/pull/640.
1. rpc轮询启动的时机，改成rpc节点启动时启动。
2. 增加轮询退出的时机。
3. 直接调用zkevm_finalizedBatchNumber的地方，修改成拿轮询缓存的batch number。