### PR TITLE
add datastream unwind on restart when needed

### DIFF
--- a/cmd/utils/flags_xlayer.go
+++ b/cmd/utils/flags_xlayer.go
@@ -452,6 +452,11 @@ var (
 		Usage: "Enable latest data stream block number global variable for RPC",
 		Value: false,
 	}
+	DataStreamUnwindToBlock = cli.Uint64Flag{
+		Name:  "zkevm.data-stream-unwind-to-block",
+		Usage: "Unwind data stream to block number (this block will be truncated, and 0 means no unwind)",
+		Value: 0,
+	}
 )
 
 func setGPOXLayer(ctx *cli.Context, cfg *gaspricecfg.Config) {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1554,6 +1554,55 @@ func (s *Ethereum) PreStart() error {
 			return err
 		}
 	}
+	// For X Layer, unwind data stream to block number if needed
+	if s.config.Zk.XLayer.DataStreamUnwindToBlock > 0 {
+		log.Info("Unwinding data stream to block number", "blockNumber", s.config.Zk.XLayer.DataStreamUnwindToBlock)
+		tx, err := s.chainDB.BeginRw(context.Background())
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback()
+
+		reader := hermez_db.NewHermezDbReader(tx)
+
+		dataStreamServer := dataStreamServerFactory.CreateDataStreamServer(s.streamServer, s.chainConfig.ChainID.Uint64())
+
+		from := s.config.Zk.XLayer.DataStreamUnwindToBlock
+		latestbatchNum, err := reader.GetBatchNoByL2Block(from - 1)
+		if err != nil && !errors.Is(err, hermez_db.ErrorNotStored) {
+			return err
+		}
+
+		batchNum, err := reader.GetBatchNoByL2Block(from)
+		if err != nil && !errors.Is(err, hermez_db.ErrorNotStored) {
+			return err
+		}
+
+		if err = dataStreamServer.UnwindIfNecessary("DataStreamUnwindToBlock", reader, from, latestbatchNum, batchNum); err != nil {
+			return err
+		}
+
+		attempts := 0
+		for {
+			_, err = zkStages.CatchupDatastream(s.sentryCtx, "stream-catchup", tx, dataStreamServer)
+			if err != nil {
+				if errors.Is(err, datastreamer.ErrAtomicOpNotAllowed) {
+					attempts++
+					if attempts == 10 {
+						return err
+					}
+					time.Sleep(500 * time.Millisecond)
+					continue
+				}
+				return err
+			} else {
+				break
+			}
+		}
+		if err = tx.Commit(); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/eth/ethconfig/config_xlayer.go
+++ b/eth/ethconfig/config_xlayer.go
@@ -72,6 +72,8 @@ type XLayerConfig struct {
 	DynamicBlockGasLimit uint64
 
 	EnableLatestDataStreamBlockNumberGlobalVariableForRpc bool
+
+	DataStreamUnwindToBlock uint64
 }
 
 var DefaultXLayerConfig = XLayerConfig{}

--- a/test/Makefile
+++ b/test/Makefile
@@ -299,6 +299,21 @@ apollo:  build-docker
 	chmod -R 777 data 
 	$(DOCKER_COMPOSE) up -d xlayer-aggkit
 
+.PHONY: test-data-stream-unwind
+test-data-stream-unwind:
+	make stop
+	make run
+	sleep 30
+	$(STOP_DOCKER_SEQ)
+	echo "test-data-stream-unwind-step-1"
+	go test -count=1 -failfast -race -v -p 1 -timeout 10s -run TestAddFlag ./e2e/data_stream_unwind_test.go
+	$(RUN_DOCKER_SEQ)
+	sleep 10
+	echo "test-data-stream-unwind-step-2"
+	docker logs xlayer-seq 2>&1 | grep -q "Unwinding data stream to block number.*blockNumber=5" && echo "✔ Found unwind message for block 5" || echo "✘ Missing unwind message for block 5"
+	docker logs xlayer-seq 2>&1 | grep -q "\[stream-catchup\] Getting progress.*previousProgress=4" && echo "✔ Found stream-catchup progress message" || echo "✘ Missing stream-catchup progress message"
+	
+
 # Target to add data loss testing logic
 .PHONY: test-data-loss
 test-data-loss: data-loss-1 data-loss-2 data-loss-3 data-loss-4 data-loss-5 data-loss-6 data-loss-7 data-loss-8

--- a/test/e2e/data_stream_unwind_test.go
+++ b/test/e2e/data_stream_unwind_test.go
@@ -1,0 +1,32 @@
+package e2e
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestAddFlag(t *testing.T) {
+	// File to modify
+	filePath := "../config/test.erigon.seq.config.yaml"
+
+	// Read the file contents
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatal("Error reading file:", err)
+	}
+
+	// Convert data to string for easier manipulation
+	content := string(data)
+
+	// Add the new configuration line at the end of the file
+	content = strings.TrimSpace(content) + "\nzkevm.data-stream-unwind-to-block: 5"
+
+	// Write the modified content back to the file
+	err = os.WriteFile(filePath, []byte(content), 0644)
+	if err != nil {
+		t.Fatal("Error writing file:", err)
+	}
+
+	t.Log("Successfully added zkevm.data-stream-unwind-to-block: 5 to test.erigon.seq.config.yaml")
+}

--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -393,4 +393,5 @@ var DefaultFlags = []cli.Flag{
 	&utils.BridgeInterceptWhitelistAddresses,
 	&utils.DynamicBlockGasLimit,
 	&utils.EnableLatestDataStreamBlockNumberGlobalVariableForRpc,
+	&utils.DataStreamUnwindToBlock,
 }

--- a/turbo/cli/flags_xlayer.go
+++ b/turbo/cli/flags_xlayer.go
@@ -103,6 +103,7 @@ func ApplyFlagsForEthXLayerConfig(ctx *cli.Context, cfg *ethconfig.Config) {
 		},
 		DynamicBlockGasLimit: ctx.Uint64(utils.DynamicBlockGasLimit.Name),
 		EnableLatestDataStreamBlockNumberGlobalVariableForRpc: ctx.Bool(utils.EnableLatestDataStreamBlockNumberGlobalVariableForRpc.Name),
+		DataStreamUnwindToBlock:                               ctx.Uint64(utils.DataStreamUnwindToBlock.Name),
 	}
 	if cfg.XLayer.BlockInfoConcurrent {
 		blockinfo.SetUseBlockInfoTree(true)


### PR DESCRIPTION
Add flag `zkevm.data-stream-unwind-to-block` (this block and onwards will all be truncated)

When ds is broken, we can specify this block number to truncate datastream data on restart first and then catch up to the latest block height from db. This is a fast way to recover datastream if its data is broken.