### PR TITLE
update gaslimit logic for realtime EstimateGas API

### DIFF
--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -17,10 +17,12 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/holiman/uint256"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	realtimeTypes "github.com/ledgerwatch/erigon/zk/realtime/types"
-	"github.com/ledgerwatch/erigon/zkevm/log"
+	"github.com/ledgerwatch/log/v3"
 )
 
 // journalEntry is a modification entry in the state change journal that can be
@@ -207,7 +209,7 @@ func (ch createObjectChange) collectChangeset(cs *realtimeTypes.Changeset) {
 	cs.NonceChanges[*ch.account] = 0
 	cs.CodeHashChanges[*ch.account] = emptyCodeHashH
 	cs.StorageChanges[*ch.account] = make(map[libcommon.Hash]*uint256.Int)
-	log.Debugf("[Realtime] createObjectChange: %v", *ch.account)
+	log.Debug(fmt.Sprintf("[Realtime] createObjectChange: %v", *ch.account))
 }
 
 func (ch resetObjectChange) revert(s *IntraBlockState) {
@@ -247,7 +249,7 @@ func (ch selfdestructChange) collectChangeset(cs *realtimeTypes.Changeset) {
 	delete(cs.IncarnationChanges, *ch.account)
 	delete(cs.IncarnationMapChanges, *ch.account)
 	delete(cs.StorageChanges, *ch.account)
-	log.Debugf("[Realtime] selfdestructChange: %v", *ch.account)
+	log.Debug(fmt.Sprintf("[Realtime] selfdestructChange: %v", *ch.account))
 }
 
 var ripemd = libcommon.HexToAddress("0000000000000000000000000000000000000003")
@@ -271,7 +273,7 @@ func (ch balanceChange) dirtied() *libcommon.Address {
 
 func (ch balanceChange) collectChangeset(cs *realtimeTypes.Changeset) {
 	cs.BalanceChanges[*ch.account] = &ch.post
-	log.Debugf("[Realtime] balanceChange: %v -> %v", ch.account, *cs.BalanceChanges[*ch.account])
+	log.Debug(fmt.Sprintf("[Realtime] balanceChange: %v -> %v", ch.account, *cs.BalanceChanges[*ch.account]))
 }
 
 func (ch balanceIncrease) revert(s *IntraBlockState) {
@@ -304,7 +306,7 @@ func (ch balanceIncreaseTransfer) collectChangeset(cs *realtimeTypes.Changeset) 
 	}
 	cs.BalanceChanges[*ch.account] = uint256.NewInt(0)
 	cs.BalanceChanges[*ch.account].Add(&ch.prev, &ch.bi.increase)
-	log.Debugf("[Realtime] balanceIncreaseTransfer: %v + %v -> %v", ch.account, ch.bi.increase, *cs.BalanceChanges[*ch.account])
+	log.Debug(fmt.Sprintf("[Realtime] balanceIncreaseTransfer: %v + %v -> %v", ch.account, ch.bi.increase, *cs.BalanceChanges[*ch.account]))
 }
 
 func (ch nonceChange) revert(s *IntraBlockState) {
@@ -317,7 +319,7 @@ func (ch nonceChange) dirtied() *libcommon.Address {
 
 func (ch nonceChange) collectChangeset(cs *realtimeTypes.Changeset) {
 	cs.NonceChanges[*ch.account] = ch.post
-	log.Debugf("[Realtime] nonceChange: %v -> %v", ch.account, ch.post)
+	log.Debug(fmt.Sprintf("[Realtime] nonceChange: %v -> %v", ch.account, ch.post))
 }
 
 func (ch codeChange) revert(s *IntraBlockState) {
@@ -333,7 +335,7 @@ func (ch codeChange) collectChangeset(cs *realtimeTypes.Changeset) {
 	if ch.posthash != emptyCodeHashH {
 		cs.CodeChanges[ch.posthash] = ch.postcode
 	}
-	log.Debugf("[Realtime] codeChange: %v -> %v", ch.account, ch.posthash)
+	log.Debug(fmt.Sprintf("[Realtime] codeChange: %v -> %v", ch.account, ch.posthash))
 }
 
 func (ch storageChange) revert(s *IntraBlockState) {
@@ -349,7 +351,7 @@ func (ch storageChange) collectChangeset(cs *realtimeTypes.Changeset) {
 		cs.StorageChanges[*ch.account] = make(map[libcommon.Hash]*uint256.Int)
 	}
 	cs.StorageChanges[*ch.account][ch.key] = &ch.postvalue
-	log.Debugf("[Realtime] storageChange: %v -> %v -> %v", ch.account, ch.key, *cs.StorageChanges[*ch.account][ch.key])
+	log.Debug(fmt.Sprintf("[Realtime] storageChange: %v -> %v -> %v", ch.account, ch.key, *cs.StorageChanges[*ch.account][ch.key]))
 }
 
 func (ch fakeStorageChange) revert(s *IntraBlockState) {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -26,6 +26,7 @@ import (
 	types2 "github.com/ledgerwatch/erigon-lib/types"
 
 	"github.com/ledgerwatch/erigon-lib/common/hexutil"
+	"github.com/ledgerwatch/erigon-lib/common/hexutility"
 	cmath "github.com/ledgerwatch/erigon/common/math"
 	"github.com/ledgerwatch/erigon/common/u256"
 	"github.com/ledgerwatch/erigon/consensus/misc"
@@ -464,6 +465,12 @@ func (st *StateTransition) TransitionDb(refunds bool, gasBailout bool) (*Executi
 		// For X Layer
 		innerTx.To = vm.AccountRef(*msg.To()).Address().String()
 	}
+	innerTx.Output = hexutility.Encode(ret[:])
+	if vmerr != nil {
+		innerTx.Error = vmerr.Error()
+		innerTx.IsError = true
+	}
+
 	if refunds {
 		if rules.IsLondon {
 			// After EIP-3529: refunds are capped to gasUsed / 5

--- a/core/vm/evm_xlayer.go
+++ b/core/vm/evm_xlayer.go
@@ -97,13 +97,16 @@ func beforeOp(
 	return innerTx, newIndex
 }
 
-func afterOp(interpreter *EVMInterpreter, opType string, gas_used uint64, newIndex int, innerTx *zktypes.InnerTx, addr *libcommon.Address, err error) {
+func afterOp(interpreter *EVMInterpreter, opType string, gas_used uint64, newIndex int, innerTx *zktypes.InnerTx, addr *libcommon.Address, err error, ret []byte) {
 	innerTx.GasUsed = gas_used
+	innerTx.Output = hexutility.Encode(ret[:])
+
 	if err != nil {
 		innerTxMeta := interpreter.evm.GetInnerTxMeta()
-		for _, innerTx := range innerTxMeta.InnerTxs[newIndex:] {
-			innerTx.IsError = true
+		for _, itx := range innerTxMeta.InnerTxs[newIndex:] {
+			itx.IsError = true
 		}
+		innerTx.Error = err.Error()
 	}
 
 	switch opType {

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -658,7 +658,7 @@ func opCreate(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 
 	innerTx, newIndex := beforeOp(interpreter, CREATE_TYP, scope.Contract.Address(), nil, nil, input, gas, value.ToBig())
 	res, addr, returnGas, suberr := interpreter.evm.Create(scope.Contract, input, gas, &value, 0)
-	afterOp(interpreter, CREATE_TYP, gas-returnGas, newIndex, innerTx, &addr, suberr)
+	afterOp(interpreter, CREATE_TYP, gas-returnGas, newIndex, innerTx, &addr, suberr, res)
 
 	// Push item on the stack based on the returned error. If the ruleset is
 	// homestead we must check for CodeStoreOutOfGasError (homestead only
@@ -700,7 +700,7 @@ func opCreate2(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 	stackValue := size
 	innerTx, newIndex := beforeOp(interpreter, CREATE2_TYP, scope.Contract.Address(), nil, nil, input, gas, endowment.ToBig())
 	res, addr, returnGas, suberr := interpreter.evm.Create2(scope.Contract, input, gas, &endowment, &salt, gas)
-	afterOp(interpreter, CREATE2_TYP, gas-returnGas, newIndex, innerTx, &addr, suberr)
+	afterOp(interpreter, CREATE2_TYP, gas-returnGas, newIndex, innerTx, &addr, suberr, res)
 
 	// Push item on the stack based on the returned error.
 	if suberr != nil {
@@ -741,7 +741,7 @@ func opCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 
 	innerTx, newIndex := beforeOp(interpreter, CALL_TYP, scope.Contract.Address(), &toAddr, nil, args, gas, value.ToBig())
 	ret, returnGas, err := interpreter.evm.Call(scope.Contract, toAddr, args, gas, &value, false /* bailout */, 0)
-	afterOp(interpreter, CALL_TYP, gas-returnGas, newIndex, innerTx, nil, err)
+	afterOp(interpreter, CALL_TYP, gas-returnGas, newIndex, innerTx, nil, err, ret)
 
 	if err != nil {
 		temp.Clear()
@@ -778,7 +778,7 @@ func opCallCode(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 
 	innerTx, newIndex := beforeOp(interpreter, CALLCODE_TYP, scope.Contract.Address(), &toAddr, &toAddr, args, gas, value.ToBig())
 	ret, returnGas, err := interpreter.evm.CallCode_zkEvm(scope.Contract, toAddr, args, gas, &value, int(retSize.Uint64()))
-	afterOp(interpreter, CALLCODE_TYP, gas-returnGas, newIndex, innerTx, nil, err)
+	afterOp(interpreter, CALLCODE_TYP, gas-returnGas, newIndex, innerTx, nil, err, ret)
 
 	if err != nil {
 		temp.Clear()
@@ -814,7 +814,7 @@ func opDelegateCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 	innerTx.TraceAddress = scope.Contract.CallerAddress.String()
 	innerTx.ValueWei = scope.Contract.value.ToBig().String()
 	innerTx.CallValueWei = hexutil.EncodeBig(scope.Contract.value.ToBig())
-	afterOp(interpreter, DELEGATECALL_TYP, gas-returnGas, newIndex, innerTx, nil, err)
+	afterOp(interpreter, DELEGATECALL_TYP, gas-returnGas, newIndex, innerTx, nil, err, ret)
 	if err != nil {
 		temp.Clear()
 	} else {
@@ -846,7 +846,7 @@ func opStaticCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) 
 
 	innerTx, newIndex := beforeOp(interpreter, STATICCAL_TYP, scope.Contract.Address(), &toAddr, nil, args, gas, big.NewInt(0))
 	ret, returnGas, err := interpreter.evm.StaticCall_zkEvm(scope.Contract, toAddr, args, gas, int(retSize.Uint64()))
-	afterOp(interpreter, STATICCAL_TYP, gas-returnGas, newIndex, innerTx, nil, err)
+	afterOp(interpreter, STATICCAL_TYP, gas-returnGas, newIndex, innerTx, nil, err, ret)
 
 	if err != nil {
 		temp.Clear()
@@ -903,7 +903,7 @@ func opSelfdestruct(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 	innerTx, newIndex := beforeOp(interpreter, SUICIDE_TYP, scope.Contract.Address(), &beneficiaryAddr, nil, nil, 0, balance.ToBig())
 	interpreter.evm.IntraBlockState().AddBalance(beneficiaryAddr, balance)
 	interpreter.evm.IntraBlockState().Selfdestruct(callerAddr)
-	afterOp(interpreter, SUICIDE_TYP, 0, newIndex, innerTx, nil, nil)
+	afterOp(interpreter, SUICIDE_TYP, 0, newIndex, innerTx, nil, nil, nil)
 	return nil, errStopToken
 }
 

--- a/core/vm/instructions_zkevm.go
+++ b/core/vm/instructions_zkevm.go
@@ -96,7 +96,7 @@ func opStaticCall_zkevm(pc *uint64, interpreter *EVMInterpreter, scope *ScopeCon
 	args := scope.Memory.GetPtr(int64(inOffset.Uint64()), int64(inSize.Uint64()))
 	innerTx, newIndex := beforeOp(interpreter, STATICCAL_TYP, scope.Contract.Address(), &toAddr, nil, args, gas, big.NewInt(0))
 	ret, returnGas, err := interpreter.evm.StaticCall(scope.Contract, toAddr, args, gas)
-	afterOp(interpreter, STATICCAL_TYP, gas-returnGas, newIndex, innerTx, nil, err)
+	afterOp(interpreter, STATICCAL_TYP, gas-returnGas, newIndex, innerTx, nil, err, ret)
 	if err != nil {
 		temp.Clear()
 	} else {
@@ -138,7 +138,7 @@ func opSendAll_zkevm(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContex
 		innerTx, newIndex := beforeOp(interpreter, SUICIDE_TYP, scope.Contract.Address(), &beneficiaryAddr, nil, nil, 0, balance.ToBig())
 		interpreter.evm.IntraBlockState().AddBalance(beneficiaryAddr, balance)
 		interpreter.evm.IntraBlockState().SubBalance(callerAddr, balance)
-		afterOp(interpreter, SUICIDE_TYP, 0, newIndex, innerTx, nil, nil)
+		afterOp(interpreter, SUICIDE_TYP, 0, newIndex, innerTx, nil, nil, nil)
 	}
 	return nil, errStopToken
 }
@@ -206,7 +206,7 @@ func opCreate_zkevm(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 
 	innerTx, newIndex := beforeOp(interpreter, CREATE_TYP, scope.Contract.Address(), nil, nil, input, gas, value.ToBig())
 	res, addr, returnGas, suberr := interpreter.evm.Create(scope.Contract, input, gas, &value, 0)
-	afterOp(interpreter, CREATE_TYP, gas-returnGas, newIndex, innerTx, &addr, suberr)
+	afterOp(interpreter, CREATE_TYP, gas-returnGas, newIndex, innerTx, &addr, suberr, res)
 
 	// Push item on the stack based on the returned error. If the ruleset is
 	// homestead we must check for CodeStoreOutOfGasError (homestead only
@@ -249,7 +249,7 @@ func opCreate2_zkevm(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContex
 
 	innerTx, newIndex := beforeOp(interpreter, CREATE2_TYP, scope.Contract.Address(), nil, nil, input, gas, endowment.ToBig())
 	res, addr, returnGas, suberr := interpreter.evm.Create2(scope.Contract, input, gas, &endowment, &salt, gas)
-	afterOp(interpreter, CREATE2_TYP, gas-returnGas, newIndex, innerTx, &addr, suberr)
+	afterOp(interpreter, CREATE2_TYP, gas-returnGas, newIndex, innerTx, &addr, suberr, res)
 
 	// Push item on the stack based on the returned error.
 	if suberr != nil {
@@ -290,7 +290,7 @@ func opCall_zkevm(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) 
 
 	innerTx, newIndex := beforeOp(interpreter, CALL_TYP, scope.Contract.Address(), &toAddr, nil, args, gas, value.ToBig())
 	ret, returnGas, err := interpreter.evm.Call_zkEvm(scope.Contract, toAddr, args, gas, &value, false /* bailout */, 0, int(retSize.Uint64()))
-	afterOp(interpreter, CALL_TYP, gas-returnGas, newIndex, innerTx, nil, err)
+	afterOp(interpreter, CALL_TYP, gas-returnGas, newIndex, innerTx, nil, err, ret)
 
 	if err != nil {
 		temp.Clear()
@@ -327,7 +327,7 @@ func opCallCode_zkevm(pc *uint64, interpreter *EVMInterpreter, scope *ScopeConte
 
 	innerTx, newIndex := beforeOp(interpreter, CALLCODE_TYP, scope.Contract.Address(), &toAddr, &toAddr, args, gas, value.ToBig())
 	ret, returnGas, err := interpreter.evm.CallCode_zkEvm(scope.Contract, toAddr, args, gas, &value, int(retSize.Uint64()))
-	afterOp(interpreter, CALLCODE_TYP, gas-returnGas, newIndex, innerTx, nil, err)
+	afterOp(interpreter, CALLCODE_TYP, gas-returnGas, newIndex, innerTx, nil, err, ret)
 
 	if err != nil {
 		temp.Clear()
@@ -363,7 +363,7 @@ func opDelegateCall_zkevm(pc *uint64, interpreter *EVMInterpreter, scope *ScopeC
 	innerTx.TraceAddress = scope.Contract.CallerAddress.String()
 	innerTx.ValueWei = scope.Contract.value.ToBig().String()
 	innerTx.CallValueWei = hexutil.EncodeBig(scope.Contract.value.ToBig())
-	afterOp(interpreter, DELEGATECALL_TYP, gas-returnGas, newIndex, innerTx, nil, err)
+	afterOp(interpreter, DELEGATECALL_TYP, gas-returnGas, newIndex, innerTx, nil, err, ret)
 	if err != nil {
 		temp.Clear()
 	} else {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1236,7 +1236,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 
 			// For X Layer, realtime
 			if cfg.Zk.XLayer.Realtime.Enable {
-				kafkaProducer, err := realtimeKafka.NewKafkaProducer(cfg.Zk.XLayer.Realtime.Kafka, backend.sentryCtx, backend.chainDB)
+				kafkaProducer, err := realtimeKafka.NewKafkaProducer(cfg.Zk.XLayer.Realtime.Kafka, backend.sentryCtx, backend.chainDB, nil)
 				if err != nil {
 					backend.kafkaEnabled = false
 					log.Warn("[Realtime] Failed to initialize kafka producer", "error", err)

--- a/turbo/jsonrpc/eth_api.go
+++ b/turbo/jsonrpc/eth_api.go
@@ -386,16 +386,17 @@ type APIImpl struct {
 	LogsMaxRange                  uint64
 
 	// For X Layer
-	dbsmt              kv.RoDB
-	L2GasPricer        gasprice.L2GasPricer
-	EnableInnerTx      bool
-	PreRunList         map[common.Address]struct{}
-	preRunProcessor    *PreRunProcessor
-	BulkAddTxs         bool
-	BulkAddTxsSize     int
-	BulkAddTxsWaitTime time.Duration
-	txChan             chan txRequest
-	EnableNotify       bool
+	dbsmt                kv.RoDB
+	L2GasPricer          gasprice.L2GasPricer
+	EnableInnerTx        bool
+	PreRunList           map[common.Address]struct{}
+	preRunProcessor      *PreRunProcessor
+	BulkAddTxs           bool
+	BulkAddTxsSize       int
+	BulkAddTxsWaitTime   time.Duration
+	txChan               chan txRequest
+	EnableNotify         bool
+	DynamicBlockGasLimit uint64
 }
 
 // For X Layer, split db and ac
@@ -437,15 +438,16 @@ func NewEthAPI(base *BaseAPI, db kv.RoDB, dbsmt kv.RoDB, eth rpchelper.ApiBacken
 		RejectLowGasPriceTolerance:    ethCfg.RejectLowGasPriceTolerance,
 
 		// For X Layer
-		L2GasPricer:        gasprice.NewL2GasPriceSuggester(context.Background(), ethCfg.GPO),
-		EnableInnerTx:      ethCfg.XLayer.EnableInnerTx,
-		PreRunList:         ethCfg.XLayer.PreRunList,
-		BulkAddTxs:         ethCfg.XLayer.BulkAddTxs,
-		BulkAddTxsSize:     ethCfg.XLayer.BulkAddTxsSize,
-		BulkAddTxsWaitTime: ethCfg.XLayer.BulkAddTxsWaitTime,
-		EnableNotify:       ethCfg.XLayer.EnableAddTxNotify,
-		txChan:             make(chan txRequest, 1000),
-		dbsmt:              dbsmt,
+		L2GasPricer:          gasprice.NewL2GasPriceSuggester(context.Background(), ethCfg.GPO),
+		EnableInnerTx:        ethCfg.XLayer.EnableInnerTx,
+		PreRunList:           ethCfg.XLayer.PreRunList,
+		BulkAddTxs:           ethCfg.XLayer.BulkAddTxs,
+		BulkAddTxsSize:       ethCfg.XLayer.BulkAddTxsSize,
+		BulkAddTxsWaitTime:   ethCfg.XLayer.BulkAddTxsWaitTime,
+		EnableNotify:         ethCfg.XLayer.EnableAddTxNotify,
+		DynamicBlockGasLimit: ethCfg.Zk.XLayer.DynamicBlockGasLimit,
+		txChan:               make(chan txRequest, 1000),
+		dbsmt:                dbsmt,
 	}
 
 	// For X Layer

--- a/zk/realtime/cache/kafka_cache.go
+++ b/zk/realtime/cache/kafka_cache.go
@@ -7,7 +7,7 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 	kafkaTypes "github.com/ledgerwatch/erigon/zk/realtime/kafka/types"
 	realtimeTypes "github.com/ledgerwatch/erigon/zk/realtime/types"
-	"github.com/ledgerwatch/erigon/zkevm/log"
+	"github.com/ledgerwatch/log/v3"
 )
 
 // -------------- Kafka Cache --------------

--- a/zk/realtime/cache/pending_state_cache.go
+++ b/zk/realtime/cache/pending_state_cache.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ledgerwatch/erigon/core/types/accounts"
 	"github.com/ledgerwatch/erigon/turbo/trie"
 	realtimeTypes "github.com/ledgerwatch/erigon/zk/realtime/types"
-	"github.com/ledgerwatch/erigon/zkevm/log"
+	"github.com/ledgerwatch/log/v3"
 )
 
 // GlobalStateCache implements the plain state reader with a changeset cache layer.

--- a/zk/realtime/cache/pending_state_cache.go
+++ b/zk/realtime/cache/pending_state_cache.go
@@ -70,7 +70,7 @@ func (cache *PendingStateCache) ApplyChangeset(changeset *realtimeTypes.Changese
 	for address, account := range addressChanges {
 		delete(cache.cache.accountCache, address)
 		cache.cache.accountCache[address] = account
-		log.Debug("[Realtime] ApplyChangeset: ", address)
+		log.Debug(fmt.Sprintf("[Realtime] ApplyChangeset: %s", address))
 	}
 
 	log.Debug(fmt.Sprintf("[Realtime] Apply changeset from tx with height: %d, txIndex: %d\n", blockNumber, txIndex))

--- a/zk/realtime/cache/realtime_cache.go
+++ b/zk/realtime/cache/realtime_cache.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ledgerwatch/erigon-lib/kv"
 	kafkaTypes "github.com/ledgerwatch/erigon/zk/realtime/kafka/types"
 	realtimeTypes "github.com/ledgerwatch/erigon/zk/realtime/types"
-	"github.com/ledgerwatch/erigon/zkevm/log"
+	"github.com/ledgerwatch/log/v3"
 )
 
 const (

--- a/zk/realtime/cache/realtime_cache.go
+++ b/zk/realtime/cache/realtime_cache.go
@@ -337,7 +337,7 @@ func (cache *RealtimeCache) tryCloseBlock(pendingBlockContext *PendingBlockConte
 	}
 	cache.PutHighestConfirmHeight(pendingBlockContext.blockNum)
 	cache.State.FlushState(pendingBlockContext.pendingStateCache.cache)
-	log.Debug(fmt.Sprintf("[Realtime] Closed block %d, pending blocks queue size: %d", pendingBlockContext.blockNum, cache.pendingBlocks.Size()))
+	log.Info(fmt.Sprintf("[Realtime] Closed block %d, pending blocks queue size: %d", pendingBlockContext.blockNum, cache.pendingBlocks.Size()))
 }
 
 // -------------- Debug operations --------------

--- a/zk/realtime/cache/state_cache.go
+++ b/zk/realtime/cache/state_cache.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ledgerwatch/erigon/core/types/accounts"
 	"github.com/ledgerwatch/erigon/crypto"
 	realtimeTypes "github.com/ledgerwatch/erigon/zk/realtime/types"
-	"github.com/ledgerwatch/log/v3"
 )
 
 var (
@@ -311,7 +310,6 @@ func (cache *GlobalStateCache) DebugCompare(reader state.StateReader) []string {
 
 	mismatches := []string{}
 	for addr, accCache := range cache.cache.accountCache {
-		log.Info(fmt.Sprintf("[Realtime] Comparing account address: %s", addr.String()))
 		accDb, err := reader.ReadAccountData(addr)
 		if err != nil {
 			mismatch := fmt.Sprintf("chain-state db reader error, failed to read account. address: %s, error: %v", addr.String(), err)

--- a/zk/realtime/cache/state_cache.go
+++ b/zk/realtime/cache/state_cache.go
@@ -17,7 +17,7 @@ import (
 	"github.com/ledgerwatch/erigon/core/types/accounts"
 	"github.com/ledgerwatch/erigon/crypto"
 	realtimeTypes "github.com/ledgerwatch/erigon/zk/realtime/types"
-	"github.com/ledgerwatch/erigon/zkevm/log"
+	"github.com/ledgerwatch/log/v3"
 )
 
 var (

--- a/zk/realtime/kafka/batch_producer.go
+++ b/zk/realtime/kafka/batch_producer.go
@@ -1,0 +1,125 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/ledgerwatch/log/v3"
+)
+
+type BatchProducer struct {
+	ctx      context.Context
+	producer sarama.AsyncProducer
+	buffer   chan *sarama.ProducerMessage
+	wg       sync.WaitGroup
+	done     chan struct{}
+}
+
+func NewBatchProducer(ctx context.Context, config KafkaConfig, successChan chan struct{}) (*BatchProducer, error) {
+	saramaConfig := sarama.NewConfig()
+	saramaConfig.Version = DEFAULT_VERSION
+	saramaConfig.ClientID = config.ClientID
+	saramaConfig.Producer.Return.Successes = true
+	saramaConfig.Producer.Return.Errors = true
+
+	// For AsyncProducer
+	saramaConfig.Producer.Flush.Messages = 100
+	saramaConfig.Producer.Flush.Frequency = 3 * time.Millisecond
+	saramaConfig.Producer.Flush.MaxMessages = 0
+	saramaConfig.Producer.Compression = sarama.CompressionSnappy
+
+	if err := verifyProducerConfig(saramaConfig); err != nil {
+		return nil, err
+	}
+
+	producer, err := sarama.NewAsyncProducer(config.BootstrapServers, saramaConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Kafka producer: %v", err)
+	}
+
+	bp := &BatchProducer{
+		ctx:      ctx,
+		producer: producer,
+		buffer:   make(chan *sarama.ProducerMessage, 1000),
+		wg:       sync.WaitGroup{},
+		done:     make(chan struct{}),
+	}
+
+	// Start the background goroutine that handles message forwarding
+	bp.wg.Add(2)
+	go bp.handle()
+	go bp.handleResults(successChan)
+
+	return bp, nil
+}
+
+func (bp *BatchProducer) Close() error {
+	close(bp.done)
+	err := bp.producer.Close()
+	bp.wg.Wait()
+	return err
+}
+
+func verifyProducerConfig(config *sarama.Config) error {
+	if !config.Producer.Return.Errors {
+		return sarama.ConfigurationError("Producer.Return.Errors must be true to be used in a SyncProducer")
+	}
+	if !config.Producer.Return.Successes {
+		return sarama.ConfigurationError("Producer.Return.Successes must be true to be used in a SyncProducer")
+	}
+	return nil
+}
+
+// SendMessage queues a message for production without waiting for results
+func (bp *BatchProducer) SendMessage(msg *sarama.ProducerMessage) error {
+	select {
+	case <-bp.ctx.Done():
+		return fmt.Errorf("context done, stopping")
+	case <-bp.done:
+		return fmt.Errorf("producer is closed")
+	case bp.buffer <- msg:
+		return nil
+	default:
+		return fmt.Errorf("buffer is full, cannot queue message")
+	}
+}
+
+func (bp *BatchProducer) handle() {
+	defer bp.wg.Done()
+	for {
+		select {
+		case <-bp.ctx.Done():
+			return
+		case <-bp.done:
+			return
+		case msg := <-bp.buffer:
+			select {
+			// Queue message to kafka broker producer
+			case bp.producer.Input() <- msg:
+			case <-bp.ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+func (bp *BatchProducer) handleResults(successChan chan struct{}) {
+	defer bp.wg.Done()
+	for {
+		select {
+		case <-bp.ctx.Done():
+			return
+		case <-bp.done:
+			return
+		case <-bp.producer.Successes():
+			if successChan != nil {
+				successChan <- struct{}{}
+			}
+		case err := <-bp.producer.Errors():
+			log.Error("[Realtime] error sending message to kafka", "error", err)
+		}
+	}
+}

--- a/zk/realtime/kafka/consumer.go
+++ b/zk/realtime/kafka/consumer.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/IBM/sarama"
 	kafkaTypes "github.com/ledgerwatch/erigon/zk/realtime/kafka/types"
-	"github.com/ledgerwatch/erigon/zkevm/log"
+	"github.com/ledgerwatch/log/v3"
 )
 
 type KafkaConsumer struct {

--- a/zk/realtime/kafka/producer.go
+++ b/zk/realtime/kafka/producer.go
@@ -16,23 +16,17 @@ import (
 
 // KafkaProducer represents a Kafka producer client for sending transaction messages
 type KafkaProducer struct {
-	producer sarama.SyncProducer
+	producer *BatchProducer
 	config   KafkaConfig
 	ctx      context.Context
 	db       kv.RoDB
 }
 
-func NewKafkaProducer(config KafkaConfig, ctx context.Context, db kv.RoDB) (*KafkaProducer, error) {
-	saramaConfig := sarama.NewConfig()
-	saramaConfig.Version = DEFAULT_VERSION
-	saramaConfig.ClientID = config.ClientID
-	saramaConfig.Producer.Return.Successes = true
-	saramaConfig.Producer.Return.Errors = true
-
+func NewKafkaProducer(config KafkaConfig, ctx context.Context, db kv.RoDB, successChan chan struct{}) (*KafkaProducer, error) {
 	// Create sync producer
-	producer, err := sarama.NewSyncProducer(config.BootstrapServers, saramaConfig)
+	producer, err := NewBatchProducer(ctx, config, successChan)
 	if err != nil {
-		return nil, fmt.Errorf("error creating Kafka producer: %v", err)
+		return nil, err
 	}
 
 	return &KafkaProducer{
@@ -67,7 +61,7 @@ func (client *KafkaProducer) SendKafkaTransaction(blockNumber uint64, tx types.T
 	}
 
 	// Send message
-	_, _, err = client.producer.SendMessage(kafkaMsg)
+	err = client.producer.SendMessage(kafkaMsg)
 	if err != nil {
 		return fmt.Errorf("error sending message to Kafka: %v", err)
 	}
@@ -103,7 +97,7 @@ func (client *KafkaProducer) SendKafkaBlockMessage(msg kafkaTypes.BlockMessage) 
 	}
 
 	// Send message
-	_, _, err = client.producer.SendMessage(kafkaMsg)
+	err = client.producer.SendMessage(kafkaMsg)
 	if err != nil {
 		return fmt.Errorf("error sending message to Kafka: %v", err)
 	}
@@ -129,7 +123,7 @@ func (client *KafkaProducer) SendKafkaErrorTrigger(blockNumber uint64) error {
 	}
 
 	// Send message
-	_, _, err = client.producer.SendMessage(kafkaMsg)
+	err = client.producer.SendMessage(kafkaMsg)
 	if err != nil {
 		return fmt.Errorf("error sending message to Kafka: %v", err)
 	}

--- a/zk/realtime/kafka/test/kafka_test.go
+++ b/zk/realtime/kafka/test/kafka_test.go
@@ -5,9 +5,12 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"testing"
+	"time"
 
+	"github.com/IBM/sarama"
 	"github.com/holiman/uint256"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon/common"
@@ -18,6 +21,7 @@ import (
 	kafkaTypes "github.com/ledgerwatch/erigon/zk/realtime/kafka/types"
 	realtimeTypes "github.com/ledgerwatch/erigon/zk/realtime/types"
 	zktypes "github.com/ledgerwatch/erigon/zk/types"
+	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/assert"
 )
 
@@ -107,7 +111,11 @@ func TestKafka(t *testing.T) {
 		ClientID:         "xlayer-test-consumer",
 		GroupID:          "xlayer-test-consumer-1",
 	}
-	producer, err := kafka.NewKafkaProducer(cfg, context.Background(), nil)
+
+	err := createKafkaTopics(cfg)
+	assert.NilError(t, err)
+
+	producer, err := kafka.NewKafkaProducer(cfg, context.Background(), nil, nil)
 	assert.NilError(t, err)
 
 	currBlockHeader := ethTypes.CopyHeader(blockHeader)
@@ -161,7 +169,7 @@ func TestKafka(t *testing.T) {
 		case err := <-errorChan:
 			t.Fatalf("Received error from consumer: %v", err)
 		case txMsg := <-txMsgsChan:
-			AssertCommonTx(t, txMsg, rightvrsTx, uint64(i), ethTypes.LegacyTxType)
+			AssertCommonTxWithoutBlockNumber(t, txMsg, rightvrsTx, ethTypes.LegacyTxType)
 			AssertReceipt(t, txMsg, rightvrsTxReceipt)
 			AssertInnerTxs(t, txMsg, rightvrsTxInnerTxs)
 			AssertChangeseet(t, txMsg, rightvrsTxChangeset)
@@ -173,7 +181,7 @@ func TestKafka(t *testing.T) {
 		case err := <-errorChan:
 			t.Fatalf("Received error from consumer: %v", err)
 		case txMsg := <-txMsgsChan:
-			AssertCommonTx(t, txMsg, accessListTx, uint64(i), ethTypes.AccessListTxType)
+			AssertCommonTxWithoutBlockNumber(t, txMsg, accessListTx, ethTypes.AccessListTxType)
 			AssertAccessList(t, txMsg.AccessList)
 			AssertReceipt(t, txMsg, rightvrsTxReceipt)
 			AssertInnerTxs(t, txMsg, rightvrsTxInnerTxs)
@@ -215,4 +223,85 @@ func TestKafka(t *testing.T) {
 	ctxWithCancel()
 	err = consumer.Close()
 	assert.NilError(t, err)
+}
+
+func TestStressTestKafkaProducer(t *testing.T) {
+	rightvrsTx.SetSender(testFromAddr)
+	cfg := kafka.KafkaConfig{
+		BootstrapServers: []string{"0.0.0.0:9095"},
+		BlockTopic:       "xlayer-test-block",
+		TxTopic:          "xlayer-test-tx",
+		ErrorTopic:       "xlayer-test-error",
+		ClientID:         "xlayer-test-consumer",
+		GroupID:          "xlayer-test-consumer-1",
+	}
+
+	err := createKafkaTopics(cfg)
+	assert.NilError(t, err)
+
+	successChan := make(chan struct{}, 10000)
+	producer, err := kafka.NewKafkaProducer(cfg, context.Background(), nil, successChan)
+	assert.NilError(t, err)
+
+	startTime := time.Now()
+	for i := 1; i <= 1000; i++ {
+		err = producer.SendKafkaTransaction(uint64(i), rightvrsTx, rightvrsTxReceipt, rightvrsTxInnerTxs, rightvrsTxChangeset)
+		assert.NilError(t, err)
+	}
+
+	// Sending 1000 messages should not be blocking, and should take less than 50ms
+	elapsed := time.Since(startTime)
+	fmt.Printf("Batch producer send took %s to dispatch 1000 messages\n", elapsed)
+	require.Less(t, elapsed, 50*time.Millisecond)
+
+	for i := 0; i < 1000; i++ {
+		select {
+		case <-successChan:
+		case <-time.After(1 * time.Second):
+			t.Fatalf("Timeout waiting for success message %d", i)
+		}
+	}
+	elapsed = time.Since(startTime)
+	fmt.Printf("Producer took %s to send 1000 messages to kafka broker\n", elapsed)
+	require.Less(t, elapsed, 100*time.Millisecond)
+
+	err = producer.Close()
+	assert.NilError(t, err)
+}
+
+// createKafkaTopics creates the required Kafka topics for testing
+func createKafkaTopics(config kafka.KafkaConfig) error {
+	// Create admin client
+	adminClient, err := sarama.NewClusterAdmin(config.BootstrapServers, nil)
+	if err != nil {
+		return err
+	}
+	defer adminClient.Close()
+
+	// Define topics to create
+	topics := []string{config.BlockTopic, config.TxTopic, config.ErrorTopic}
+
+	for _, topic := range topics {
+		// Check if topic already exists
+		metadata, err := adminClient.DescribeConfig(sarama.ConfigResource{
+			Type: sarama.TopicResource,
+			Name: topic,
+		})
+
+		if err != nil {
+			// Topic doesn't exist, create it
+			err = adminClient.CreateTopic(topic, &sarama.TopicDetail{
+				NumPartitions:     1,
+				ReplicationFactor: 1,
+			}, false)
+			if err != nil {
+				return err
+			}
+		} else {
+			// Topic exists, just verify it's accessible
+			_ = metadata
+		}
+	}
+	time.Sleep(1 * time.Second)
+	return nil
 }

--- a/zk/realtime/kafka/test/test_utils.go
+++ b/zk/realtime/kafka/test/test_utils.go
@@ -64,6 +64,22 @@ func AssertCommonTx(t *testing.T, msg kafkaTypes.TransactionMessage, tx types1.T
 	assert.Equal(t, msg.V, *v)
 }
 
+func AssertCommonTxWithoutBlockNumber(t *testing.T, msg kafkaTypes.TransactionMessage, tx types1.Transaction, txType int) {
+	assert.Equal(t, int(msg.Type), txType)
+	assert.Equal(t, msg.Hash, tx.Hash())
+	assert.Equal(t, msg.From, testFromAddr)
+	assert.Equal(t, msg.ChainID.Uint64(), tx.GetChainID().Uint64())
+	assert.Equal(t, msg.Nonce, tx.GetNonce())
+	assert.Equal(t, msg.Gas, tx.GetGas())
+	assert.Equal(t, msg.To.String(), testToAddr.String())
+	assert.Equal(t, msg.Value.String(), tx.GetValue().String())
+	assert.Equal(t, string(msg.Data), string(tx.GetData()))
+	v, r, s := tx.RawSignatureValues()
+	assert.Equal(t, msg.R, *r)
+	assert.Equal(t, msg.S, *s)
+	assert.Equal(t, msg.V, *v)
+}
+
 func AssertAccessList(t *testing.T, msgAccessList []kafkaTypes.AccessTupleMessage) {
 	assert.Equal(t, len(msgAccessList), len(accesses))
 	for idx, access := range msgAccessList {

--- a/zk/realtime/realtimeapi/api_call.go
+++ b/zk/realtime/realtimeapi/api_call.go
@@ -17,7 +17,7 @@ import (
 	"github.com/ledgerwatch/erigon/turbo/adapter/ethapi"
 	ethapi2 "github.com/ledgerwatch/erigon/turbo/adapter/ethapi"
 	"github.com/ledgerwatch/erigon/turbo/transactions"
-	"github.com/ledgerwatch/erigon/zkevm/log"
+	"github.com/ledgerwatch/log/v3"
 )
 
 // Call implements the realtime eth_call.

--- a/zk/realtime/realtimeapi/api_call.go
+++ b/zk/realtime/realtimeapi/api_call.go
@@ -116,9 +116,16 @@ func (api *RealtimeAPIImpl) EstimateGas(ctx context.Context, argsOrNil *ethapi.C
 
 	// Determine the highest gas limit can be used during the estimation.
 	if args.Gas != nil && uint64(*args.Gas) >= params.TxGas {
+		if uint64(*args.Gas) > api.DynamicBlockGasLimit {
+			return 0, fmt.Errorf("gas limit exceeds block gas limit %d", api.DynamicBlockGasLimit)
+		}
 		hi = uint64(*args.Gas)
 	} else {
-		hi = header.GasLimit
+		if api.DynamicBlockGasLimit > 0 {
+			hi = api.DynamicBlockGasLimit
+		} else {
+			hi = header.GasLimit
+		}
 	}
 
 	var feeCap *big.Int

--- a/zk/realtime/realtimeapi/api_debug.go
+++ b/zk/realtime/realtimeapi/api_debug.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/ledgerwatch/erigon/turbo/jsonrpc"
 	realtimeCache "github.com/ledgerwatch/erigon/zk/realtime/cache"
-	"github.com/ledgerwatch/erigon/zkevm/log"
+	"github.com/ledgerwatch/log/v3"
 )
 
 type RealtimeDebugApiImpl struct {

--- a/zk/realtime/stageloop.go
+++ b/zk/realtime/stageloop.go
@@ -19,7 +19,7 @@ import (
 
 var (
 	MaxKafkaChanSize        = 10_000
-	MaxKafkaCacheSize       = 1_000
+	MaxKafkaCacheSize       = 10_000
 	MinRealtimeLoopWaitTime = 10 * time.Millisecond
 
 	errorFlag  = atomic.Bool{}
@@ -188,7 +188,7 @@ func realtimeLoop(ctx context.Context, realtimeCache *cache.RealtimeCache) {
 		}
 
 		// Check for corrupted cache
-		pendingHeight := realtimeCache.GetHighestPendingHeight()
+		pendingHeight := realtimeCache.GetCurrentPendingHeight()
 		lastExecutionHeight := realtimeCache.GetExecutionHeight()
 		if pendingHeight != 0 && pendingHeight < lastExecutionHeight {
 			// Execution is ahead of pending cache. This should not happen

--- a/zk/realtime/stageloop.go
+++ b/zk/realtime/stageloop.go
@@ -14,7 +14,7 @@ import (
 	realtimeSub "github.com/ledgerwatch/erigon/zk/realtime/subscription"
 	realtimeTypes "github.com/ledgerwatch/erigon/zk/realtime/types"
 	"github.com/ledgerwatch/erigon/zk/sequencer"
-	"github.com/ledgerwatch/erigon/zkevm/log"
+	"github.com/ledgerwatch/log/v3"
 )
 
 var (

--- a/zk/realtime/test/comparison_test.go
+++ b/zk/realtime/test/comparison_test.go
@@ -21,8 +21,7 @@ import (
 	"github.com/ledgerwatch/erigon/zk/realtime/rtclient"
 	zktypes "github.com/ledgerwatch/erigon/zk/types"
 	"github.com/ledgerwatch/erigon/zkevm/encoding"
-	"github.com/ledgerwatch/erigon/zkevm/log"
-	log3 "github.com/ledgerwatch/log/v3"
+	"github.com/ledgerwatch/log/v3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,7 +40,7 @@ func TestRealtimeComparison(t *testing.T) {
 	client := rtclient.NewRealtimeClient(ec, DefaultL2NetworkRealtimeURL)
 
 	// Create shared RPC client for direct JSON RPC calls to non-realtime node
-	nonRealtimeRPCClient, err := rpc.Dial(DefaultL2NetworkNoRealtimeURL, log3.Root())
+	nonRealtimeRPCClient, err := rpc.Dial(DefaultL2NetworkNoRealtimeURL, log.Root())
 	require.NoError(t, err)
 	defer nonRealtimeRPCClient.Close()
 

--- a/zk/realtime/test/smoke_test.go
+++ b/zk/realtime/test/smoke_test.go
@@ -32,8 +32,7 @@ import (
 	"github.com/ledgerwatch/erigon/zk/realtime/rtclient"
 	zktypes "github.com/ledgerwatch/erigon/zk/types"
 	"github.com/ledgerwatch/erigon/zkevm/encoding"
-	"github.com/ledgerwatch/erigon/zkevm/log"
-	logger "github.com/ledgerwatch/log/v3"
+	"github.com/ledgerwatch/log/v3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -440,7 +439,7 @@ func compareCacheWithSequenceDB(t *testing.T, dbDir, cacheDir string) {
 	copiedDbDir := filepath.Join(tempDbDir, filepath.Base(dbDir))
 
 	ctx := context.Background()
-	db, err := mdbx.NewMDBX(logger.New()).Path(copiedDbDir).Open(ctx)
+	db, err := mdbx.NewMDBX(log.New()).Path(copiedDbDir).Open(ctx)
 	require.NoError(t, err)
 	defer db.Close()
 

--- a/zk/realtime/test/utils.go
+++ b/zk/realtime/test/utils.go
@@ -19,7 +19,7 @@ import (
 	"github.com/ledgerwatch/erigon/crypto"
 	"github.com/ledgerwatch/erigon/test/operations"
 	"github.com/ledgerwatch/erigon/zk/realtime/rtclient"
-	"github.com/ledgerwatch/erigon/zkevm/log"
+	"github.com/ledgerwatch/log/v3"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
Use dynamic gaslimit for realtime eth_estimateGas api

- return error if tx.gas > dynamic block gaslimit
- set the highest gaslimit during execution as dynamic block gaslimit instead of header.gaslimit

Follows implementation from: https://github.com/okx/xlayer-erigon/pull/681