### PR TITLE
RT: Fix realtime subscription to pass confirmed block headers

### DIFF
--- a/zk/realtime/realtimeapi/api_filters.go
+++ b/zk/realtime/realtimeapi/api_filters.go
@@ -49,11 +49,12 @@ func (api *RealtimeAPIImpl) Realtime(ctx context.Context, criteria realtimeSub.S
 				result := RealtimeSubResult{}
 				sendFlag := false
 				if criteria.NewHeads && msg.BlockMsg != nil {
-					header, _, err := msg.BlockMsg.GetBlockInfo()
-					if err != nil {
+					// Send the latest confirmed block header
+					_, prevBlockInfo, err := msg.BlockMsg.GetBlockInfo()
+					if err != nil || prevBlockInfo.Header == nil {
 						log.Warn("[realtime subscription] error getting block info", "err", err)
 					}
-					result.Header = header
+					result.Header = prevBlockInfo.Header
 					sendFlag = true
 				}
 


### PR DESCRIPTION
## Summary

- Fix design of subscription logic to pass confirmed block headers so that header fields have block hashes populated
- Old logic passed pending block headers with block hash field unpopulated