### PR TITLE
Add smt db/cache retrieve and commit timing to metrics

### DIFF
--- a/zk/metrics/metrics_xlayer.go
+++ b/zk/metrics/metrics_xlayer.go
@@ -17,24 +17,25 @@ const (
 )
 
 var (
-	SeqPrefix            = "sequencer_"
-	BatchExecuteTimeName = SeqPrefix + "batch_execute_time"
-	PoolTxCountName      = SeqPrefix + "pool_tx_count"
-	SeqTxDurationName    = SeqPrefix + "tx_duration"
-	SeqTxCountName       = SeqPrefix + "tx_count"
-	SeqZKOverflowBlockCounterName   = SeqPrefix + "zk_overflow_block_count"
-	SeqBlockGasUsedName  = SeqPrefix + "block_gas_used"
-	
+	SeqPrefix                     = "sequencer_"
+	BatchExecuteTimeName          = SeqPrefix + "batch_execute_time"
+	PoolTxCountName               = SeqPrefix + "pool_tx_count"
+	SeqTxDurationName             = SeqPrefix + "tx_duration"
+	SeqTxCountName                = SeqPrefix + "tx_count"
+	SeqZKOverflowBlockCounterName = SeqPrefix + "zk_overflow_block_count"
+	SeqBlockGasUsedName           = SeqPrefix + "block_gas_used"
+
 	// Batch timing metrics
-	SeqBatchDurationName = SeqPrefix + "batch_duration"
-	SeqSequencingBatchTimingName = SeqPrefix + "sequencing_batch_timing"
-	SeqProcessTxTimingName = SeqPrefix + "process_tx_timing"
-	SeqGetTxTimingName = SeqPrefix + "get_tx_timing"
-	SeqGetTxPauseTimingName = SeqPrefix + "get_tx_pause_timing"
-	SeqPbStateTimingName = SeqPrefix + "pb_state_timing"
+	SeqBatchDurationName                 = SeqPrefix + "batch_duration"
+	SeqSequencingBatchTimingName         = SeqPrefix + "sequencing_batch_timing"
+	SeqProcessTxTimingName               = SeqPrefix + "process_tx_timing"
+	SeqGetTxTimingName                   = SeqPrefix + "get_tx_timing"
+	SeqGetTxPauseTimingName              = SeqPrefix + "get_tx_pause_timing"
+	SeqPbStateTimingName                 = SeqPrefix + "pb_state_timing"
 	SeqZkIncIntermediateHashesTimingName = SeqPrefix + "zk_inc_intermediate_hashes_timing"
-	SeqFinaliseBlockWriteTimingName = SeqPrefix + "finalise_block_write_timing"
-	SeqBatchCommitDBTimingName = SeqPrefix + "batch_commit_db_timing"
+	SeqFinaliseBlockWriteTimingName      = SeqPrefix + "finalise_block_write_timing"
+	SeqSmtBatchCommitDBTimingName        = SeqPrefix + "smt_batch_commit_db_timing"
+	SeqBatchCommitDBTimingName           = SeqPrefix + "batch_commit_db_timing"
 
 	RpcPrefix              = "rpc_"
 	RpcDynamicGasPriceName = RpcPrefix + "dynamic_gas_price"
@@ -50,7 +51,7 @@ func Init() {
 	prometheus.MustRegister(SeqBlockGasUsed)
 	prometheus.MustRegister(RpcDynamicGasPrice)
 	prometheus.MustRegister(RpcInnerTxExecuted)
-	
+
 	// Register new batch timing metrics
 	prometheus.MustRegister(SeqBatchDuration)
 	prometheus.MustRegister(SeqSequencingBatchTiming)
@@ -60,6 +61,7 @@ func Init() {
 	prometheus.MustRegister(SeqPbStateTiming)
 	prometheus.MustRegister(SeqZkIncIntermediateHashesTiming)
 	prometheus.MustRegister(SeqFinaliseBlockWriteTiming)
+	prometheus.MustRegister(SeqSmtBatchCommitDBTiming)
 	prometheus.MustRegister(SeqBatchCommitDBTiming)
 }
 
@@ -193,6 +195,13 @@ var SeqFinaliseBlockWriteTiming = prometheus.NewGauge(
 	prometheus.GaugeOpts{
 		Name: SeqFinaliseBlockWriteTimingName,
 		Help: "[SEQUENCER] finalise block write timing in milliseconds",
+	},
+)
+
+var SeqSmtBatchCommitDBTiming = prometheus.NewGauge(
+	prometheus.GaugeOpts{
+		Name: SeqSmtBatchCommitDBTimingName,
+		Help: "[SEQUENCER] smt batch commit DB timing in milliseconds",
 	},
 )
 

--- a/zk/metrics/statistics_xlayer.go
+++ b/zk/metrics/statistics_xlayer.go
@@ -21,6 +21,7 @@ const (
 	ProcessingInvalidTxCounter    LogTag = "ProcessingInvalidTxCounter"
 	FinalizeBatchNumber           LogTag = "FinalizeBatchNumber"
 	BatchCommitDBTiming           LogTag = "BatchCommitDBTiming"
+	SmtBatchCommitDBTiming        LogTag = "SmtBatchCommitTiming"
 	PbStateTiming                 LogTag = "PbStateTiming"
 	ZkIncIntermediateHashesTiming LogTag = "ZkIncIntermediateHashesTiming"
 	FinaliseBlockWriteTiming      LogTag = "FinaliseBlockWriteTiming"

--- a/zk/metrics/statistics_xlayer.go
+++ b/zk/metrics/statistics_xlayer.go
@@ -21,7 +21,7 @@ const (
 	ProcessingInvalidTxCounter    LogTag = "ProcessingInvalidTxCounter"
 	FinalizeBatchNumber           LogTag = "FinalizeBatchNumber"
 	BatchCommitDBTiming           LogTag = "BatchCommitDBTiming"
-	SmtBatchCommitDBTiming        LogTag = "SmtBatchCommitTiming"
+	SmtBatchCommitDBTiming        LogTag = "SmtBatchCommitDBTiming"
 	PbStateTiming                 LogTag = "PbStateTiming"
 	ZkIncIntermediateHashesTiming LogTag = "ZkIncIntermediateHashesTiming"
 	FinaliseBlockWriteTiming      LogTag = "FinaliseBlockWriteTiming"

--- a/zk/metrics/statisticsimpl_xlayer.go
+++ b/zk/metrics/statisticsimpl_xlayer.go
@@ -97,6 +97,7 @@ func (l *statisticsInstance) SummaryCheckpoint() string {
 	blockPbStateTiming := l.statistics[PbStateTiming] - l.statisticsOld[PbStateTiming]
 	blockZkIncIntermediateHashesTiming := l.statistics[ZkIncIntermediateHashesTiming] - l.statisticsOld[ZkIncIntermediateHashesTiming]
 	blockFinaliseBlockWriteTiming := l.statistics[FinaliseBlockWriteTiming] - l.statisticsOld[FinaliseBlockWriteTiming]
+	blockSmtBatchCommitDBTiming := l.statistics[SmtBatchCommitDBTiming] - l.statisticsOld[SmtBatchCommitDBTiming]
 
 	blockZKHashAccountCount := l.statistics[ZKHashAccountCount] - l.statisticsOld[ZKHashAccountCount]
 	blockZKHashStoreCount := l.statistics[ZKHashStoreCount] - l.statisticsOld[ZKHashStoreCount]
@@ -152,7 +153,8 @@ func (l *statisticsInstance) SummaryCheckpoint() string {
 		"PbStateTiming<%dms>, "+
 		"ZkIncIntermediateHashesTiming<%dms> %s, "+
 		"FinaliseBlockWriteTiming<%dms>, "+
-		"BatchCommitDBTiming<%dms> "+
+		"SmtBatchCommitDBTiming<%dms>, "+
+		"BatchCommitDBTiming<%dms>, "+
 		"}, "+
 		"GasUsed<%d>, GetTxPause<%d>, "+
 		"GasOverTx<%d>, ZKOverflowBlock<%t>, InvalidTx<%d>, "+
@@ -163,6 +165,7 @@ func (l *statisticsInstance) SummaryCheckpoint() string {
 		blockPbStateTiming,
 		blockZkIncIntermediateHashesTiming, zkHashingDetails,
 		blockFinaliseBlockWriteTiming,
+		blockSmtBatchCommitDBTiming,
 		blockBatchCommitDBTiming,
 		blockGasUsed, blockGetTxPause,
 		blockGasOverTx, blockZkOverflowBlock, blockInvalidTx,
@@ -198,6 +201,7 @@ func (l *statisticsInstance) Summary() string {
 	pbStateTiming := l.statistics[PbStateTiming]
 	zkIncIntermediateHashesTiming := l.statistics[ZkIncIntermediateHashesTiming]
 	finaliseBlockWriteTiming := l.statistics[FinaliseBlockWriteTiming]
+	smtBatchCommitDBTiming := l.statistics[SmtBatchCommitDBTiming]
 
 	zkHashAccountCount := l.statistics[ZKHashAccountCount]
 	zkHashStoreCount := l.statistics[ZKHashStoreCount]
@@ -246,7 +250,7 @@ func (l *statisticsInstance) Summary() string {
 
 	zkHashingDetails := fmt.Sprintf("{ zkHashSMT %s, hermezSMT %s }", zkHashSMTTimings, hermezTimings)
 
-	result := fmt.Sprintf("Batch<%s>, Blocks<%d>, Txs<%d>, TotalDuration-batch<%dms> { SequencingBatchTiming<%dms> { ProcessTxTiming<%dms> %s, PbStateTiming<%dms>, ZkIncIntermediateHashesTiming<%dms> %s, FinaliseBlockWriteTiming<%dms>, BatchCommitDBTiming<%dms> } }"+
+	result := fmt.Sprintf("Batch<%s>, Blocks<%d>, Txs<%d>, TotalDuration-batch<%dms> { SequencingBatchTiming<%dms> { ProcessTxTiming<%dms> %s, PbStateTiming<%dms>, ZkIncIntermediateHashesTiming<%dms> %s, FinaliseBlockWriteTiming<%dms>, SmtBatchCommitDBTiming<%dms>, BatchCommitDBTiming<%dms> } }"+
 		", GasUsed<%d>, GetTxPause<%d>, "+
 		"GasOverTx<%d>, ZKOverflowBlock<%d>, InvalidTx<%d>, "+
 		"zkHashAccCount<account:%d, storage:%d, code:%d>, "+
@@ -257,6 +261,7 @@ func (l *statisticsInstance) Summary() string {
 		pbStateTiming,
 		zkIncIntermediateHashesTiming, zkHashingDetails,
 		finaliseBlockWriteTiming,
+		smtBatchCommitDBTiming,
 		batchCommitDBTiming,
 		gasUsed, getTxPause,
 		gasOverTx, zkOverflowBlock, invalidTx,
@@ -278,6 +283,7 @@ func (l *statisticsInstance) Summary() string {
 	SeqPbStateTiming.Set(float64(pbStateTiming))
 	SeqZkIncIntermediateHashesTiming.Set(float64(zkIncIntermediateHashesTiming))
 	SeqFinaliseBlockWriteTiming.Set(float64(finaliseBlockWriteTiming))
+	SeqSmtBatchCommitDBTiming.Set(float64(smtBatchCommitDBTiming))
 	SeqBatchCommitDBTiming.Set(float64(batchCommitDBTiming))
 
 	l.resetStatistics()

--- a/zk/stages/stage_sequence_execute.go
+++ b/zk/stages/stage_sequence_execute.go
@@ -774,10 +774,12 @@ BatchLoop:
 				batchContext.sdb.eridb.RollbackBatch()
 				return err
 			}
+			commitSmtTime := time.Now()
 			blockCache := batchContext.sdb.eridb.RetriveAndCleanCache()
 			if err := batchContext.sdb.eridb.CommitBatch(); err != nil {
 				return err
 			}
+			metrics.GetLogStatistics().CumulativeTiming(metrics.SmtBatchCommitDBTiming, time.Since(commitSmtTime))
 			setTime := time.Now()
 			s.SetSmtCache(blockNumber, blockCache)
 			metrics.GetLogStatistics().CumulativeTiming(metrics.SetSmtCacheTiming, time.Since(setTime))
@@ -788,9 +790,11 @@ BatchLoop:
 				batchContext.sdb.eridb.RollbackBatch()
 				return err
 			}
+			commitSmtTime := time.Now()
 			if err := batchContext.sdb.eridb.CommitBatch(); err != nil {
 				return err
 			}
+			metrics.GetLogStatistics().CumulativeTiming(metrics.SmtBatchCommitDBTiming, time.Since(commitSmtTime))
 		}
 
 		// For X Layer


### PR DESCRIPTION
## Summary

- Add smt db/cache retrieve and commit timing to metrics for both async commit and non-async commit logic